### PR TITLE
fix: Install just in PR checks workflow

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -16,6 +16,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 
+      - name: Install just
+        uses: taiki-e/install-action@just
+
       - name: Setup Rust toolchain
         uses: dtolnay/rust-toolchain@stable
         with:


### PR DESCRIPTION
## Summary

Fixes the PR checks workflow that was failing due to missing `just` command runner.

## Problem

The `pr-checks.yml` workflow runs commands like `just fmt-check`, `just lint`, and `just build`, but it wasn't installing the `just` tool first, causing the workflow to fail with "command not found" errors.

## Solution

Added the `taiki-e/install-action@just` step to install just before running any just commands, matching the pattern already used in the main `ci.yml` workflow.

## Changes

- Added `Install just` step to the `pr-quick-check` job in `.github/workflows/pr-checks.yml`
- Placed it before the Rust toolchain setup to ensure just is available early

## Testing

The fix follows the same pattern successfully used in:
- `.github/workflows/ci.yml` (check, test, build-release, dependency-check jobs)

This is a low-risk change that only adds a missing dependency installation step.