### PR TITLE
chore: Bump version to v0.12.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.11.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.12.0" }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,6 +15,6 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.11.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.11.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.12.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.12.0", features = ["serde"] }
 colored = "2.1"


### PR DESCRIPTION
## Summary

Bump version to v0.12.0 in preparation for release.

## Features in This Release

### Option Type Integration (#113)
- ✅ Complete Option module with all standard functions
- ✅ Some and None constructors auto-imported
- ✅ Pattern matching support
- ✅ Type inference for Option<'a>
- ✅ Comprehensive test coverage

### Anonymous Records with Structural Typing (#114)
- ✅ Anonymous record syntax `{| field = value |}`
- ✅ Structural typing (same fields = compatible types)
- ✅ Field order irrelevance
- ✅ Nested anonymous records
- ✅ Record updates
- ✅ Full test coverage

## Version Updates

- fusabi: 0.11.0 → 0.12.0
- fusabi-frontend: 0.11.0 → 0.12.0
- fusabi-vm: 0.11.0 → 0.12.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)