### PR TITLE
fix: Support comma-separated list literal syntax (#125)

### DIFF
--- a/rust/ISSUE_125_FIX_SUMMARY.md
+++ b/rust/ISSUE_125_FIX_SUMMARY.md
@@ -1,0 +1,186 @@
+# Fix for Issue #125: List Literal Comma Syntax
+
+## Problem
+List literals with comma-separated syntax `[1, 2, 3]` were not parsing correctly. The parser only supported semicolon-separated syntax `[1; 2; 3]`.
+
+Error encountered:
+```
+UnexpectedToken { expected: "]", found: Comma }
+```
+
+## Solution
+Updated the `parse_list()` function in `/home/beengud/tmp/fusabi/rust/crates/fusabi-frontend/src/parser.rs` to support both comma and semicolon separators for backward compatibility.
+
+### Changes Made
+
+#### 1. Updated Parser Implementation (parser.rs:1447-1480)
+
+**Before:**
+```rust
+fn parse_list(&mut self) -> Result<Expr> {
+    self.expect_token(Token::LBracket)?;
+
+    if self.match_token(&Token::RBracket) {
+        return Ok(Expr::List(vec![]));
+    }
+
+    let mut elements = vec![];
+
+    loop {
+        elements.push(self.parse_expr()?);
+
+        // Check for semicolon separator
+        if self.match_token(&Token::Semicolon) {
+            if matches!(self.current_token().token, Token::RBracket) {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    self.expect_token(Token::RBracket)?;
+    Ok(Expr::List(elements))
+}
+```
+
+**After:**
+```rust
+fn parse_list(&mut self) -> Result<Expr> {
+    self.expect_token(Token::LBracket)?;
+
+    if self.match_token(&Token::RBracket) {
+        return Ok(Expr::List(vec![]));
+    }
+
+    let mut elements = vec![];
+
+    loop {
+        elements.push(self.parse_expr()?);
+
+        // Check for comma or semicolon separator
+        if self.match_token(&Token::Comma) || self.match_token(&Token::Semicolon) {
+            if matches!(self.current_token().token, Token::RBracket) {
+                break;
+            }
+        } else {
+            break;
+        }
+    }
+
+    self.expect_token(Token::RBracket)?;
+    Ok(Expr::List(elements))
+}
+```
+
+Key change: Line 1466 now accepts both `Token::Comma` and `Token::Semicolon` as valid separators.
+
+#### 2. Updated Grammar Documentation
+
+Updated the parser module documentation to reflect the new syntax:
+
+**Before:**
+```
+//! - Lists: `[1; 2; 3]`, `[]`
+```
+
+**After:**
+```
+//! - Lists: `[1, 2, 3]`, `[1; 2; 3]`, `[]`
+```
+
+And in the grammar specification (line 55):
+```
+//! list       ::= "[" "]" | "[" expr (("," | ";") expr)* ("," | ";")? "]"
+```
+
+### Supported Syntax
+
+The parser now supports all of these syntaxes:
+
+1. **Comma-separated:** `[1, 2, 3]`
+2. **Comma with trailing comma:** `[1, 2, 3,]`
+3. **Semicolon-separated (backward compatible):** `[1; 2; 3]`
+4. **Semicolon with trailing separator:** `[1; 2; 3;]`
+5. **Empty lists:** `[]`
+6. **Nested lists:** `[[1, 2], [3, 4]]`
+7. **Mixed separators:** `[[1; 2], [3, 4]]` (outer comma, inner semicolon)
+
+### Tests Added
+
+Created comprehensive test suite in `/home/beengud/tmp/fusabi/rust/crates/fusabi-frontend/tests/list_literal_syntax_tests.rs`:
+
+- 34 test cases covering:
+  - Comma-separated lists
+  - Backward compatibility with semicolons
+  - Different element types (strings, floats, bools)
+  - Lists with expressions
+  - Nested lists
+  - Lists in different contexts (let bindings, if conditions, function arguments)
+  - Cons operator with comma lists
+  - Edge cases (whitespace, newlines)
+  - Real-world usage examples
+
+All tests pass: **34 passed; 0 failed**
+
+### Verification
+
+#### Parser Tests
+```bash
+cargo test --package fusabi-frontend
+```
+Result: **590+ tests passed, 0 failed**
+
+#### Specific Fix Verification
+```bash
+cargo test --package fusabi-frontend --test list_literal_syntax_tests
+```
+Result: **34 passed; 0 failed**
+
+#### Real-World Example
+The exact syntax from the bytecode API test now parses correctly:
+```fsharp
+let list = [1, 2, 3] in
+let doubled = List.map (fun x -> x * 2) list in
+List.head doubled
+```
+
+**Status:** Parsing works correctly. (Execution fails due to unrelated runtime issue with `List.map` method dispatch)
+
+## Backward Compatibility
+
+The fix maintains **full backward compatibility**:
+- All existing code using semicolon syntax `[1; 2; 3]` continues to work
+- No breaking changes to the AST or compiler
+- All 590+ existing frontend tests pass
+
+## Files Modified
+
+1. `/home/beengud/tmp/fusabi/rust/crates/fusabi-frontend/src/parser.rs`
+   - Updated `parse_list()` function (lines 1447-1480)
+   - Updated module documentation (lines 15, 55)
+
+## Files Created
+
+1. `/home/beengud/tmp/fusabi/rust/crates/fusabi-frontend/tests/list_literal_syntax_tests.rs`
+   - Comprehensive test suite for comma-separated list syntax
+
+2. `/home/beengud/tmp/fusabi/rust/crates/fusabi-frontend/tests/list_syntax_demo.rs`
+   - Demonstration tests showing the fix works for issue #125
+
+## Impact
+
+- **Issue Fixed:** List literals can now use F#-style comma syntax
+- **Backward Compatible:** Yes, semicolon syntax still works
+- **Breaking Changes:** None
+- **Performance Impact:** Negligible (one additional token check)
+- **Test Coverage:** 34 new tests added, all existing tests pass
+
+## Next Steps
+
+The parsing issue is resolved. However, the `test_compile_list_operations` bytecode API test still fails with:
+```
+Runtime(Runtime("Method dispatch not supported for type: record"))
+```
+
+This is a separate issue related to runtime method dispatch for `List.map` and `List.head`, which is outside the scope of this parsing fix.

--- a/rust/VERIFICATION.md
+++ b/rust/VERIFICATION.md
@@ -1,0 +1,165 @@
+# Issue #125 Fix Verification
+
+## Test Results
+
+### 1. All Frontend Tests Pass
+```bash
+cargo test --package fusabi-frontend
+```
+**Result:** 590+ tests passed, 0 failed
+
+### 2. New List Syntax Tests Pass
+```bash
+cargo test --package fusabi-frontend --test list_literal_syntax_tests
+```
+**Result:** 34 tests passed, 0 failed
+
+### 3. Demonstration Tests Pass
+```bash
+cargo test --package fusabi-frontend --test list_syntax_demo
+```
+**Result:** 3 tests passed, 0 failed
+
+## What Now Works
+
+### ✅ Comma-Separated Lists
+```fsharp
+[1, 2, 3]
+["hello", "world"]
+[1.5, 2.5, 3.5]
+[true, false, true]
+```
+
+### ✅ Trailing Commas
+```fsharp
+[1, 2, 3,]
+["a", "b", "c",]
+```
+
+### ✅ Empty Lists
+```fsharp
+[]
+```
+
+### ✅ Nested Lists
+```fsharp
+[[1, 2], [3, 4]]
+[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]
+```
+
+### ✅ Backward Compatibility
+```fsharp
+[1; 2; 3]      // Still works
+[1; 2; 3;]     // Still works
+```
+
+### ✅ Lists with Expressions
+```fsharp
+[1 + 2, 3 * 4, 5 - 1]
+[f 1, g 2, h 3]
+[fun x -> x, fun y -> y + 1]
+```
+
+### ✅ Lists in Context
+```fsharp
+let nums = [1, 2, 3] in nums
+if [1, 2] = [1, 2] then true else false
+f [1, 2, 3]
+1 :: [2, 3]
+```
+
+### ✅ Real-World Example
+The exact syntax from the failing bytecode API test now parses:
+```fsharp
+let list = [1, 2, 3] in
+let doubled = List.map (fun x -> x * 2) list in
+List.head doubled
+```
+
+## Test Samples
+
+### Test: Simple Comma List
+```rust
+#[test]
+fn test_parse_three_element_comma_list() {
+    let expr = parse("[1, 2, 3]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+```
+**Status:** ✅ PASS
+
+### Test: Trailing Comma
+```rust
+#[test]
+fn test_parse_comma_list_with_trailing_comma() {
+    let expr = parse("[1, 2, 3,]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+```
+**Status:** ✅ PASS
+
+### Test: Nested Lists
+```rust
+#[test]
+fn test_parse_nested_lists_comma() {
+    let expr = parse("[[1, 2], [3, 4]]").unwrap();
+    match expr {
+        Expr::List(outer) => {
+            assert_eq!(outer.len(), 2);
+            match &outer[0] {
+                Expr::List(inner) => assert_eq!(inner.len(), 2),
+                _ => panic!("Expected nested List"),
+            }
+        }
+        _ => panic!("Expected List"),
+    }
+}
+```
+**Status:** ✅ PASS
+
+### Test: Backward Compatibility
+```rust
+#[test]
+fn test_parse_semicolon_list() {
+    let expr = parse("[1; 2; 3]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+```
+**Status:** ✅ PASS
+
+### Test: Issue #125 Exact Syntax
+```rust
+#[test]
+fn test_issue_125_comma_syntax() {
+    let source = "let list = [1, 2, 3] in list";
+    match parse(source) {
+        Ok(expr) => {
+            match expr {
+                Expr::Let { name, value, .. } => {
+                    assert_eq!(name, "list");
+                    match *value {
+                        Expr::List(elements) => {
+                            assert_eq!(elements.len(), 3);
+                        }
+                        _ => panic!("Expected List in value"),
+                    }
+                }
+                _ => panic!("Expected Let expression"),
+            }
+        }
+        Err(e) => panic!("Failed to parse: {}", e),
+    }
+}
+```
+**Status:** ✅ PASS
+
+## Summary
+
+The list literal syntax parsing for issue #125 has been **successfully fixed**.
+
+- **Parser Change:** 1 line modified in `parse_list()` function
+- **Backward Compatible:** Yes, all existing tests pass
+- **New Tests Added:** 37 tests (34 + 3 demo tests)
+- **Test Results:** All tests pass (0 failures)
+
+The comma-separated list syntax `[1, 2, 3]` now works correctly alongside the existing semicolon syntax `[1; 2; 3]`.

--- a/rust/crates/fusabi-frontend/tests/list_literal_syntax_tests.rs
+++ b/rust/crates/fusabi-frontend/tests/list_literal_syntax_tests.rs
@@ -1,0 +1,422 @@
+//! Comprehensive tests for list literal syntax with comma separators (Issue #125)
+//!
+//! Tests cover:
+//! - Comma-separated list syntax: [1, 2, 3]
+//! - Backward compatibility with semicolon syntax: [1; 2; 3]
+//! - Trailing commas: [1, 2, 3,]
+//! - Empty lists: []
+//! - Nested lists: [[1, 2], [3, 4]]
+//! - Lists with different element types
+//! - Mixed separators (should work with either)
+
+use fusabi_frontend::ast::{Expr, Literal};
+use fusabi_frontend::lexer::Lexer;
+use fusabi_frontend::parser::Parser;
+
+// Helper to parse source code
+fn parse(input: &str) -> Result<Expr, String> {
+    let mut lexer = Lexer::new(input);
+    let tokens = lexer.tokenize().map_err(|e| format!("{}", e))?;
+    let mut parser = Parser::new(tokens);
+    parser.parse().map_err(|e| format!("{}", e))
+}
+
+// Helper to verify list structure
+fn assert_list_with_elements(expr: Expr, expected_count: usize) {
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(
+                elements.len(),
+                expected_count,
+                "Expected {} elements, got {}",
+                expected_count,
+                elements.len()
+            );
+        }
+        _ => panic!("Expected List, got {:?}", expr),
+    }
+}
+
+// ============================================================================
+// Comma-separated syntax tests
+// ============================================================================
+
+#[test]
+fn test_parse_empty_list() {
+    let expr = parse("[]").unwrap();
+    assert_list_with_elements(expr, 0);
+}
+
+#[test]
+fn test_parse_single_element_comma_list() {
+    let expr = parse("[1]").unwrap();
+    assert_list_with_elements(expr, 1);
+}
+
+#[test]
+fn test_parse_two_element_comma_list() {
+    let expr = parse("[1, 2]").unwrap();
+    assert_list_with_elements(expr, 2);
+}
+
+#[test]
+fn test_parse_three_element_comma_list() {
+    let expr = parse("[1, 2, 3]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_multiple_element_comma_list() {
+    let expr = parse("[1, 2, 3, 4, 5]").unwrap();
+    assert_list_with_elements(expr, 5);
+}
+
+#[test]
+fn test_parse_comma_list_with_trailing_comma() {
+    let expr = parse("[1, 2, 3,]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_single_element_with_trailing_comma() {
+    let expr = parse("[42,]").unwrap();
+    assert_list_with_elements(expr, 1);
+}
+
+// ============================================================================
+// Semicolon syntax tests (backward compatibility)
+// ============================================================================
+
+#[test]
+fn test_parse_semicolon_list() {
+    let expr = parse("[1; 2; 3]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_semicolon_list_with_trailing() {
+    let expr = parse("[1; 2; 3;]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+// ============================================================================
+// Different element types
+// ============================================================================
+
+#[test]
+fn test_parse_string_comma_list() {
+    let expr = parse(r#"["hello", "world"]"#).unwrap();
+    assert_list_with_elements(expr, 2);
+}
+
+#[test]
+fn test_parse_float_comma_list() {
+    let expr = parse("[1.5, 2.5, 3.5]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_bool_comma_list() {
+    let expr = parse("[true, false, true]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_string_list_with_trailing_comma() {
+    let expr = parse(r#"["a", "b", "c",]"#).unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+// ============================================================================
+// Lists with expressions
+// ============================================================================
+
+#[test]
+fn test_parse_list_with_arithmetic_expressions() {
+    let expr = parse("[1 + 2, 3 * 4, 5 - 1]").unwrap();
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(elements.len(), 3);
+            assert!(elements[0].is_binop());
+            assert!(elements[1].is_binop());
+            assert!(elements[2].is_binop());
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+#[test]
+fn test_parse_list_with_variables() {
+    let expr = parse("let x = 1 in let y = 2 in [x, y]").unwrap();
+    match expr {
+        Expr::Let { body, .. } => match *body {
+            Expr::Let { body, .. } => match *body {
+                Expr::List(elements) => {
+                    assert_eq!(elements.len(), 2);
+                }
+                _ => panic!("Expected List in nested let"),
+            },
+            _ => panic!("Expected nested Let"),
+        },
+        _ => panic!("Expected Let expression"),
+    }
+}
+
+#[test]
+fn test_parse_list_with_function_calls() {
+    let expr = parse("[f 1, g 2, h 3]").unwrap();
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(elements.len(), 3);
+            assert!(elements[0].is_app());
+            assert!(elements[1].is_app());
+            assert!(elements[2].is_app());
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+// ============================================================================
+// Nested lists
+// ============================================================================
+
+#[test]
+fn test_parse_nested_empty_lists() {
+    let expr = parse("[[], []]").unwrap();
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(elements.len(), 2);
+            assert!(matches!(elements[0], Expr::List(_)));
+            assert!(matches!(elements[1], Expr::List(_)));
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+#[test]
+fn test_parse_nested_lists_comma() {
+    let expr = parse("[[1, 2], [3, 4]]").unwrap();
+    match expr {
+        Expr::List(outer) => {
+            assert_eq!(outer.len(), 2);
+            match &outer[0] {
+                Expr::List(inner) => assert_eq!(inner.len(), 2),
+                _ => panic!("Expected nested List"),
+            }
+            match &outer[1] {
+                Expr::List(inner) => assert_eq!(inner.len(), 2),
+                _ => panic!("Expected nested List"),
+            }
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+#[test]
+fn test_parse_nested_lists_mixed_separators() {
+    // Outer uses comma, inner uses semicolon
+    let expr = parse("[[1; 2], [3; 4]]").unwrap();
+    match expr {
+        Expr::List(outer) => {
+            assert_eq!(outer.len(), 2);
+            match &outer[0] {
+                Expr::List(inner) => assert_eq!(inner.len(), 2),
+                _ => panic!("Expected nested List"),
+            }
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+#[test]
+fn test_parse_deeply_nested_lists() {
+    let expr = parse("[[[1, 2], [3, 4]], [[5, 6], [7, 8]]]").unwrap();
+    match expr {
+        Expr::List(outer) => {
+            assert_eq!(outer.len(), 2);
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+// ============================================================================
+// Lists in different contexts
+// ============================================================================
+
+#[test]
+fn test_parse_list_in_let_binding() {
+    let expr = parse("let nums = [1, 2, 3] in nums").unwrap();
+    match expr {
+        Expr::Let { value, .. } => match *value {
+            Expr::List(elements) => assert_eq!(elements.len(), 3),
+            _ => panic!("Expected List in let value"),
+        },
+        _ => panic!("Expected Let"),
+    }
+}
+
+#[test]
+fn test_parse_list_in_if_condition() {
+    let expr = parse("if [1, 2] = [1, 2] then true else false").unwrap();
+    match expr {
+        Expr::If { cond, .. } => match *cond {
+            Expr::BinOp { left, right, .. } => {
+                assert!(matches!(*left, Expr::List(_)));
+                assert!(matches!(*right, Expr::List(_)));
+            }
+            _ => panic!("Expected BinOp in if condition"),
+        },
+        _ => panic!("Expected If"),
+    }
+}
+
+#[test]
+fn test_parse_list_as_function_argument() {
+    let expr = parse("f [1, 2, 3]").unwrap();
+    match expr {
+        Expr::App { arg, .. } => match *arg {
+            Expr::List(elements) => assert_eq!(elements.len(), 3),
+            _ => panic!("Expected List as argument"),
+        },
+        _ => panic!("Expected App"),
+    }
+}
+
+// ============================================================================
+// Cons operator with lists
+// ============================================================================
+
+#[test]
+fn test_parse_cons_with_comma_list() {
+    let expr = parse("1 :: [2, 3]").unwrap();
+    match expr {
+        Expr::Cons { head, tail } => {
+            assert!(matches!(*head, Expr::Lit(Literal::Int(1))));
+            match *tail {
+                Expr::List(elements) => assert_eq!(elements.len(), 2),
+                _ => panic!("Expected List in tail"),
+            }
+        }
+        _ => panic!("Expected Cons"),
+    }
+}
+
+#[test]
+fn test_parse_cons_with_empty_list() {
+    let expr = parse("42 :: []").unwrap();
+    match expr {
+        Expr::Cons { tail, .. } => match *tail {
+            Expr::List(elements) => assert_eq!(elements.len(), 0),
+            _ => panic!("Expected empty List"),
+        },
+        _ => panic!("Expected Cons"),
+    }
+}
+
+// ============================================================================
+// Edge cases
+// ============================================================================
+
+#[test]
+fn test_parse_list_with_whitespace() {
+    let expr = parse("[  1  ,  2  ,  3  ]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_list_with_newlines() {
+    let expr = parse("[\n  1,\n  2,\n  3\n]").unwrap();
+    assert_list_with_elements(expr, 3);
+}
+
+#[test]
+fn test_parse_list_single_line() {
+    let expr = parse("[1,2,3,4,5,6,7,8,9,10]").unwrap();
+    assert_list_with_elements(expr, 10);
+}
+
+// ============================================================================
+// Complex expressions in lists
+// ============================================================================
+
+#[test]
+fn test_parse_list_with_tuples() {
+    let expr = parse("[(1, 2), (3, 4)]").unwrap();
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(elements.len(), 2);
+            assert!(matches!(elements[0], Expr::Tuple(_)));
+            assert!(matches!(elements[1], Expr::Tuple(_)));
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+#[test]
+fn test_parse_list_with_lambdas() {
+    let expr = parse("[fun x -> x, fun y -> y + 1]").unwrap();
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(elements.len(), 2);
+            assert!(elements[0].is_lambda());
+            assert!(elements[1].is_lambda());
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+#[test]
+fn test_parse_list_with_nested_expressions() {
+    let expr = parse("[1 + (2 * 3), (4 - 5) * 6]").unwrap();
+    match expr {
+        Expr::List(elements) => {
+            assert_eq!(elements.len(), 2);
+            assert!(elements[0].is_binop());
+            assert!(elements[1].is_binop());
+        }
+        _ => panic!("Expected List"),
+    }
+}
+
+// ============================================================================
+// Real-world usage examples
+// ============================================================================
+
+#[test]
+fn test_bytecode_api_example() {
+    // This is the exact syntax from the failing test
+    let expr = parse("let list = [1, 2, 3] in list").unwrap();
+    match expr {
+        Expr::Let { value, body, .. } => {
+            match *value {
+                Expr::List(elements) => assert_eq!(elements.len(), 3),
+                _ => panic!("Expected List"),
+            }
+            match *body {
+                Expr::Var(name) => assert_eq!(name, "list"),
+                _ => panic!("Expected Var"),
+            }
+        }
+        _ => panic!("Expected Let"),
+    }
+}
+
+#[test]
+fn test_list_with_map_operation() {
+    // Simulating List.map usage
+    let expr = parse("let nums = [1, 2, 3] in List.map (fun x -> x * 2) nums").unwrap();
+    match expr {
+        Expr::Let { value, .. } => match *value {
+            Expr::List(elements) => assert_eq!(elements.len(), 3),
+            _ => panic!("Expected List"),
+        },
+        _ => panic!("Expected Let"),
+    }
+}
+
+#[test]
+fn test_multiple_lists() {
+    let expr = parse("let a = [1, 2] in let b = [3, 4] in [a, b]").unwrap();
+    // Just verify it parses without error
+    assert!(expr.is_let());
+}

--- a/rust/crates/fusabi-frontend/tests/list_syntax_demo.rs
+++ b/rust/crates/fusabi-frontend/tests/list_syntax_demo.rs
@@ -1,0 +1,78 @@
+//! Demonstration that comma-separated list syntax now works (Issue #125)
+
+use fusabi_frontend::ast::Expr;
+use fusabi_frontend::lexer::Lexer;
+use fusabi_frontend::parser::Parser;
+
+fn parse(source: &str) -> Result<Expr, String> {
+    let mut lexer = Lexer::new(source);
+    let tokens = lexer.tokenize().map_err(|e| e.to_string())?;
+    let mut parser = Parser::new(tokens);
+    parser.parse().map_err(|e| e.to_string())
+}
+
+#[test]
+fn test_issue_125_comma_syntax() {
+    // This is the exact syntax from issue #125 that was failing
+    let source = "let list = [1, 2, 3] in list";
+
+    match parse(source) {
+        Ok(expr) => {
+            // Verify it parses correctly
+            match expr {
+                Expr::Let { name, value, .. } => {
+                    assert_eq!(name, "list");
+                    match *value {
+                        Expr::List(elements) => {
+                            assert_eq!(elements.len(), 3);
+                            println!("SUCCESS: Parsed list with {} elements using comma syntax", elements.len());
+                        }
+                        _ => panic!("Expected List in value"),
+                    }
+                }
+                _ => panic!("Expected Let expression"),
+            }
+        }
+        Err(e) => {
+            panic!("Failed to parse: {}", e);
+        }
+    }
+}
+
+#[test]
+fn test_all_supported_list_syntaxes() {
+    let test_cases = vec![
+        ("[1, 2, 3]", 3, "comma-separated"),
+        ("[1, 2, 3,]", 3, "comma with trailing"),
+        ("[1; 2; 3]", 3, "semicolon-separated"),
+        ("[1; 2; 3;]", 3, "semicolon with trailing"),
+        ("[]", 0, "empty list"),
+        ("[[1, 2], [3, 4]]", 2, "nested lists with commas"),
+    ];
+
+    for (source, expected_len, description) in test_cases {
+        match parse(source) {
+            Ok(Expr::List(elements)) => {
+                assert_eq!(elements.len(), expected_len, "Failed for: {}", description);
+                println!("PASS: {} - parsed {} elements", description, expected_len);
+            }
+            Ok(_) => panic!("Expected List for: {}", description),
+            Err(e) => panic!("Failed to parse {}: {}", description, e),
+        }
+    }
+}
+
+#[test]
+fn test_bytecode_api_syntax() {
+    // This is the exact source from the bytecode API test
+    let source = r#"
+        let list = [1, 2, 3] in
+        let doubled = List.map (fun x -> x * 2) list in
+        List.head doubled
+    "#;
+
+    // This should parse without errors now
+    let result = parse(source);
+    assert!(result.is_ok(), "Failed to parse: {:?}", result.err());
+    println!("SUCCESS: Bytecode API test syntax parses correctly");
+}


### PR DESCRIPTION
## Summary

Adds support for F#-style comma-separated list literals, fixing the parsing error for syntax like `[1, 2, 3]`.

## Problem

List literals with comma-separated syntax were failing to parse:
```
Error: UnexpectedToken { expected: "]", found: Comma }
```

## Solution

Modified `parse_list()` in parser.rs to accept both commas and semicolons as separators, providing flexibility and F# compatibility while maintaining backward compatibility.

## Changes Made

### Parser Enhancement
- ✅ Modified `parse_list()` to accept both commas and semicolons
- ✅ Support for trailing commas: `[1, 2, 3,]`
- ✅ Backward compatible with semicolon syntax: `[1; 2; 3]`
- ✅ Works with nested lists: `[[1, 2], [3, 4]]`

### Supported Syntax

```fsharp
let nums = [1, 2, 3]           // Comma-separated ✓
let words = ["a", "b", "c"]    // Works with strings ✓
let trailing = [1, 2, 3,]      // Trailing comma OK ✓
let empty = []                 // Empty lists ✓
let nested = [[1, 2], [3, 4]]  // Nested lists ✓
let semicolon = [1; 2; 3]      // Still works (backward compat) ✓
```

## Test Coverage

**New Tests Added:**
- 34 comprehensive tests in `list_literal_syntax_tests.rs`
- 3 demonstration tests in `list_syntax_demo.rs`

**Test Results:**
- ✅ List syntax tests: 37/37 passed (100%)
- ✅ Frontend tests: 590+ passed
- ✅ Full backward compatibility maintained

## Files Modified

1. `crates/fusabi-frontend/src/parser.rs` - Parser update
2. `crates/fusabi-frontend/tests/list_literal_syntax_tests.rs` - Comprehensive tests (NEW)
3. `crates/fusabi-frontend/tests/list_syntax_demo.rs` - Demo tests (NEW)
4. `ISSUE_125_FIX_SUMMARY.md` - Detailed documentation (NEW)
5. `VERIFICATION.md` - Test verification results (NEW)

## Benefits

- Better F# compatibility
- More intuitive syntax for new users
- Backward compatible with existing code
- Comprehensive test coverage

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)