### PR TITLE
chore: Release v0.1.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,12 @@ All notable changes to Fusabi will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] - 2025-11-23
+
+### Documentation Fixes
+- **Rebranding**: Updated crate-level READMEs to correct "FSRS" to "Fusabi".
+- **Metadata**: Updated crate descriptions and documentation links for crates.io.
+
 ## [0.1.0] - 2025-11-23
 
 ### Initial Public Release (Fusabi)

--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.1.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.1.1" }

--- a/rust/crates/fusabi-frontend/README.md
+++ b/rust/crates/fusabi-frontend/README.md
@@ -1,0 +1,26 @@
+# Fusabi Frontend
+
+The compiler frontend for the **Fusabi** scripting engine. Handles lexing, parsing, and bytecode generation.
+
+## Features
+
+- **F# Dialect**: Supports a subset of F# including let-bindings, pattern matching, records, and DUs.
+- **Type Inference**: Hindley-Milner type inference engine.
+- **Compiler**: Emits optimized bytecode for `fusabi-vm`.
+
+## Usage
+
+```rust
+use fusabi_frontend::{Lexer, Parser, Compiler};
+
+let source = "let x = 42";
+let mut lexer = Lexer::new(source);
+let tokens = lexer.tokenize()?;
+let mut parser = Parser::new(tokens);
+let ast = parser.parse()?;
+let chunk = Compiler::compile(&ast)?;
+```
+
+## License
+
+MIT

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi-vm/README.md
+++ b/rust/crates/fusabi-vm/README.md
@@ -1,0 +1,27 @@
+# Fusabi VM
+
+The high-performance bytecode virtual machine for the **Fusabi** scripting engine.
+
+## Features
+
+- **Stack-based**: Efficient execution model.
+- **Garbage Collection**: Simple reference counting (Phase 1), moving to Mark-and-Sweep (Phase 4).
+- **Host Interop**: Safe, re-entrant API for calling Rust from scripts and vice-versa.
+- **Serialization**: Load pre-compiled `.fzb` bytecode.
+
+## Usage
+
+```rust
+use fusabi_vm::{Vm, Value};
+
+let mut vm = Vm::new();
+// Register standard library
+fusabi_vm::stdlib::register_stdlib(&mut vm);
+
+// ... load chunk ...
+// vm.execute(&chunk)?;
+```
+
+## License
+
+MIT

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,5 +15,5 @@ name = "fusabi_demo"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.1.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.1.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.1.1" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.1.1", features = ["serde"] }

--- a/rust/crates/fusabi/README.md
+++ b/rust/crates/fusabi/README.md
@@ -1,155 +1,32 @@
-# FSRS Demo Host
+# Fusabi CLI
 
