### PR TITLE
feat: Make Engine Send + Sync for async/await integration (fixes #146)

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Frontend (lexer, parser, compiler) for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.16.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.17.0" }

--- a/rust/crates/fusabi-frontend/src/compiler.rs
+++ b/rust/crates/fusabi-frontend/src/compiler.rs
@@ -47,7 +47,7 @@ use fusabi_vm::instruction::Instruction;
 use fusabi_vm::value::Value;
 use std::collections::HashMap;
 use std::fmt;
-use std::rc::Rc;
+use std::sync::Arc;
 
 /// Compilation errors
 #[derive(Debug, Clone, PartialEq)]
@@ -939,7 +939,7 @@ impl Compiler {
         // For now, we don't support upvalue capture in the compiler (Phase 2 extension)
         // We assume no upvalues.
         let closure = Closure::with_arity(lambda_compiler.chunk, 1);
-        let closure_val = Value::Closure(Rc::new(closure));
+        let closure_val = Value::Closure(Arc::new(closure));
 
         // Store prototype in constants
         let const_idx = self.add_constant(closure_val)?;

--- a/rust/crates/fusabi-frontend/src/types.rs
+++ b/rust/crates/fusabi-frontend/src/types.rs
@@ -33,6 +33,7 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 use std::rc::Rc;
+use std::sync::Arc;
 
 /// Type variable identifier.
 ///

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-mcp"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) server for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,7 +15,7 @@ name = "fusabi_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.16.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.17.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -18,6 +18,7 @@ rosc = { version = "0.10", optional = true }
 [dev-dependencies]
 criterion = "0.5"
 fusabi = { path = "../fusabi" }
+fusabi-frontend = { path = "../fusabi-frontend" }
 
 [[bench]]
 name = "simple_bench"

--- a/rust/crates/fusabi-vm/tests/test_method_dispatch.rs
+++ b/rust/crates/fusabi-vm/tests/test_method_dispatch.rs
@@ -38,7 +38,7 @@ fn test_method_dispatch_basic() {
     // Register the increment method
     let mut vm = Vm::new();
     {
-        let mut registry = vm.host_registry.borrow_mut();
+        let mut registry = vm.host_registry.lock().unwrap();
         registry.register_method::<Counter, _>("increment", |_vm, args| {
             // First arg is receiver
             if args.is_empty() {
@@ -115,7 +115,7 @@ fn test_method_dispatch_with_args() {
 
     let mut vm = Vm::new();
     {
-        let mut registry = vm.host_registry.borrow_mut();
+        let mut registry = vm.host_registry.lock().unwrap();
         registry.register_method::<Counter, _>("add", |_vm, args| {
             if args.len() < 2 {
                 return Err(VmError::Runtime("Expected receiver and argument".into()));

--- a/rust/crates/fusabi-vm/tests/test_serialization.rs
+++ b/rust/crates/fusabi-vm/tests/test_serialization.rs
@@ -5,7 +5,7 @@ use fusabi_vm::{
     chunk::Chunk, deserialize_chunk, instruction::Instruction, serialize_chunk, value::Value,
     FZB_MAGIC, FZB_VERSION,
 };
-use std::rc::Rc;
+use std::sync::Arc;
 
 #[test]
 fn test_serialize_deserialize_chunk_simple() {
@@ -35,7 +35,7 @@ fn test_serialize_deserialize_chunk_with_closure_prototype() {
     let closure_prototype = Closure::with_arity(inner_chunk, 1);
 
     let mut chunk = Chunk::new();
-    let const_closure_idx = chunk.add_constant(Value::Closure(Rc::new(closure_prototype)));
+    let const_closure_idx = chunk.add_constant(Value::Closure(Arc::new(closure_prototype)));
     chunk.emit(Instruction::MakeClosure(const_closure_idx, 0)); // 0 upvalues
     chunk.emit(Instruction::Return);
 

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.16.0"
+version = "0.17.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,8 +15,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.16.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.16.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.17.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.17.0", features = ["serde"] }
 colored = "2.1"
 
 [features]

--- a/rust/crates/fusabi/tests/anonymous_records_integration.rs
+++ b/rust/crates/fusabi/tests/anonymous_records_integration.rs
@@ -14,7 +14,7 @@ fn test_empty_anonymous_record() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Record(_)));
     if let Value::Record(rec) = result {
-        assert_eq!(rec.borrow().len(), 0);
+        assert_eq!(rec.lock().unwrap().len(), 0);
     }
 }
 
@@ -24,7 +24,7 @@ fn test_single_field_anonymous_record() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Record(_)));
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 1);
         assert_eq!(
             *borrowed.get("name").unwrap(),
@@ -39,7 +39,7 @@ fn test_multi_field_anonymous_record() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Record(_)));
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 3);
         assert_eq!(
             *borrowed.get("name").unwrap(),
@@ -55,7 +55,7 @@ fn test_anonymous_record_with_computed_fields() {
     let source = r#"{| x = 5 + 3; y = 10 * 2; sum = (5 + 3) + (10 * 2) |}"#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(*borrowed.get("x").unwrap(), Value::Int(8));
         assert_eq!(*borrowed.get("y").unwrap(), Value::Int(20));
         assert_eq!(*borrowed.get("sum").unwrap(), Value::Int(28));
@@ -67,7 +67,7 @@ fn test_anonymous_record_trailing_semicolon() {
     let source = r#"{| x = 1; y = 2; |}"#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 2);
         assert_eq!(*borrowed.get("x").unwrap(), Value::Int(1));
         assert_eq!(*borrowed.get("y").unwrap(), Value::Int(2));
@@ -159,7 +159,7 @@ fn test_nested_anonymous_record_literal() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert!(matches!(borrowed.get("user").unwrap(), Value::Record(_)));
         assert!(matches!(
             borrowed.get("metadata").unwrap(),
@@ -239,7 +239,7 @@ fn test_function_returning_anonymous_record() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(
             *borrowed.get("name").unwrap(),
             Value::Str("Kelly".to_string())
@@ -399,7 +399,7 @@ fn test_anonymous_record_with_string_field_names() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 2);
         assert!(borrowed.contains_key("firstName"));
         assert!(borrowed.contains_key("lastName"));
@@ -450,7 +450,7 @@ fn test_anonymous_record_no_semicolons() {
     let source = r#"{| x = 1 |}"#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 1);
         assert_eq!(*borrowed.get("x").unwrap(), Value::Int(1));
     }
@@ -467,7 +467,7 @@ fn test_anonymous_record_multiline() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 3);
     }
 }
@@ -479,7 +479,7 @@ fn test_anonymous_record_inline_expressions() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(*borrowed.get("result").unwrap(), Value::Int(1));
         assert_eq!(*borrowed.get("flag").unwrap(), Value::Bool(true));
     }

--- a/rust/crates/fusabi/tests/arrays_integration.rs
+++ b/rust/crates/fusabi/tests/arrays_integration.rs
@@ -14,7 +14,7 @@ fn test_empty_array_literal() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Array(_)));
     if let Value::Array(arr) = result {
-        assert_eq!(arr.borrow().len(), 0);
+        assert_eq!(arr.lock().unwrap().len(), 0);
     }
 }
 
@@ -24,7 +24,7 @@ fn test_single_element_array() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Array(_)));
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed.len(), 1);
         assert_eq!(borrowed[0], Value::Int(42));
     }
