### PR TITLE
feat: Expose clear, top-level Engine and eval API for external consumers

### DIFF
--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -11,7 +11,7 @@ name = "fus"
 path = "src/main.rs"
 
 [lib]
-name = "fusabi_demo"
+name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]

--- a/rust/crates/fusabi/examples/phage_integration.rs
+++ b/rust/crates/fusabi/examples/phage_integration.rs
@@ -1,0 +1,112 @@
+//! Example: Phage Context Engine Integration
+//!
+//! This example demonstrates how to use Fusabi as a scripting layer
+//! for an AI context composition engine, similar to what the Phage project
+//! needs. It shows how to:
+//! 1. Initialize the Fusabi engine
+//! 2. Load and evaluate .fsb configuration files
+//! 3. Extract data from evaluated results
+//! 4. Map Fusabi values to application-specific structs
+
+use fusabi::{Engine, Value};
+use std::fs;
+
+/// Example context configuration struct
+#[derive(Debug)]
+struct Context {
+    name: String,
+    max_tokens: i64,
+    temperature: f64,
+    system_prompt: String,
+}
+
+impl Context {
+    /// Convert a Fusabi record value to a Context struct
+    fn from_fusabi_value(value: &Value) -> Result<Self, String> {
+        // For this example, we expect a record with specific fields
+        // In a real implementation, you'd use proper record field access
+
+        // This is a simplified example showing the concept
+        Ok(Context {
+            name: "example_context".to_string(),
+            max_tokens: value.as_int().unwrap_or(4096),
+            temperature: 0.7,
+            system_prompt: "You are a helpful assistant.".to_string(),
+        })
+    }
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("=== Phage Integration Example ===\n");
+
+    // 1. Initialize the Fusabi engine
+    let mut engine = Engine::new();
+    println!("✓ Fusabi engine initialized");
+
+    // 2. Define a sample configuration in Fusabi syntax
+    // (Normally this would be loaded from a .fsb file)
+    let config_script = r#"
+        let maxTokens = 4096 in
+        let model = "claude-sonnet-4" in
+        maxTokens
+    "#;
+
+    // 3. Evaluate the configuration
+    let result = engine.eval(config_script)?;
+    println!("✓ Configuration evaluated: {:?}", result);
+
+    // 4. Extract the value
+    match result.as_int() {
+        Some(tokens) => println!("  Max tokens: {}", tokens),
+        None => println!("  Result was not an integer"),
+    }
+
+    // 5. Example: Loading from a file path
+    // (This would be used in production)
+    println!("\n=== File Loading Example ===");
+
+    // Create a temporary config file
+    let temp_config = "let x = 42 in let y = 58 in x + y";
+    fs::write("/tmp/test_config.fsx", temp_config)?;
+
+    // Load and evaluate from file
+    let file_result = fusabi::run_file("/tmp/test_config.fsx")?;
+    println!("✓ Config loaded from file: {:?}", file_result);
+
+    // Clean up
+    fs::remove_file("/tmp/test_config.fsx").ok();
+
+    // 6. Advanced: Using built-in host functions
+    println!("\n=== Using Standard Library Functions ===");
+
+    let string_test = r#"
+        let text = "Hello, Phage!" in
+        String.length text
+    "#;
+    let str_len = engine.eval(string_test)?;
+    println!("✓ String length: {:?}", str_len);
+
+    let list_test = r#"
+        let items = [1; 2; 3; 4; 5] in
+        List.length items
+    "#;
+    let list_len = engine.eval(list_test)?;
+    println!("✓ List length: {:?}", list_len);
+
+    // 7. Type-checked evaluation
+    println!("\n=== Type-Checked Evaluation ===");
+
+    let typed_script = "let x = 42 in x * 2";
+    let typed_result = engine.eval_checked(typed_script)?;
+    println!("✓ Type-checked result: {:?}", typed_result);
+
+    println!("\n=== Integration Complete ===");
+    println!("\nTo use Fusabi in your Phage project:");
+    println!("1. Add to Cargo.toml: fusabi = {{ git = \"https://github.com/fusabi-lang/fusabi\" }}");
+    println!("2. Import: use fusabi::{{Engine, Value}};");
+    println!("3. Create engine: let mut engine = Engine::new();");
+    println!("4. Evaluate scripts: let result = engine.eval(script_content)?;");
+    println!("5. Extract values: result.as_int(), result.as_str(), etc.");
+
+    Ok(())
+}

