### PR TITLE
feat: implement lists layer 3 - runtime (#25)

### DIFF
--- a/rust/crates/fsrs-vm/src/instruction.rs
+++ b/rust/crates/fsrs-vm/src/instruction.rs
@@ -94,6 +94,23 @@ pub enum Instruction {
     /// Extract field from tuple by index
     /// Pop tuple from stack, push field at index
     GetTupleField(u8),
+
+    // ===== List Operations =====
+    /// Create list from N stack values [e1; e2; ...]
+    /// Pop N values from stack (in reverse order), build cons list, push list
+    MakeList(u16),
+
+    /// Cons: Pop tail, pop head, push (head :: tail)
+    Cons,
+
+    /// ListHead: Pop list, push head (error if empty)
+    ListHead,
+
+    /// ListTail: Pop list, push tail (error if empty)
+    ListTail,
+
+    /// IsNil: Pop list, push bool (true if empty)
+    IsNil,
 }
 
 impl fmt::Display for Instruction {
@@ -136,6 +153,13 @@ impl fmt::Display for Instruction {
             // Tuple operations
             Instruction::MakeTuple(n) => write!(f, "MAKE_TUPLE {}", n),
             Instruction::GetTupleField(idx) => write!(f, "GET_TUPLE_FIELD {}", idx),
+
+            // List operations
+            Instruction::MakeList(n) => write!(f, "MAKE_LIST {}", n),
+            Instruction::Cons => write!(f, "CONS"),
+            Instruction::ListHead => write!(f, "LIST_HEAD"),
+            Instruction::ListTail => write!(f, "LIST_TAIL"),
+            Instruction::IsNil => write!(f, "IS_NIL"),
         }
     }
 }
@@ -207,6 +231,38 @@ mod tests {
     fn test_instruction_get_tuple_field() {
         let instr = Instruction::GetTupleField(1);
         assert_eq!(instr, Instruction::GetTupleField(1));
+    }
+
+    // ========== List Instruction Tests ==========
+
+    #[test]
+    fn test_instruction_make_list() {
+        let instr = Instruction::MakeList(3);
+        assert_eq!(instr, Instruction::MakeList(3));
+    }
+
+    #[test]
+    fn test_instruction_cons() {
+        let instr = Instruction::Cons;
+        assert_eq!(instr, Instruction::Cons);
+    }
+
+    #[test]
+    fn test_instruction_list_head() {
+        let instr = Instruction::ListHead;
+        assert_eq!(instr, Instruction::ListHead);
+    }
+
+    #[test]
+    fn test_instruction_list_tail() {
+        let instr = Instruction::ListTail;
+        assert_eq!(instr, Instruction::ListTail);
+    }
+
+    #[test]
+    fn test_instruction_is_nil() {
+        let instr = Instruction::IsNil;
+        assert_eq!(instr, Instruction::IsNil);
     }
 
     // ========== Display Formatting Tests ==========
@@ -300,6 +356,32 @@ mod tests {
         );
     }
 
+    #[test]
+    fn test_display_make_list() {
+        assert_eq!(format!("{}", Instruction::MakeList(3)), "MAKE_LIST 3");
+        assert_eq!(format!("{}", Instruction::MakeList(0)), "MAKE_LIST 0");
+    }
+
+    #[test]
+    fn test_display_cons() {
+        assert_eq!(format!("{}", Instruction::Cons), "CONS");
+    }
+
+    #[test]
+    fn test_display_list_head() {
+        assert_eq!(format!("{}", Instruction::ListHead), "LIST_HEAD");
+    }
+
+    #[test]
+    fn test_display_list_tail() {
+        assert_eq!(format!("{}", Instruction::ListTail), "LIST_TAIL");
+    }
+
+    #[test]
+    fn test_display_is_nil() {
+        assert_eq!(format!("{}", Instruction::IsNil), "IS_NIL");
+    }
+
     // ========== Clone Tests ==========
 
     #[test]
