### PR TITLE
chore: Release v0.7.0

### DIFF
--- a/rust/crates/fusabi-bench-compare/Cargo.toml
+++ b/rust/crates/fusabi-bench-compare/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-bench-compare"
-version = "0.1.0"
+version = "0.7.0"
 edition = "2021"
 description = "Benchmarking comparison harness for Fusabi vs other embedded languages"
 

--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.6.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.7.0" }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.6.0"
+version = "0.7.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,6 +15,6 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.6.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.6.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.7.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.7.0", features = ["serde"] }
 colored = "2.1"


### PR DESCRIPTION
Release v0.7.0 with MCP server integration and comprehensive benchmarking infrastructure.

## New Features

### Fusabi-MCP Server (#64, #101)
- New crate `fusabi-mcp` implementing Model Context Protocol
- Two MCP tools: `eval_fusabi` and `get_context`
- Full JSON-RPC 2.0 protocol support via stdio
- Automatic Value → JSON conversion
- Claude Desktop integration guide

### Comprehensive Benchmarking Suite (#62, #102)
- Micro-benchmarks for VM operations, allocation, function calls
- Macro-benchmarks: Fibonacci, Sieve, Binary Trees, Takeuchi
- Comparison harness vs Rhai and Lua
- Just recipes for easy benchmark execution
- Complete documentation in docs/BENCHMARKS.md

## Version Bumps

- fusabi: 0.6.0 → 0.7.0
- fusabi-frontend: 0.6.0 → 0.7.0
- fusabi-vm: 0.6.0 → 0.7.0
- fusabi-mcp: 0.1.0 → 0.7.0
- fusabi-bench-compare: 0.1.0 → 0.7.0

## Issues Addressed

Closed:
- #64: Create Fusabi-MCP Server ✅
- #62: Create Comprehensive Benchmarking Suite ✅

Commented (deferred):
- #100: Send + Sync Engine (v1.0.0)
- #95: Method dispatch for HostData
- #61: Mark-and-Sweep GC (v1.0.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)