### PR TITLE
chore: Bump version to v0.16.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Frontend (lexer, parser, compiler) for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.15.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.16.0" }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-mcp"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) server for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,7 +15,7 @@ name = "fusabi_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.15.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.16.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,8 +15,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.15.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.15.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.16.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.16.0", features = ["serde"] }
 colored = "2.1"
 
 [features]


### PR DESCRIPTION
## Summary
Bumps version to v0.16.0 to prepare for release.

## What's Included in This Release

### New Features
- **sprintf/format string formatting** (#137, #141)
  - Added `String.format` with printf-style formatting
  - Added `sprintf` alias for F# compatibility
  - Supports %s, %d, %f, %.Nf, %% specifiers

- **++ operator for string concatenation** (#139, #142)
  - Ergonomic infix operator for string concatenation
  - Example: `"http://" ++ host ++ ":" ++ port`

### Documentation
- **Clarified let bindings support** (#138, #143)
  - Added prominent README section
  - Created comprehensive showcase file
  - Added Language Features checklist

- **Comprehensive stdlib API reference** (#140, #144)
  - Created /docs/stdlib/ documentation
  - 2,132 lines of API reference
  - Documented List, String, Option, Map modules

## Version Changes
- fusabi: 0.15.0 → 0.16.0
- fusabi-vm: 0.15.0 → 0.16.0
- fusabi-frontend: 0.15.0 → 0.16.0
- fusabi-mcp: 0.15.0 → 0.16.0

## Testing
✅ All integration tests passing (41/41)
✅ All library tests passing (except 1 pre-existing gc test issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)