### PR TITLE
chore: Release v0.2.0 - Public Engine API

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.1.1" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.2.0" }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,5 +15,5 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.1.1" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.1.1", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.2.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.2.0", features = ["serde"] }


### PR DESCRIPTION
## Release v0.2.0

This PR prepares the v0.2.0 release with the new public Engine API.

### What's New

#### Major Features
- **Public Engine API**: Clean, discoverable API with `Engine::new()` and `eval()` methods (#85, #86)
- **Top-level exports**: `use fusabi::{Engine, Value}` now works as expected
- **Library rename**: Internal library name changed from `fusabi_demo` to `fusabi`

#### API Improvements
- Added `Engine::eval()`, `Engine::eval_checked()`, and `Engine::eval_with_options()`
- Fixed standard library module registration (String, List, Option globals)
- Comprehensive documentation with usage examples
- Added Phage integration example demonstrating real-world usage

#### Bug Fixes
- Fixed PR checks CI workflow missing `just` installation (#87)

### Breaking Changes

- Internal library name changed from `fusabi_demo` to `fusabi` (only affects internal imports, external users already use `fusabi` as crate name)

### Migration Guide

```rust
// Before (0.1.x)
use fusabi_demo::run_source;
let result = run_source(script)?;

// After (0.2.0) - Recommended
use fusabi::Engine;
let mut engine = Engine::new();
let result = engine.eval(script)?;

// After (0.2.0) - Legacy functions still available
use fusabi::run_source;
let result = run_source(script)?;
```

### Version Bumps

- `fusabi`: 0.1.1 → 0.2.0
- `fusabi-frontend`: 0.1.1 → 0.2.0
- `fusabi-vm`: 0.1.1 → 0.2.0

### Testing

- ✅ All 246 tests pass
- ✅ Release build successful
- ✅ Example code verified working

Once merged, this will trigger the release workflow to create GitHub release and build artifacts.