### PR TITLE
chore: Bump version to v0.13.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.12.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.13.0" }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.12.0"
+version = "0.13.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,6 +15,6 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.12.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.12.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.13.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.13.0", features = ["serde"] }
 colored = "2.1"


### PR DESCRIPTION
## Summary

Bump version to v0.13.0 for release with language improvements.

## Changes in This Release

### Fix: Comma-Separated List Literal Syntax (#125)
- ✅ Added F#-style comma syntax: `[1, 2, 3]`
- ✅ Backward compatible with semicolons: `[1; 2; 3]`
- ✅ Trailing comma support: `[1, 2, 3,]`
- ✅ 37 new tests, all passing

### Fix: Auto-Recursive Function Type Inference (#126)
- ✅ Auto-detect recursive lambdas
- ✅ Type-check recursive functions correctly
- ✅ Better developer experience
- ✅ All type inference tests passing

### Feature: Multi-Line Comment Support (#127)
- ✅ F#-style syntax: `(* comment *)`
- ✅ Nested comment support
- ✅ 13 new tests, all passing
- ✅ Full backward compatibility

## Version Updates

- fusabi: 0.12.0 → 0.13.0
- fusabi-frontend: 0.12.0 → 0.13.0
- fusabi-vm: 0.12.0 → 0.13.0

## Test Results

- All frontend tests pass (590+)
- All new tests pass (87 new tests)
- Full backward compatibility maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)