### PR TITLE
chore: Release v0.14.0 - MCP DSL Foundation

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.13.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.14.0" }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,6 +15,6 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.13.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.13.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.14.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.14.0", features = ["serde"] }
 colored = "2.1"


### PR DESCRIPTION
## Release v0.14.0: MCP DSL Foundation

This PR bumps the version to v0.14.0 and creates the release.

## What's New in v0.14.0

### New Standard Library Modules

#### 1. Json Module
- `Json.parse` - Parse JSON strings to Fusabi values
- `Json.stringify` - Convert Fusabi values to JSON strings
- `Json.stringifyPretty` - Pretty-print JSON with formatting

```fsharp
open Json

let data = Json.parse "{\"name\":\"Alice\",\"age\":30}"
let json = Json.stringifyPretty data
```

#### 2. Net.Osc Module  
- `Osc.client` - Create OSC client with hostname resolution
- `Osc.send` - Send OSC messages
- `Osc.sendInt`, `Osc.sendFloat`, `Osc.sendString` - Send typed OSC messages

```fsharp
open Osc

let ardour = Osc.client "localhost" 3819
ardour |> Osc.send "/transport_play"
ardour |> Osc.sendInt "/set_tempo" 120
```

### Documentation

#### RFD-001: Unified MCP DSL
- Proposes Fusabi as the unified language for MCP servers
- Analysis of current fragmentation (Python, TypeScript, Rust)
- Vision for 75% code reduction and improved maintainability
- Implementation roadmap

### Example Scripts
- `examples/json_demo.fsx` - JSON parsing and serialization examples
- `examples/ardour_osc_control.fsx` - Ardour DAW control via OSC
- `examples/mcp_server_concept.fsx` - Future MCP DSL vision

## Merged PRs
- #132: feat: Add Json standard library module
- #133: feat: Add Net.Osc module for OSC support
- #134: docs: Add RFD-001 and MCP DSL examples

## Version Changes
- fusabi-vm: 0.13.0 → 0.14.0
- fusabi-frontend: 0.13.0 → 0.14.0
- fusabi: 0.13.0 → 0.14.0

## Impact
This release establishes the foundation for Fusabi as a unified language for building MCP servers, with built-in support for JSON (essential for MCP protocol) and network protocols like OSC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)