### PR TITLE
feat: Complete Configuration DSL support (#109)

### DIFF
--- a/rust/crates/fusabi-frontend/tests/option_syntax_tests.rs
+++ b/rust/crates/fusabi-frontend/tests/option_syntax_tests.rs
@@ -1,0 +1,163 @@
+//! Integration tests for Option type syntax support
+//!
+//! Tests to ensure that Option constructors (Some and None) work naturally
+//! without requiring parentheses for single arguments.
+
+use fusabi_frontend::ast::{Expr, Literal};
+use fusabi_frontend::compiler::Compiler;
+use fusabi_frontend::lexer::Lexer;
+use fusabi_frontend::parser::Parser;
+
+// Helper function to parse a string
+fn parse_expr(input: &str) -> Result<Expr, String> {
+    let mut lexer = Lexer::new(input);
+    let tokens = lexer.tokenize().map_err(|e| format!("Lex error: {}", e))?;
+    let mut parser = Parser::new(tokens);
+    parser.parse().map_err(|e| format!("Parse error: {}", e))
+}
+
+#[test]
+fn test_none_no_parens() {
+    // None should work without parentheses
+    let expr = parse_expr("None").unwrap();
+    assert!(expr.is_variant_construct());
+
+    if let Expr::VariantConstruct { variant, fields, .. } = expr {
+        assert_eq!(variant, "None");
+        assert_eq!(fields.len(), 0);
+    } else {
+        panic!("Expected VariantConstruct");
+    }
+}
+
+#[test]
+fn test_some_with_parens() {
+    // Some(42) should work (current implementation)
+    let expr = parse_expr("Some(42)").unwrap();
+    assert!(expr.is_variant_construct());
+
+    if let Expr::VariantConstruct { variant, fields, .. } = expr {
+        assert_eq!(variant, "Some");
+        assert_eq!(fields.len(), 1);
+    } else {
+        panic!("Expected VariantConstruct");
+    }
+}
+
+#[test]
+fn test_some_without_parens() {
+    // Some 42 should work (F# style)
+    let expr = parse_expr("Some 42").unwrap();
+    assert!(expr.is_variant_construct(), "Some 42 should be parsed as variant, got: {:?}", expr);
+
+    if let Expr::VariantConstruct { variant, fields, .. } = expr {
+        assert_eq!(variant, "Some");
+        assert_eq!(fields.len(), 1);
+        // Check the field is Int(42)
+        if let Expr::Lit(Literal::Int(n)) = *fields[0].as_ref() {
+            assert_eq!(n, 42);
+        } else {
+            panic!("Expected Int(42) in field");
+        }
+    } else {
+        panic!("Expected VariantConstruct, got: {:?}", expr);
+    }
+}
+
+#[test]
+fn test_some_with_variable() {
+    // Some x should work
+    let expr = parse_expr("let x = 42 in Some x").unwrap();
+
+    if let Expr::Let { body, .. } = expr {
+        assert!(body.is_variant_construct());
+        if let Expr::VariantConstruct { variant, fields, .. } = *body {
+            assert_eq!(variant, "Some");
+            assert_eq!(fields.len(), 1);
+            assert!(fields[0].is_var());
+        }
+    } else {
+        panic!("Expected Let expression");
+    }
+}
+
+#[test]
+fn test_some_with_expression() {
+    // Some (x + 1) should work
+    let expr = parse_expr("let x = 41 in Some (x + 1)").unwrap();
+
+    if let Expr::Let { body, .. } = expr {
+        assert!(body.is_variant_construct());
+    } else {
+        panic!("Expected Let expression");
+    }
+}
+
+#[test]
+fn test_nested_option() {
+    // Some (Some 42) should work
+    let expr = parse_expr("Some (Some 42)").unwrap();
+    assert!(expr.is_variant_construct());
+
+    if let Expr::VariantConstruct { variant, fields, .. } = expr {
+        assert_eq!(variant, "Some");
+        assert_eq!(fields.len(), 1);
+        // Inner should also be a variant construct
+        assert!(fields[0].is_variant_construct());
+    }
+}
+
+#[test]
+fn test_option_in_let_binding() {
+    // let opt = Some 42 in opt
+    let expr = parse_expr("let opt = Some 42 in opt").unwrap();
+
+    if let Expr::Let { value, .. } = expr {
+        assert!(value.is_variant_construct());
+    } else {
+        panic!("Expected Let expression");
+    }
+}
+
+#[test]
+fn test_option_with_string() {
+    // Some "hello" should work
+    let expr = parse_expr("Some \"hello\"").unwrap();
+    assert!(expr.is_variant_construct());
+
+    if let Expr::VariantConstruct { variant, fields, .. } = expr {
+        assert_eq!(variant, "Some");
+        assert_eq!(fields.len(), 1);
+        match fields[0].as_ref() {
+            Expr::Lit(Literal::Str(s)) => {
+                assert_eq!(s, "hello");
+            }
+            _ => panic!("Expected string literal"),
+        }
+    }
+}
+
+#[test]
+fn test_multiple_variants_in_list() {
+    // [Some 1; None; Some 2] should work
+    let expr = parse_expr("[Some 1; None; Some 2]").unwrap();
+
+    if let Expr::List(elements) = expr {
+        assert_eq!(elements.len(), 3);
+        assert!(elements[0].is_variant_construct());
+        assert!(elements[1].is_variant_construct());
+        assert!(elements[2].is_variant_construct());
+    } else {
+        panic!("Expected List");
+    }
+}
+
+#[test]
+fn test_compile_some_without_parens() {
+    // Ensure Some 42 compiles correctly
+    let expr = parse_expr("Some 42").unwrap();
+    let chunk = Compiler::compile(&expr).unwrap();
+
+    // Should have MakeVariant instruction
+    assert!(chunk.instructions.iter().any(|i| matches!(i, fusabi_vm::instruction::Instruction::MakeVariant(1))));
+}

--- a/rust/crates/fusabi-frontend/tests/test_du_parsing.rs
+++ b/rust/crates/fusabi-frontend/tests/test_du_parsing.rs
@@ -544,7 +544,8 @@ fn test_parse_du_missing_eq() {
 
 #[test]
 fn test_parse_du_missing_variant_name() {
-    let result = parse_du_typedef("type Option = | None");
+    // This should fail because there's a pipe with nothing after it
+    let result = parse_du_typedef("type Option = |");
     assert!(result.is_err());
 }
 

--- a/rust/crates/fusabi/tests/anonymous_records_integration.rs
+++ b/rust/crates/fusabi/tests/anonymous_records_integration.rs
@@ -1,0 +1,486 @@
+// Integration tests for Anonymous Records (Issue #109 Workstream 3)
+// Tests compilation and execution of anonymous record operations
+
+use fusabi::run_source;
+use fusabi_vm::Value;
+
+// ============================================================================
+// BASIC ANONYMOUS RECORD LITERAL TESTS
+// ============================================================================
+
+#[test]
+fn test_empty_anonymous_record() {
+    let source = r#"{||}"#;
+    let result = run_source(source).unwrap();
+    assert!(matches!(result, Value::Record(_)));
+    if let Value::Record(rec) = result {
+        assert_eq!(rec.borrow().len(), 0);
+    }
+}
+
+#[test]
+fn test_single_field_anonymous_record() {
+    let source = r#"{| name = "Alice" |}"#;
+    let result = run_source(source).unwrap();
+    assert!(matches!(result, Value::Record(_)));
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(borrowed.len(), 1);
+        assert_eq!(
+            *borrowed.get("name").unwrap(),
+            Value::Str("Alice".to_string())
+        );
+    }
+}
+
+#[test]
+fn test_multi_field_anonymous_record() {
+    let source = r#"{| name = "Bob"; age = 30; active = true |}"#;
+    let result = run_source(source).unwrap();
+    assert!(matches!(result, Value::Record(_)));
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(borrowed.len(), 3);
+        assert_eq!(
+            *borrowed.get("name").unwrap(),
+            Value::Str("Bob".to_string())
+        );
+        assert_eq!(*borrowed.get("age").unwrap(), Value::Int(30));
+        assert_eq!(*borrowed.get("active").unwrap(), Value::Bool(true));
+    }
+}
+
+#[test]
+fn test_anonymous_record_with_computed_fields() {
+    let source = r#"{| x = 5 + 3; y = 10 * 2; sum = (5 + 3) + (10 * 2) |}"#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(*borrowed.get("x").unwrap(), Value::Int(8));
+        assert_eq!(*borrowed.get("y").unwrap(), Value::Int(20));
+        assert_eq!(*borrowed.get("sum").unwrap(), Value::Int(28));
+    }
+}
+
+#[test]
+fn test_anonymous_record_trailing_semicolon() {
+    let source = r#"{| x = 1; y = 2; |}"#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(borrowed.len(), 2);
+        assert_eq!(*borrowed.get("x").unwrap(), Value::Int(1));
+        assert_eq!(*borrowed.get("y").unwrap(), Value::Int(2));
+    }
+}
+
+// ============================================================================
+// FIELD ACCESS TESTS
+// ============================================================================
+
+#[test]
+fn test_anonymous_record_field_access() {
+    let source = r#"
+        let person = {| name = "Charlie"; age = 25 |} in
+        person.name
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("Charlie".to_string()));
+}
+
+#[test]
+fn test_anonymous_record_multiple_field_accesses() {
+    let source = r#"
+        let person = {| name = "Diana"; age = 35; city = "NYC" |} in
+        person.age
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(35));
+}
+
+#[test]
+fn test_anonymous_record_chained_field_access() {
+    let source = r#"
+        let config = {| server = {| host = "localhost"; port = 8080 |} |} in
+        config.server.host
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("localhost".to_string()));
+}
+
+// ============================================================================
+// RECORD UPDATE TESTS (with anonymous records)
+// ============================================================================
+
+#[test]
+fn test_anonymous_record_update() {
+    let source = r#"
+        let person = {| name = "Eve"; age = 28 |} in
+        let updated = { person with age = 29 } in
+        updated.age
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(29));
+}
+
+#[test]
+fn test_anonymous_record_multi_field_update() {
+    let source = r#"
+        let person = {| name = "Frank"; age = 40; city = "LA" |} in
+        let updated = { person with age = 41; city = "SF" } in
+        updated.city
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("SF".to_string()));
+}
+
+#[test]
+fn test_anonymous_record_update_preserves_original() {
+    let source = r#"
+        let person = {| name = "Grace"; age = 30 |} in
+        let updated = { person with age = 31 } in
+        person.age
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(30));
+}
+
+// ============================================================================
+// NESTED ANONYMOUS RECORD TESTS
+// ============================================================================
+
+#[test]
+fn test_nested_anonymous_record_literal() {
+    let source = r#"
+        {|
+            user = {| name = "Henry"; id = 101 |};
+            metadata = {| created = "2024-01-01"; version = 1 |}
+        |}
+    "#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert!(matches!(borrowed.get("user").unwrap(), Value::Record(_)));
+        assert!(matches!(
+            borrowed.get("metadata").unwrap(),
+            Value::Record(_)
+        ));
+    }
+}
+
+#[test]
+fn test_nested_anonymous_record_access() {
+    let source = r#"
+        let data = {|
+            user = {| name = "Iris"; profile = {| age = 32; bio = "Developer" |} |}
+        |} in
+        data.user.profile.bio
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("Developer".to_string()));
+}
+
+#[test]
+fn test_nested_anonymous_record_update() {
+    let source = r#"
+        let data = {| user = {| name = "Jack"; age = 25 |} |} in
+        let updated = { data with user = {| name = "Jack"; age = 26 |} } in
+        updated.user.age
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(26));
+}
+
+// ============================================================================
+// MIXED REGULAR AND ANONYMOUS RECORDS
+// ============================================================================
+
+#[test]
+fn test_mix_regular_and_anonymous_records() {
+    let source = r#"
+        let anon = {| x = 10; y = 20 |} in
+        let regular = { a = 1; b = 2 } in
+        anon.x + regular.a
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(11));
+}
+
+#[test]
+fn test_anonymous_record_nested_in_regular() {
+    let source = r#"
+        let outer = { inner = {| value = 42 |} } in
+        outer.inner.value
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(42));
+}
+
+#[test]
+fn test_regular_record_nested_in_anonymous() {
+    let source = r#"
+        let outer = {| inner = { value = 99 } |} in
+        outer.inner.value
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(99));
+}
+
+// ============================================================================
+// ANONYMOUS RECORDS WITH FUNCTIONS
+// ============================================================================
+
+#[test]
+#[ignore = "TODO: Requires compiler support for record field variable shadowing"]
+fn test_function_returning_anonymous_record() {
+    let source = r#"
+        let makePerson name age = {| name = name; age = age |} in
+        makePerson "Kelly" 27
+    "#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(
+            *borrowed.get("name").unwrap(),
+            Value::Str("Kelly".to_string())
+        );
+        assert_eq!(*borrowed.get("age").unwrap(), Value::Int(27));
+    }
+}
+
+#[test]
+#[ignore = "TODO: Requires compiler support for parameter variable scoping"]
+fn test_function_taking_anonymous_record() {
+    let source = r#"
+        let getAge person = person.age in
+        let person = {| name = "Larry"; age = 45 |} in
+        getAge person
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(45));
+}
+
+#[test]
+#[ignore = "TODO: Requires compiler support for parameter variable scoping in record updates"]
+fn test_function_updating_anonymous_record() {
+    let source = r#"
+        let incrementAge person = { person with age = person.age + 1 } in
+        let person = {| name = "Mary"; age = 29 |} in
+        let older = incrementAge person in
+        older.age
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(30));
+}
+
+// ============================================================================
+// ANONYMOUS RECORDS IN DATA STRUCTURES
+// ============================================================================
+
+#[test]
+#[ignore = "TODO: Requires runtime support for List.head with records"]
+fn test_anonymous_record_in_list() {
+    let source = r#"
+        let people = [
+            {| name = "Oscar"; age = 28 |};
+            {| name = "Pam"; age = 32 |}
+        ] in
+        let first = List.head people in
+        first.name
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("Oscar".to_string()));
+}
+
+#[test]
+fn test_anonymous_record_with_array_field() {
+    let source = r#"
+        let data = {| values = [|1; 2; 3|]; count = 3 |} in
+        data.count
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(3));
+}
+
+#[test]
+fn test_anonymous_record_with_list_field() {
+    let source = r#"
+        let data = {| items = [1; 2; 3]; total = 3 |} in
+        data.total
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(3));
+}
+
+// ============================================================================
+// COMPLEX SCENARIOS
+// ============================================================================
+
+#[test]
+fn test_multiple_anonymous_record_updates() {
+    let source = r#"
+        let person = {| name = "Tom"; age = 20; city = "NYC" |} in
+        let person2 = { person with age = 21 } in
+        let person3 = { person2 with city = "LA" } in
+        person3.city
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("LA".to_string()));
+}
+
+#[test]
+fn test_anonymous_record_equality_fields() {
+    let source = r#"
+        let p1 = {| x = 5; y = 10 |} in
+        let p2 = {| x = 5; y = 10 |} in
+        p1.x = p2.x && p1.y = p2.y
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[test]
+fn test_anonymous_record_with_boolean_fields() {
+    let source = r#"
+        let flags = {| active = true; verified = false; admin = true |} in
+        flags.active && flags.admin
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Bool(true));
+}
+
+#[test]
+fn test_anonymous_record_field_arithmetic() {
+    let source = r#"
+        let rect = {| width = 10; height = 20 |} in
+        rect.width * rect.height
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(200));
+}
+
+#[test]
+fn test_anonymous_record_update_with_computation() {
+    let source = r#"
+        let counter = {| count = 5 |} in
+        let updated = { counter with count = counter.count * 2 } in
+        updated.count
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(10));
+}
+
+#[test]
+fn test_deeply_nested_anonymous_records() {
+    let source = r#"
+        let config = {|
+            app = {|
+                name = "MyApp";
+                settings = {|
+                    debug = true;
+                    port = 3000
+                |}
+            |}
+        |} in
+        config.app.settings.port
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Int(3000));
+}
+
+// ============================================================================
+// EDGE CASES
+// ============================================================================
+
+#[test]
+fn test_anonymous_record_with_string_field_names() {
+    let source = r#"
+        {| firstName = "Uma"; lastName = "Volt" |}
+    "#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(borrowed.len(), 2);
+        assert!(borrowed.contains_key("firstName"));
+        assert!(borrowed.contains_key("lastName"));
+    }
+}
+
+#[test]
+fn test_anonymous_record_field_shadowing() {
+    let source = r#"
+        let name = "Wendy" in
+        let person = {| name = name; age = 24 |} in
+        person.name
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("Wendy".to_string()));
+}
+
+#[test]
+fn test_anonymous_record_in_match_value() {
+    let source = r#"
+        let person = {| name = "Sam"; age = 40 |} in
+        match person.age with
+        | 40 -> "forty"
+        | _ -> "other"
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Str("forty".to_string()));
+}
+
+#[test]
+fn test_match_on_anonymous_record_field() {
+    let source = r#"
+        let status = {| code = 200; message = "OK" |} in
+        match status.code with
+        | 200 -> true
+        | _ -> false
+    "#;
+    let result = run_source(source).unwrap();
+    assert_eq!(result, Value::Bool(true));
+}
+
+// ============================================================================
+// ANONYMOUS RECORD SYNTAX VARIATIONS
+// ============================================================================
+
+#[test]
+fn test_anonymous_record_no_semicolons() {
+    let source = r#"{| x = 1 |}"#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(borrowed.len(), 1);
+        assert_eq!(*borrowed.get("x").unwrap(), Value::Int(1));
+    }
+}
+
+#[test]
+fn test_anonymous_record_multiline() {
+    let source = r#"
+        {|
+            a = 1;
+            b = 2;
+            c = 3
+        |}
+    "#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(borrowed.len(), 3);
+    }
+}
+
+#[test]
+fn test_anonymous_record_inline_expressions() {
+    let source = r#"
+        {| result = if true then 1 else 0; flag = 1 > 0 |}
+    "#;
+    let result = run_source(source).unwrap();
+    if let Value::Record(rec) = result {
+        let borrowed = rec.borrow();
+        assert_eq!(*borrowed.get("result").unwrap(), Value::Int(1));
+        assert_eq!(*borrowed.get("flag").unwrap(), Value::Bool(true));
+    }
+}


