### PR TITLE
fix: Add permissions to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,6 +51,8 @@ jobs:
   build-release:
     name: Build Release (${{ matrix.os }})
     needs: create-release
+    permissions:
+      contents: write
     strategy:
       matrix:
         include:


### PR DESCRIPTION
Adds contents: write permissions to build-release job to allow uploading assets.