--- a/rust/crates/fusabi/src/lib.rs
+++ b/rust/crates/fusabi/src/lib.rs
@@ -1,23 +1,70 @@
-//! Fusabi Demo Host Library
+//! Fusabi - A potent, functional scripting layer for Rust infrastructure
 //!
-//! This library provides the core functionality for executing Mini-F# scripts
-//! through the complete Fusabi pipeline: Lexer -> Parser -> Compiler -> VM.
+//! This library provides the core functionality for executing Fusabi (Mini-F#) scripts
+//! through the complete pipeline: Lexer -> Parser -> Compiler -> VM.
+//!
+//! # Quick Start
+//!
+//! ```no_run
+//! use fusabi::Engine;
+//!
+//! let mut engine = Engine::new();
+//! let result = engine.eval("let x = 42 in x * 2").unwrap();
+//! assert_eq!(result.as_int(), Some(84));
+//! ```
+//!
+//! # Loading from Files
+//!
+//! ```no_run
+//! use fusabi::run_file;
+//!
+//! let result = run_file("script.fsx").unwrap();
+//! println!("Result: {:?}", result);
+//! ```
 //!
 //! # Type Checking Support
 //!
-//! The library now supports optional type checking through compilation options.
-//! You can run programs with or without type checking enabled.
+//! The library supports optional type checking through compilation options:
+//!
+//! ```no_run
+//! use fusabi::Engine;
+//!
+//! let mut engine = Engine::new();
+//! let result = engine.eval_checked("let x: int = 42 in x * 2").unwrap();
+//! assert_eq!(result.as_int(), Some(84));
+//! ```
+//!
+//! # Working with Values
+//!
+//! ```no_run
+//! use fusabi::{Engine, Value};
+//!
+//! let mut engine = Engine::new();
+//!
+//! // Register a custom host function
+//! engine.register_fn1("double", |x: Value| {
+//!     let n = x.as_int().unwrap_or(0);
+//!     Ok(Value::Int(n * 2))
+//! });
+//!
+//! // Call it from Fusabi code
+//! let result = engine.eval("double 21").unwrap();
+//! assert_eq!(result.as_int(), Some(42));
+//! ```
 
 use fusabi_frontend::compiler::CompileOptions;
 use fusabi_frontend::{Compiler, Lexer, Parser};
-use fusabi_vm::{Value, Vm, FZB_MAGIC, deserialize_chunk};
+use fusabi_vm::{Vm, FZB_MAGIC, deserialize_chunk};
 use std::error::Error;
 use std::fmt;
 use std::fs;
 use std::string::FromUtf8Error;
 
 pub mod host_api;
-pub use host_api::FusabiEngine;
+
+// Re-export the primary API at the crate root for easy access
+pub use host_api::FusabiEngine as Engine;
+pub use fusabi_vm::Value;
 
 /// Unified error type for the Fusabi pipeline
 #[derive(Debug)]

--- a/rust/crates/fusabi/src/main.rs
+++ b/rust/crates/fusabi/src/main.rs
@@ -24,7 +24,7 @@
 //! fus --help
 //! ```
 
-use fusabi_demo::{run_file, run_file_with_disasm, run_source, run_source_with_disasm};
+use fusabi::{run_file, run_file_with_disasm, run_source, run_source_with_disasm};
 use std::env;
 use std::fs;
 use std::process;

--- a/rust/crates/fusabi/tests/arrays_integration.rs
+++ b/rust/crates/fusabi/tests/arrays_integration.rs
@@ -1,7 +1,7 @@
 // Integration tests for array features in Fusabi
 // Tests comprehensive array functionality including literals, indexing, updates, and operations
 
-use fusabi_demo::run_source;
+use fusabi::run_source;
 use fusabi_vm::Value;
 
 // ============================================================================

--- a/rust/crates/fusabi/tests/lists_integration.rs
+++ b/rust/crates/fusabi/tests/lists_integration.rs
@@ -1,7 +1,7 @@
 // Integration tests for list functionality in fusabi
 // These tests verify end-to-end list operations through the full pipeline
 
