### PR TITLE
fix: Configure linker for ARM64 cross-compilation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -97,6 +97,8 @@ jobs:
         run: |
           cd rust
           cargo build --release --target ${{ matrix.target }} -p fusabi
+        env:
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
Sets CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER to use the installed aarch64-linux-gnu-gcc cross-compiler.