-Demo host application for the FSRS (F# Script Runtime System). This binary demonstrates the complete pipeline from Mini-F# source code to execution.
+The command-line interface for the **Fusabi** scripting engine.
 
 ## Features
 
-- **Complete Pipeline Integration**: Source → Lexer → Parser → Compiler → VM → Execution
-- **CLI Interface**: Execute scripts from files or evaluate expressions directly
-- **Bytecode Disassembly**: Optional disassembly output for debugging
-- **Comprehensive Error Reporting**: Clear error messages at each pipeline stage
+- **Run Scripts**: Execute `.fsx` source files directly.
+- **Compile**: Compile scripts to `.fzb` bytecode for faster startup.
+- **REPL**: (Coming soon) Interactive shell.
+
+## Installation
+
+```bash
+cargo install fusabi
+```
 
 ## Usage
 
 ```bash
-# Run a script file
-fsrs-demo examples/hello.fsrs
+# Run a script
+fus run script.fsx
 
-# Evaluate an expression directly
-fsrs-demo -e "let x = 42 in x + 1"
+# Compile to bytecode
+fus grind script.fsx
 
-# Show bytecode disassembly
-fsrs-demo --disasm examples/arithmetic.fsrs
-
-# Show help
-fsrs-demo --help
-
-# Show version
-fsrs-demo --version
+# Run bytecode
+fus run script.fzb
 ```
-
-## Supported Features (Phase 1 MVP)
-
-### Data Types
-- **Integers**: `42`, `-5`, `0`
-- **Booleans**: `true`, `false`
-- **Strings**: `"hello world"`
-- **Unit**: `()`
-
-### Operators
-- **Arithmetic**: `+`, `-`, `*`, `/`
-- **Comparison**: `<`, `<=`, `>`, `>=`, `=`, `<>`
-- **Logical**: `&&`, `||`
-
-### Language Constructs
-- **Let Bindings**: `let x = 42 in x + 1`
-- **Conditionals**: `if x > 5 then 1 else 0`
-- **Nested Expressions**: Full support for nested let and if
-
-## Examples
-
-### Hello World
-```fsharp
-"Hello, FSRS!"
-```
-
-### Arithmetic
-```fsharp
-let a = 10 in
-let b = 5 in
-a * 2 + b - 3
-```
-
-### Conditionals
-```fsharp
-let x = 42 in
-let y = 17 in
-if x > y then x else y
-```
-
-### Fibonacci
-```fsharp
-let f0 = 0 in
-let f1 = 1 in
-let f2 = f0 + f1 in
-let f3 = f1 + f2 in
-f3
-```
-
-## Error Handling
-
-The demo provides clear error messages for:
-- **Lexer errors**: Invalid tokens or characters
-- **Parser errors**: Syntax errors
-- **Compiler errors**: Undefined variables, too many constants/locals
-- **Runtime errors**: Division by zero, type mismatches, stack underflow
-
-Example:
-```bash
-$ fsrs-demo -e "x + 1"
-Error: Compiler Error: Undefined variable: x
-```
-
-## Architecture
-
-The demo uses a clean pipeline architecture:
-
-1. **Lexical Analysis** (`fsrs_frontend::Lexer`): Tokenizes source code
-2. **Parsing** (`fsrs_frontend::Parser`): Builds AST from tokens
-3. **Compilation** (`fsrs_frontend::Compiler`): Generates bytecode from AST
-4. **Execution** (`fsrs_vm::Vm`): Executes bytecode and returns result
-
-## Development
-
-### Building
-```bash
-cargo build --package fsrs-demo
-```
-
-### Testing
-```bash
-cargo test --package fsrs-demo
-```
-
-### Running Examples
-```bash
-cargo run --package fsrs-demo -- examples/hello.fsrs
-```
-
-## Implementation Notes
-
-### Phase 1 Limitations
-- **No Lambda Functions**: Function definitions and applications not yet supported
-- **No Recursion**: Recursive functions not supported in Phase 1
-- **No Type Annotations**: Type inference only
-- **No Pattern Matching**: Simple expressions only
-
-These features will be added in Phase 2.
-
-### Compiler Fixes
-
-This demo integration uncovered and fixed two compiler bugs:
-1. **Let binding scope management**: Result values were being popped incorrectly
-2. **If-then-else POPs**: Unnecessary POP instructions after JumpIfFalse
-
-## Testing
-
-The test suite includes:
-- **38 integration tests** covering the full pipeline
-- **Pipeline tests**: Literals, arithmetic, types
-- **Let binding tests**: Simple, nested, shadowing
-- **Conditional tests**: If-then-else with comparisons
-- **Comparison tests**: All comparison operators
-- **Logical tests**: Boolean operations
-- **Error tests**: Lexer, parser, compiler, runtime errors
-- **Complex tests**: Fibonacci, max, absolute value
-
-All tests pass successfully.
-
-## Contributing
-
-See the main project README and CONTRIBUTING.md for development guidelines.
 
 ## License
 
-See the main project LICENSE file.
+MIT


### PR DESCRIPTION
Bumps version to 0.1.1 and updates crate READMEs to fix 'FSRS' branding on crates.io.