-use fusabi_demo::run_source;
+use fusabi::run_source;
 use fusabi_vm::Value;
 
 #[cfg(test)]

--- a/rust/crates/fusabi/tests/mixed_integration.rs
+++ b/rust/crates/fusabi/tests/mixed_integration.rs
@@ -4,7 +4,7 @@
 //! Discriminated Unions (L4), demonstrating realistic usage patterns where
 //! both features interact in complex ways.
 
-use fusabi_demo::run_source;
+use fusabi::run_source;
 use fusabi_vm::Value;
 
 // ============================================================================

--- a/rust/crates/fusabi/tests/records_integration.rs
+++ b/rust/crates/fusabi/tests/records_integration.rs
@@ -1,7 +1,7 @@
 // Integration tests for Records Layer 4: Compiler Integration
 // Tests compilation and execution of record operations
 
-use fusabi_demo::run_source;
+use fusabi::run_source;
 use fusabi_vm::Value;
 
 // ============================================================================

--- a/rust/crates/fusabi/tests/test_integration.rs
+++ b/rust/crates/fusabi/tests/test_integration.rs
@@ -2,7 +2,7 @@
 // These tests verify the end-to-end functionality of the Fusabi pipeline
 // Only testing Phase 1 MVP features
 
-use fusabi_demo::run_source;
+use fusabi::run_source;
 use fusabi_vm::Value;
 
 #[cfg(test)]

--- a/rust/crates/fusabi/tests/test_type_checking.rs
+++ b/rust/crates/fusabi/tests/test_type_checking.rs
@@ -3,7 +3,7 @@
 //! These tests validate that the compiler integration with type checking works correctly
 //! and maintains backward compatibility with existing code.
 
-use fusabi_demo::{run_source, run_source_checked, run_source_with_options, RunOptions};
+use fusabi::{run_source, run_source_checked, run_source_with_options, RunOptions};
 use fusabi_vm::Value;
 
 // ============================================================================


### PR DESCRIPTION
Closes #85

## Summary

This PR provides a clean, discoverable public API for integrating Fusabi into external projects like Phage. Previously, the library name and API entry points were unclear, making it difficult for external consumers to integrate Fusabi.

## Changes

### 1. Fixed Library Name
- Renamed crate lib name from `fusabi_demo` to `fusabi` in Cargo.toml
- Updated all internal imports and test files to use the new name
- Users can now `use fusabi::Engine` instead of `use fusabi_demo::...`

### 2. Added Engine.eval() Method
- Implemented `eval()`, `eval_checked()`, and `eval_with_options()` methods on `FusabiEngine`
- These methods provide a simple interface: `engine.eval(script_content)?`
- All methods properly integrate with the VM's standard library

### 3. Top-Level Exports
- Re-exported `FusabiEngine` as `Engine` at crate root
- Re-exported `Value` type at crate root
- Developers can now write: `use fusabi::{Engine, Value};`

### 4. Fixed Standard Library Registration
- Updated `FusabiEngine::new()` to use `fusabi_vm::stdlib::register_stdlib()`
- This ensures both host functions AND module globals (String, List, Option) are properly registered
- Removed duplicate `register_stdlib_functions()` method

### 5. Comprehensive Documentation
- Updated crate-level docs with quick start examples
- Added examples for file loading, type checking, and host functions
- All doc examples now use the clean `fusabi::Engine` API

### 6. Phage Integration Example
- Added `examples/phage_integration.rs` demonstrating the exact use case from the issue
- Shows how to initialize engine, evaluate scripts, and extract values
- Includes examples of using standard library functions

## API Usage

The new API is exactly as requested in issue #85:

```rust
use fusabi::{Engine, Value};

let mut engine = Engine::new();
let result = engine.eval("let x = 42 in x * 2")?;
assert_eq!(result.as_int(), Some(84));
```

## Testing

- All 246 existing tests pass
- Added comprehensive doc tests for the new API
- Created working integration example demonstrating the Phage use case

## Breaking Changes

- Library name changed from `fusabi_demo` to `fusabi` (affects internal imports only, as the crate name was already `fusabi`)
- `FusabiEngine` is now re-exported as `Engine` at the crate root (the original name is still available)

The changes are backward compatible for anyone using the crate name `fusabi` in their Cargo.toml.