### PR TITLE
chore: Bump version to v0.15.0 and refactor OSC API

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "fusabi-frontend"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
-description = "Compiler frontend (lexer, parser, AST) for Fusabi scripting language."
+description = "Frontend (lexer, parser, compiler) for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
 license = "MIT"
 
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.14.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.15.0" }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-mcp"
-version = "0.1.0"
+version = "0.15.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) server for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,7 +15,7 @@ name = "fusabi_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.6.0" }
+fusabi = { path = "../fusabi", version = "0.15.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi-vm/src/stdlib/mod.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/mod.rs
@@ -171,9 +171,6 @@ pub fn register_stdlib(vm: &mut Vm) {
         {
             registry.register("Osc.client", net::osc::osc_client);
             registry.register("Osc.send", net::osc::osc_send);
-            registry.register("Osc.sendInt", net::osc::osc_send_int);
-            registry.register("Osc.sendFloat", net::osc::osc_send_float);
-            registry.register("Osc.sendString", net::osc::osc_send_string);
         }
     }
 
@@ -275,10 +272,7 @@ pub fn register_stdlib(vm: &mut Vm) {
     {
         let mut osc_fields = HashMap::new();
         osc_fields.insert("client".to_string(), native("Osc.client", 2));
-        osc_fields.insert("send".to_string(), native("Osc.send", 2));
-        osc_fields.insert("sendInt".to_string(), native("Osc.sendInt", 3));
-        osc_fields.insert("sendFloat".to_string(), native("Osc.sendFloat", 3));
-        osc_fields.insert("sendString".to_string(), native("Osc.sendString", 3));
+        osc_fields.insert("send".to_string(), native("Osc.send", 3));
         vm.globals.insert(
             "Osc".to_string(),
             Value::Record(Rc::new(RefCell::new(osc_fields))),

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,6 +15,12 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.14.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.14.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.15.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.15.0", features = ["serde"] }
 colored = "2.1"
+
+[features]
+default = ["json"]
+serde = ["fusabi-vm/serde"]
+json = ["fusabi-vm/json"]
+osc = ["fusabi-vm/osc"]


### PR DESCRIPTION
## Summary
- Bump all crate versions from 0.14.0 to 0.15.0
- Refactor `Osc.send` to accept a list of arguments instead of type-specific functions
- Deprecate `Osc.sendInt`, `Osc.sendFloat`, and `Osc.sendString`
- Add feature flags to fusabi crate (json, osc, serde)
- Update fusabi-mcp to use fusabi v0.15.0 with json and osc features
- Improve OSC module with generic `value_to_osc_type` converter

## Breaking Changes
The OSC API has been simplified:
- **Before**: `client |> Osc.sendInt "/address" 42`
- **After**: `client |> Osc.send "/address" [42]`

The new `Osc.send` function accepts a list of arguments of any supported type (int, float, string, bool, unit), making it more flexible and idiomatic.

## Test plan
- [ ] Build all crates successfully
- [ ] Verify version numbers are consistent across all Cargo.toml files
- [ ] Test OSC functionality with the new API
- [ ] Ensure backward compatibility concerns are documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)