@@ -36,7 +36,7 @@ fn test_multiple_element_array() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Array(_)));
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed.len(), 5);
         assert_eq!(borrowed[0], Value::Int(1));
         assert_eq!(borrowed[4], Value::Int(5));
@@ -72,7 +72,7 @@ fn test_array_with_different_types() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Array(_)));
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed.len(), 3);
         assert_eq!(borrowed[0], Value::Int(1));
         assert_eq!(borrowed[1], Value::Bool(true));
@@ -92,7 +92,7 @@ fn test_simple_update() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed[0], Value::Int(1));
         assert_eq!(borrowed[1], Value::Int(99));
         assert_eq!(borrowed[2], Value::Int(3));
@@ -111,7 +111,7 @@ fn test_multiple_updates() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed[0], Value::Int(10));
         assert_eq!(borrowed[2], Value::Int(30));
     } else {
@@ -127,7 +127,7 @@ fn test_chained_updates() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed[0], Value::Int(10));
         assert_eq!(borrowed[1], Value::Int(20));
         assert_eq!(borrowed[2], Value::Int(30));
@@ -158,7 +158,7 @@ fn test_update_with_expressions() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(arr) = result {
-        let borrowed = arr.borrow();
+        let borrowed = arr.lock().unwrap();
         assert_eq!(borrowed[1], Value::Int(100));
     } else {
         panic!("Expected array");
@@ -186,11 +186,11 @@ fn test_array_of_arrays() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(outer) = result {
-        let borrowed = outer.borrow();
+        let borrowed = outer.lock().unwrap();
         assert_eq!(borrowed.len(), 3);
 
         if let Value::Array(first_row) = &borrowed[0] {
-            let first_borrowed = first_row.borrow();
+            let first_borrowed = first_row.lock().unwrap();
             assert_eq!(first_borrowed[0], Value::Int(1));
             assert_eq!(first_borrowed[1], Value::Int(2));
         } else {
@@ -219,9 +219,9 @@ fn test_update_nested_array() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(outer) = result {
-        let borrowed = outer.borrow();
+        let borrowed = outer.lock().unwrap();
         if let Value::Array(first_row) = &borrowed[0] {
-            let first_borrowed = first_row.borrow();
+            let first_borrowed = first_row.lock().unwrap();
             assert_eq!(first_borrowed[0], Value::Int(99));
             assert_eq!(first_borrowed[1], Value::Int(88));
         } else {
@@ -249,12 +249,12 @@ fn test_empty_nested_arrays() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Array(outer) = result {
-        let borrowed = outer.borrow();
+        let borrowed = outer.lock().unwrap();
         assert_eq!(borrowed.len(), 3);
 
         for elem in borrowed.iter() {
             if let Value::Array(inner) = elem {
-                assert_eq!(inner.borrow().len(), 0);
+                assert_eq!(inner.lock().unwrap().len(), 0);
             } else {
                 panic!("Expected nested array");
             }

--- a/rust/crates/fusabi/tests/records_integration.rs
+++ b/rust/crates/fusabi/tests/records_integration.rs
@@ -14,7 +14,7 @@ fn test_empty_record() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Record(_)));
     if let Value::Record(rec) = result {
-        assert_eq!(rec.borrow().len(), 0);
+        assert_eq!(rec.lock().unwrap().len(), 0);
     }
 }
 
@@ -24,7 +24,7 @@ fn test_single_field_record() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Record(_)));
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 1);
         assert_eq!(
             *borrowed.get("name").unwrap(),
@@ -39,7 +39,7 @@ fn test_multi_field_record() {
     let result = run_source(source).unwrap();
     assert!(matches!(result, Value::Record(_)));
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 3);
         assert_eq!(
             *borrowed.get("name").unwrap(),
@@ -55,7 +55,7 @@ fn test_record_with_computed_fields() {
     let source = r#"{ x = 5 + 3; y = 10 * 2; sum = (5 + 3) + (10 * 2) }"#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(*borrowed.get("x").unwrap(), Value::Int(8));
         assert_eq!(*borrowed.get("y").unwrap(), Value::Int(20));
         assert_eq!(*borrowed.get("sum").unwrap(), Value::Int(28));
@@ -147,7 +147,7 @@ fn test_nested_record_literal() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert!(matches!(borrowed.get("user").unwrap(), Value::Record(_)));
         assert!(matches!(
             borrowed.get("metadata").unwrap(),
@@ -192,7 +192,7 @@ fn test_function_returning_record() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(
             *borrowed.get("name").unwrap(),
             Value::Str("Kelly".to_string())
@@ -421,7 +421,7 @@ fn test_record_with_string_field_names() {
     "#;
     let result = run_source(source).unwrap();
     if let Value::Record(rec) = result {
-        let borrowed = rec.borrow();
+        let borrowed = rec.lock().unwrap();
         assert_eq!(borrowed.len(), 2);
         assert!(borrowed.contains_key("firstName"));
         assert!(borrowed.contains_key("lastName"));

--- a/rust/crates/fusabi/tests/send_sync_tests.rs
+++ b/rust/crates/fusabi/tests/send_sync_tests.rs
@@ -1,0 +1,47 @@
+// Tests to verify that Engine and related types implement Send + Sync
+// This addresses issue #146: Make Engine Send + Sync for async/await integration
+
+use fusabi::Engine;
+
+#[test]
+fn test_engine_is_send() {
+    fn assert_send<T: Send>() {}
+    assert_send::<Engine>();
+}
+
+#[test]
+fn test_engine_is_sync() {
+    fn assert_sync<T: Sync>() {}
+    assert_sync::<Engine>();
+}
+
+#[test]
+fn test_engine_works_with_tokio_spawn() {
+    // This test verifies that Engine can be used with tokio::spawn
+    // which requires Send + 'static
+
+    // Create a simple async runtime test without actually using Tokio
+    // to avoid adding a dependency just for tests
+    fn requires_send_sync<T: Send + Sync>(_: T) {}
+
+    let engine = Engine::new();
+    requires_send_sync(engine);
+}
+
+#[test]
+fn test_engine_can_be_shared_across_threads() {
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+
+    let engine = Arc::new(Mutex::new(Engine::new()));
+    let engine_clone = engine.clone();
+
+    let handle = thread::spawn(move || {
+        // Engine should be usable in another thread
+        let eng = engine_clone.lock().unwrap();
+        // Check that stdlib functions are registered
+        assert!(eng.host_function_names().len() > 0);
+    });
+
+    handle.join().unwrap();
+}


### PR DESCRIPTION
## Summary  
This PR implements thread-safe types across the Fusabi VM to enable `Engine` to be `Send + Sync`, allowing it to be used with async/await and multi-threaded applications.

Fixes #146

## Changes

### Core VM Changes
- Replaced `Rc<RefCell<T>>` with `Arc<Mutex<T>>` throughout the VM
- Updated `Value::Array`, `Value::Record`, and `Value::Map` to use `Arc<Mutex<>>`
- Changed `Closure::upvalues` to use `Arc<Mutex<Upvalue>>`
- Updated `Vm::host_registry` to use `Arc<Mutex<HostRegistry>>`
- Modified `HostData` to require `Send` bound and use `Arc<Mutex<dyn Any + Send>>`

### HostData API Changes  
- Introduced `LockedHostData` and `LockedHostDataMut` wrapper types
- These provide `Deref`/`DerefMut` access to locked host data  
- Updated `try_borrow` and `try_borrow_mut` to return these wrappers
- Maintains same ergonomic API while ensuring thread safety

### Test Updates
- Replaced all `.borrow()` and `.borrow_mut()` calls with `.lock().unwrap()`
- Added comprehensive Send + Sync trait tests in `rust/crates/fusabi/tests/send_sync_tests.rs`
- Tests verify Engine can be shared across threads safely
- All existing integration tests pass with Arc/Mutex changes

### Version Bump
- Bumped version to v0.17.0 across all crates
- This is a breaking change due to HostData API modifications
- `create_host_data` now requires `T: Send`

## Testing
- ✅ All library tests pass
- ✅ All integration tests pass (arrays, records, anonymous records, etc.)
- ✅ New Send/Sync tests verify thread-safety guarantees
- ✅ Engine can now be used with `tokio::spawn` and other async runtimes

## Test plan
- [x] Run `just test` to ensure all tests pass
- [x] Verify Send + Sync trait tests pass
- [x] Check that Engine can be wrapped in Arc and shared across threads
- [x] Confirm no regressions in existing functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)