### PR TITLE
chore: Release v0.4.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.3.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.4.0" }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,5 +15,5 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.3.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.3.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.4.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.4.0", features = ["serde"] }


### PR DESCRIPTION
Bumps version to 0.4.0 after top-level bindings feature.