@@ -319,6 +401,13 @@ mod tests {
     #[test]
     fn test_clone_make_tuple() {
         let instr1 = Instruction::MakeTuple(3);
+        let instr2 = instr1.clone();
+        assert_eq!(instr1, instr2);
+    }
+
+    #[test]
+    fn test_clone_make_list() {
+        let instr1 = Instruction::MakeList(5);
         let instr2 = instr1.clone();
         assert_eq!(instr1, instr2);
     }
@@ -349,6 +438,18 @@ mod tests {
         assert_eq!(format!("{:?}", instr), "GetTupleField(1)");
     }
 
+    #[test]
+    fn test_debug_make_list() {
+        let instr = Instruction::MakeList(3);
+        assert_eq!(format!("{:?}", instr), "MakeList(3)");
+    }
+
+    #[test]
+    fn test_debug_cons() {
+        let instr = Instruction::Cons;
+        assert_eq!(format!("{:?}", instr), "Cons");
+    }
+
     // ========== Equality Tests ==========
 
     #[test]
@@ -369,6 +470,16 @@ mod tests {
         assert_ne!(Instruction::MakeTuple(2), Instruction::MakeTuple(3));
         assert_eq!(Instruction::GetTupleField(0), Instruction::GetTupleField(0));
         assert_ne!(Instruction::GetTupleField(0), Instruction::GetTupleField(1));
+    }
+
+    #[test]
+    fn test_equality_list_instructions() {
+        assert_eq!(Instruction::MakeList(3), Instruction::MakeList(3));
+        assert_ne!(Instruction::MakeList(3), Instruction::MakeList(5));
+        assert_eq!(Instruction::Cons, Instruction::Cons);
+        assert_eq!(Instruction::ListHead, Instruction::ListHead);
+        assert_eq!(Instruction::ListTail, Instruction::ListTail);
+        assert_eq!(Instruction::IsNil, Instruction::IsNil);
     }
 
     // ========== Edge Case Tests ==========
@@ -407,5 +518,11 @@ mod tests {
     fn test_max_tuple_field_index() {
         let instr = Instruction::GetTupleField(u8::MAX);
         assert_eq!(format!("{}", instr), format!("GET_TUPLE_FIELD {}", u8::MAX));
+    }
+
+    #[test]
+    fn test_max_list_size() {
+        let instr = Instruction::MakeList(u16::MAX);
+        assert_eq!(format!("{}", instr), format!("MAKE_LIST {}", u16::MAX));
     }
 }


### PR DESCRIPTION
Layer 3 of Issue #25 - Lists Runtime Stack

## Changes
- ✅ Value::Cons and Value::Nil variants for cons-cell representation
- ✅ Instructions: MakeList, Cons, ListHead, ListTail, IsNil
- ✅ Compiler support for List and Cons expressions
- ✅ VM execution of list instructions with error handling
- ✅ Helper methods: is_cons(), is_nil(), as_cons(), list_to_vec(), vec_to_cons()
- ✅ Display impl for pretty-printing lists as [e1; e2; e3]
- ✅ VmError::EmptyList for head/tail of empty list errors

## Testing
```bash
cd rust && cargo test
```

**Test Summary:**
- 26 new Value tests for cons operations
- 10 new Instruction tests for list instructions
- 15 new VM execution tests for list operations
- 12 new Compiler tests for list expressions
- **Total: 63+ new tests, 200 tests passing**

## Features Implemented
- Empty lists: `[]`
- Single/multiple elements: `[42]`, `[1; 2; 3]`
- Cons construction: `1 :: []`, `1 :: [2; 3]`
- Nested lists: `[[1; 2]; [3; 4]]`
- List operations: head, tail, is_nil checks
- Error handling: head/tail of empty list, type mismatches
- Structural equality and pretty printing

## Implementation Details

### Value Representation
```rust
pub enum Value {
    // ... existing variants
    Cons {
        head: Box<Value>,
        tail: Box<Value>,
    },
    Nil,
}
```

### Instructions
- `MakeList(n)`: Pop N values, build cons list
- `Cons`: Pop tail, pop head, push (head :: tail)
- `ListHead`: Pop list, push head (error if empty)
- `ListTail`: Pop list, push tail (error if empty)
- `IsNil`: Pop list, push bool (is empty?)

### Error Handling
- `VmError::EmptyList` for operations on empty lists
- `VmError::TypeMismatch` for non-list values
- Proper error messages and stack traces

## Dependencies
- Builds on Layers 1-2 (PR #37): AST + Parser support

## Next Steps
- Layer 4: Example scripts + finalization

Related: #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>