### PR DESCRIPTION
# Complete Configuration DSL Support for Issue #109

This PR implements the remaining high-priority features from issue #109 to complete Configuration DSL support for Fusabi. All three workstreams were developed in parallel using Claude Code's parallel orchestration capabilities.

## 📋 Summary

This PR completes the Configuration DSL feature request by implementing:
1. **Option Type Syntax** (HIGH) - Native `Some 42` and `None` syntax
2. **Module Imports** (HIGH) - Working `open` statements for standard library
3. **Anonymous Records** (LOW) - `{| ... |}` syntax support

## 🎯 Workstream 1: Option Type Syntax (HIGH Priority)

**Goal**: Add native syntax support for `Some` and `None` variant constructors.

**Implementation**:
- Modified parser to convert variant constructor applications into proper variant constructs
- Added `convert_variant_app_to_construct()` function to detect patterns like `Some 42`
- Added `extract_variant_and_args()` helper for application chain analysis
- Full backward compatibility: `Some(42)` still works alongside `Some 42`

**Test Coverage**:
- ✅ 10 new integration tests in `option_syntax_tests.rs`
- ✅ All tests passing (100% success rate)

**Examples**:
\`\`\`fsharp
let x = Some 42          // New syntax  
let y = None             // Works without parens
let z = Some(42)         // Old syntax still works

match x with
| Some v -> v * 2
| None -> 0
\`\`\`

## 🎯 Workstream 2: Module Imports Implementation (HIGH Priority)

**Goal**: Make `open` statements work for importing standard library modules.

**Implementation**:
- Added `ModuleRegistry::with_stdlib()` to pre-populate standard library modules
- Registered List, String, Map, Option, and System.Collections.Generic modules
- Updated compiler to use stdlib-aware module registry
- Standard library modules resolve to runtime globals via RecordAccess

**Test Coverage**:
- ✅ All existing module tests passing (30/30)
- ✅ Module resolution works correctly
- ✅ Multiple imports supported

**Examples**:
\`\`\`fsharp
open List
open String
open System.Collections.Generic

// Now you can use standard library modules
\`\`\`

## 🎯 Workstream 3: Anonymous Records (LOW Priority)

**Goal**: Add `{| ... |}` syntax for anonymous records.

**Implementation**:
- Added `LBracePipe` and `PipeRBrace` tokens to lexer
- Added `parse_anonymous_record_literal()` function to parser
- Reuses existing `RecordLiteral` AST node and `Value::Record` runtime representation
- Zero compiler changes needed - anonymous records compile identically to regular records

**Test Coverage**:
- ✅ 36 new integration tests in `anonymous_records_integration.rs`
- ✅ 32 passing, 4 ignored (same limitations as regular records)

**Examples**:
\`\`\`fsharp
{||}                                         // Empty
{| name = "Alice"; age = 30 |}              // Basic  
{| outer = {| inner = 42 |} |}              // Nested
let config = {| debug = true; port = 8080 |}
\`\`\`

## 🔧 Additional Changes

- Fixed test `test_parse_du_missing_variant_name` to test actual invalid syntax (`type T = |` instead of `type T = | None`)
- Removed dead code warnings for unused helper methods
- Parser refactoring reduced file size by ~500 lines while adding features

## ✅ Testing Summary

| Test Suite | Status |
|------------|--------|
| Option Syntax Tests | 10/10 passing ✅ |
| Anonymous Records Tests | 32/32 passing (4 ignored) ✅ |
| Module Tests | 30/30 passing ✅ |
| All Other Tests | 100% passing ✅ |
| **Total** | **No breaking changes** ✅ |

## 📊 Issue Resolution

Closes #109

This completes all features from the Configuration DSL Support request, enabling Scarab Terminal to use Fusabi as a full-featured configuration language with:

- ✅ Type-safe Option types (this PR)
- ✅ Records (previously implemented)
- ✅ Anonymous records (this PR)
- ✅ Module imports (this PR)
- ✅ Floating-point numbers (PR #110)
- ✅ Map types (PR #116)
- ✅ Enum/DU types (previously implemented)

## 🚀 Impact

Fusabi now has configuration capabilities on par with:
- **Lua** (neovim configs)
- **Dhall** (kubernetes configs)
- **Nix** (system configs)

But with **static type safety** and **F# expressiveness**.

## 🔍 Files Changed

- `crates/fusabi-frontend/src/parser.rs` - Parser enhancements for all three features
- `crates/fusabi-frontend/src/lexer.rs` - Anonymous record tokens
- `crates/fusabi-frontend/src/modules.rs` - Standard library module registry
- `crates/fusabi-frontend/src/compiler.rs` - Module compilation updates
- `crates/fusabi-frontend/tests/option_syntax_tests.rs` - New test suite
- `crates/fusabi/tests/anonymous_records_integration.rs` - New test suite
- `crates/fusabi-frontend/tests/test_du_parsing.rs` - Test fix

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>