### PR TITLE
feat: Add Array module and higher-order functions to stdlib

### DIFF
--- a/examples/stdlib_demo.fsx
+++ b/examples/stdlib_demo.fsx
@@ -1,5 +1,5 @@
 // FSRS Standard Library Demonstration
-// This file shows how to use the built-in List, String, and Option modules
+// This file shows how to use the built-in List, String, Array, Map, and Option modules
 
 // ========== List Operations ==========
 
@@ -29,6 +29,54 @@ let combined = List.append numbers moreNumbers in  // [1; 2; 3; 4; 5; 6; 7; 8]
 // Concatenate a list of lists
 let listOfLists = [[1; 2]; [3; 4]; [5]] in
 let flattened = List.concat listOfLists in  // [1; 2; 3; 4; 5]
+
+// Map a function over a list
+let doubled = List.map (fun x -> x * 2) numbers in  // [2; 4; 6; 8; 10]
+
+// Filter elements based on a predicate
+let evens = List.filter (fun x -> x % 2 = 0) numbers in  // [2; 4]
+
+// Fold (reduce) a list to a single value
+let sum = List.fold (fun acc x -> acc + x) 0 numbers in  // 15
+
+// Check if any element satisfies a predicate
+let hasEven = List.exists (fun x -> x % 2 = 0) numbers in  // true
+
+// Find the first element matching a predicate
+let firstEven = List.find (fun x -> x % 2 = 0) numbers in  // 2
+
+// Safely find (returns Option)
+let maybeEven = List.tryFind (fun x -> x > 10) numbers in  // None
+
+// Iterate over a list for side effects
+let _ = List.iter (fun x -> x) numbers in  // Returns unit
+
+
+// ========== Array Operations ==========
+
+// Create arrays from lists
+let arr = Array.ofList [1; 2; 3; 4; 5] in
+
+// Get array length
+let arrLen = Array.length arr in  // 5
+
+// Check if array is empty
+let arrEmpty = Array.isEmpty arr in  // false
+
+// Get element by index (0-based)
+let third = Array.get 2 arr in  // 3
+
+// Set element by index (mutates in place)
+let _ = Array.set 0 100 arr in  // arr[0] is now 100
+
+// Create array filled with a value
+let zeros = Array.create 5 0 in  // [|0; 0; 0; 0; 0|]
+
+// Create array using initializer function
+let squares = Array.init 5 (fun i -> i * i) in  // [|0; 1; 4; 9; 16|]
+
+// Convert array back to list
+let arrList = Array.toList squares in  // [0; 1; 4; 9; 16]
 
 
 // ========== String Operations ==========
@@ -60,19 +108,36 @@ let startsHello = String.startsWith "hello" text in  // true
 let endsWorld = String.endsWith "world" text in    // true
 
 
+// ========== Map Operations ==========
+
+// Create an empty map
+let emptyMap = Map.empty () in
+
+// Add entries to a map
+let myMap = Map.add "name" "Alice" (Map.add "city" "NYC" emptyMap) in
+
+// Find a value by key
+let name = Map.find "name" myMap in  // "Alice"
+
+// Safely find (returns Option)
+let maybeName = Map.tryFind "age" myMap in  // None
+
+// Check if key exists
+let hasName = Map.containsKey "name" myMap in  // true
+
+// Get map size
+let mapSize = Map.count myMap in  // 2
+
+// Transform all values in a map
+let upperMap = Map.map String.toUpper myMap in
+
+// Iterate over map entries
+let _ = Map.iter (fun k v -> ()) myMap in  // Returns unit
+
+
 // ========== Option Operations ==========
 
-// Option type definition syntax is not yet stable or fully supported for generics.
-// Using explicit constructors for now.
-// For type-safe Option handling, it's recommended to register Option.Some and Option.None
-// as host functions, or use built-in VM variants where appropriate.
-
-// Create option values (assuming Some/None are in scope or registered as variant constructors)
-// The compiler/VM already supports Discriminated Unions and their variants.
-// If not defined here, 'Some' and 'None' need to be defined as variants of a type.
-// Example: type MyOption = Some of any | None
-// Or rely on host-defined variant constructors.
-// For this demo, we'll assume Some and None are available as variant constructors.
+// Create option values
 let someValue = Some(42) in
 let noValue = None in
 
@@ -84,6 +149,15 @@ let isNone = Option.isNone noValue in     // true
 let value = Option.defaultValue 0 someValue in  // 42
 let defaulted = Option.defaultValue 0 noValue in  // 0
 
+// Map over options
+let doubledOpt = Option.map (fun x -> x * 2) someValue in  // Some(84)
+
+// Bind (flatMap) options
+let bound = Option.bind (fun x -> Some(x + 1)) someValue in  // Some(43)
+
+// Iterate over option for side effects
+let _ = Option.iter (fun x -> ()) someValue in  // Returns unit
+
 
 // ========== Real-World Examples ==========
 
@@ -91,17 +165,19 @@ let defaulted = Option.defaultValue 0 noValue in  // 0
 let csvData = "name,age,city" in
 let fields = String.split "," csvData in
 let fieldCount = List.length fields in  // 3
-let upperFields = List.map String.toUpper fields in  // Not implemented yet
+let upperFields = List.map String.toUpper fields in  // ["NAME"; "AGE"; "CITY"]
 
 // Example 2: Safe string processing with options
 let maybeName = Some("Alice") in
 let defaultName = Option.defaultValue "Unknown" maybeName in
 let greeting = String.concat ["Hello, "; defaultName; "!"] in
 
-// Example 3: List transformations
+// Example 3: List transformations with higher-order functions
 let data = [1; 2; 3; 4; 5] in
-let reversed = List.reverse data in
-let doubled = List.map (fun x -> x * 2) data in  // Not implemented yet
+let processed = data
+    |> List.filter (fun x -> x > 2)
+    |> List.map (fun x -> x * 2)
+    |> List.fold (fun acc x -> acc + x) 0 in  // 24 (sum of [6; 8; 10])
 
 // Example 4: String cleaning pipeline
 let rawInput = "  HELLO WORLD  " in
@@ -109,21 +185,14 @@ let cleaned = rawInput
     |> String.trim
     |> String.toLower in  // "hello world"
 
-// Example 5: Combining list and string operations
+// Example 5: Array manipulation
+let arr = Array.init 10 (fun i -> i + 1) in  // [|1; 2; 3; ...; 10|]
+let _ = Array.set 0 999 arr in  // Mutate first element
+let firstElem = Array.get 0 arr in  // 999
+
+// Example 6: Combining list and string operations
 let paths = ["/home"; "/user"; "/docs"] in
 let fullPath = String.concat (List.append paths ["/file.txt"]) in
 // Result: "/home/user/docs/file.txt"
 
-
-// ========== Notes ==========
-
-// The following higher-order functions are referenced but not yet implemented:
-// - List.map : ('a -> 'b) -> 'a list -> 'b list
-// - List.filter : ('a -> bool) -> 'a list -> 'a list
-// - List.fold : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a
-// - Option.map : ('a -> 'b) -> 'a option -> 'b option
-// - Option.bind : ('a -> 'b option) -> 'a option -> 'b option
-
-// These will be added in future iterations when closures and
-// first-class functions are fully integrated with the VM.
 fullPath // Return the last calculated value to be printed by the CLI

--- a/rust/crates/fusabi-vm/src/stdlib/array.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/array.rs
@@ -1,0 +1,542 @@
+// Fusabi Array Standard Library
+// Provides operations for mutable arrays
+
+use crate::value::Value;
+use crate::vm::{Vm, VmError};
+use std::sync::{Arc, Mutex};
+
+/// Array.length : 'a array -> int
+/// Returns the number of elements in the array
+pub fn array_length(arr: &Value) -> Result<Value, VmError> {
+    match arr {
+        Value::Array(vec) => {
+            let vec = vec.lock().unwrap();
+            Ok(Value::Int(vec.len() as i64))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "array",
+            got: arr.type_name(),
+        }),
+    }
+}
+
+/// Array.isEmpty : 'a array -> bool
+/// Returns true if the array is empty
+pub fn array_is_empty(arr: &Value) -> Result<Value, VmError> {
+    match arr {
+        Value::Array(vec) => {
+            let vec = vec.lock().unwrap();
+            Ok(Value::Bool(vec.is_empty()))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "array",
+            got: arr.type_name(),
+        }),
+    }
+}
+
+/// Array.get : int -> 'a array -> 'a
+/// Safe array indexing - throws error if index is out of bounds
+pub fn array_get(index: &Value, arr: &Value) -> Result<Value, VmError> {
+    let idx = index.as_int().ok_or_else(|| VmError::TypeMismatch {
+        expected: "int",
+        got: index.type_name(),
+    })?;
+
+    match arr {
+        Value::Array(vec) => {
+            let vec = vec.lock().unwrap();
+
+            if idx < 0 {
+                return Err(VmError::Runtime(format!(
+                    "Array index out of bounds: index {} is negative",
+                    idx
+                )));
+            }
+
+            let idx_usize = idx as usize;
+            if idx_usize >= vec.len() {
+                return Err(VmError::Runtime(format!(
+                    "Array index out of bounds: index {} >= length {}",
+                    idx, vec.len()
+                )));
+            }
+
+            Ok(vec[idx_usize].clone())
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "array",
+            got: arr.type_name(),
+        }),
+    }
+}
+
+/// Array.set : int -> 'a -> 'a array -> unit
+/// Mutates array in place by setting the element at the given index
+/// Throws error if index is out of bounds
+pub fn array_set(index: &Value, value: &Value, arr: &Value) -> Result<Value, VmError> {
+    let idx = index.as_int().ok_or_else(|| VmError::TypeMismatch {
+        expected: "int",
+        got: index.type_name(),
+    })?;
+
+    match arr {
+        Value::Array(vec) => {
+            let mut vec = vec.lock().unwrap();
+
+            if idx < 0 {
+                return Err(VmError::Runtime(format!(
+                    "Array index out of bounds: index {} is negative",
+                    idx
+                )));
+            }
+
+            let idx_usize = idx as usize;
+            if idx_usize >= vec.len() {
+                return Err(VmError::Runtime(format!(
+                    "Array index out of bounds: index {} >= length {}",
+                    idx, vec.len()
+                )));
+            }
+
+            vec[idx_usize] = value.clone();
+            Ok(Value::Unit)
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "array",
+            got: arr.type_name(),
+        }),
+    }
+}
+
+/// Array.ofList : 'a list -> 'a array
+/// Converts a cons list to an array
+pub fn array_of_list(list: &Value) -> Result<Value, VmError> {
+    let vec = list.list_to_vec().ok_or_else(|| VmError::TypeMismatch {
+        expected: "list",
+        got: list.type_name(),
+    })?;
+
+    Ok(Value::Array(Arc::new(Mutex::new(vec))))
+}
+
+/// Array.toList : 'a array -> 'a list
+/// Converts an array to a cons list
+pub fn array_to_list(arr: &Value) -> Result<Value, VmError> {
+    match arr {
+        Value::Array(vec) => {
+            let vec = vec.lock().unwrap();
+            Ok(Value::vec_to_cons(vec.clone()))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "array",
+            got: arr.type_name(),
+        }),
+    }
+}
+
+/// Array.init : int -> (int -> 'a) -> 'a array
+/// Creates an array of given length by calling the function for each index
+/// Takes (length: int, fn: int -> 'a) and creates array by calling fn for each index from 0 to length-1
+pub fn array_init(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Array.init expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let length = args[0].as_int().ok_or_else(|| VmError::TypeMismatch {
+        expected: "int",
+        got: args[0].type_name(),
+    })?;
+
+    if length < 0 {
+        return Err(VmError::Runtime(format!(
+            "Array.init requires non-negative length, got {}",
+            length
+        )));
+    }
+
+    let func = &args[1];
+    let mut result = Vec::new();
+
+    for i in 0..length {
+        let value = vm.call_value(func.clone(), &[Value::Int(i)])?;
+        result.push(value);
+    }
+
+    Ok(Value::Array(Arc::new(Mutex::new(result))))
+}
+
+/// Array.create : int -> 'a -> 'a array
+/// Creates an array of given length filled with the specified value
+pub fn array_create(length: &Value, value: &Value) -> Result<Value, VmError> {
+    let len = length.as_int().ok_or_else(|| VmError::TypeMismatch {
+        expected: "int",
+        got: length.type_name(),
+    })?;
+
+    if len < 0 {
+        return Err(VmError::Runtime(format!(
+            "Array.create requires non-negative length, got {}",
+            len
+        )));
+    }
+
+    let vec = vec![value.clone(); len as usize];
+    Ok(Value::Array(Arc::new(Mutex::new(vec))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_array(elements: Vec<Value>) -> Value {
+        Value::Array(Arc::new(Mutex::new(elements)))
+    }
+
+    #[test]
+    fn test_array_length_empty() {
+        let arr = make_array(vec![]);
+        let result = array_length(&arr).unwrap();
+        assert_eq!(result, Value::Int(0));
+    }
+
+    #[test]
+    fn test_array_length_single() {
+        let arr = make_array(vec![Value::Int(42)]);
+        let result = array_length(&arr).unwrap();
+        assert_eq!(result, Value::Int(1));
+    }
+
+    #[test]
+    fn test_array_length_multiple() {
+        let arr = make_array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let result = array_length(&arr).unwrap();
+        assert_eq!(result, Value::Int(3));
+    }
+
+    #[test]
+    fn test_array_length_type_error() {
+        let not_array = Value::Int(42);
+        let result = array_length(&not_array);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_is_empty_true() {
+        let arr = make_array(vec![]);
+        let result = array_is_empty(&arr).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn test_array_is_empty_false() {
+        let arr = make_array(vec![Value::Int(1)]);
+        let result = array_is_empty(&arr).unwrap();
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[test]
+    fn test_array_is_empty_type_error() {
+        let not_array = Value::Str("hello".to_string());
+        let result = array_is_empty(&not_array);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_get_success() {
+        let arr = make_array(vec![Value::Int(10), Value::Int(20), Value::Int(30)]);
+
+        let result = array_get(&Value::Int(0), &arr).unwrap();
+        assert_eq!(result, Value::Int(10));
+
+        let result = array_get(&Value::Int(1), &arr).unwrap();
+        assert_eq!(result, Value::Int(20));
+
+        let result = array_get(&Value::Int(2), &arr).unwrap();
+        assert_eq!(result, Value::Int(30));
+    }
+
+    #[test]
+    fn test_array_get_out_of_bounds() {
+        let arr = make_array(vec![Value::Int(10), Value::Int(20)]);
+
+        let result = array_get(&Value::Int(2), &arr);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+
+        let result = array_get(&Value::Int(100), &arr);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_get_negative_index() {
+        let arr = make_array(vec![Value::Int(10), Value::Int(20)]);
+        let result = array_get(&Value::Int(-1), &arr);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_get_type_errors() {
+        let arr = make_array(vec![Value::Int(10)]);
+
+        // Non-int index
+        let result = array_get(&Value::Str("0".to_string()), &arr);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+
+        // Non-array value
+        let result = array_get(&Value::Int(0), &Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_set_success() {
+        let arr = make_array(vec![Value::Int(10), Value::Int(20), Value::Int(30)]);
+
+        let result = array_set(&Value::Int(1), &Value::Int(100), &arr);
+        assert_eq!(result.unwrap(), Value::Unit);
+
+        // Verify the value was changed
+        let value = array_get(&Value::Int(1), &arr).unwrap();
+        assert_eq!(value, Value::Int(100));
+
+        // Verify other values unchanged
+        let value = array_get(&Value::Int(0), &arr).unwrap();
+        assert_eq!(value, Value::Int(10));
+        let value = array_get(&Value::Int(2), &arr).unwrap();
+        assert_eq!(value, Value::Int(30));
+    }
+
+    #[test]
+    fn test_array_set_out_of_bounds() {
+        let arr = make_array(vec![Value::Int(10), Value::Int(20)]);
+
+        let result = array_set(&Value::Int(2), &Value::Int(100), &arr);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+
+        let result = array_set(&Value::Int(100), &Value::Int(100), &arr);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_set_negative_index() {
+        let arr = make_array(vec![Value::Int(10), Value::Int(20)]);
+        let result = array_set(&Value::Int(-1), &Value::Int(100), &arr);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_set_type_errors() {
+        let arr = make_array(vec![Value::Int(10)]);
+
+        // Non-int index
+        let result = array_set(&Value::Str("0".to_string()), &Value::Int(100), &arr);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+
+        // Non-array value
+        let result = array_set(&Value::Int(0), &Value::Int(100), &Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_of_list_empty() {
+        let list = Value::Nil;
+        let result = array_of_list(&list).unwrap();
+
+        let length = array_length(&result).unwrap();
+        assert_eq!(length, Value::Int(0));
+    }
+
+    #[test]
+    fn test_array_of_list_single() {
+        let list = Value::vec_to_cons(vec![Value::Int(42)]);
+        let result = array_of_list(&list).unwrap();
+
+        let length = array_length(&result).unwrap();
+        assert_eq!(length, Value::Int(1));
+
+        let value = array_get(&Value::Int(0), &result).unwrap();
+        assert_eq!(value, Value::Int(42));
+    }
+
+    #[test]
+    fn test_array_of_list_multiple() {
+        let list = Value::vec_to_cons(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let result = array_of_list(&list).unwrap();
+
+        let length = array_length(&result).unwrap();
+        assert_eq!(length, Value::Int(3));
+
+        assert_eq!(array_get(&Value::Int(0), &result).unwrap(), Value::Int(1));
+        assert_eq!(array_get(&Value::Int(1), &result).unwrap(), Value::Int(2));
+        assert_eq!(array_get(&Value::Int(2), &result).unwrap(), Value::Int(3));
+    }
+
+    #[test]
+    fn test_array_of_list_type_error() {
+        let not_list = Value::Int(42);
+        let result = array_of_list(&not_list);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_to_list_empty() {
+        let arr = make_array(vec![]);
+        let result = array_to_list(&arr).unwrap();
+        assert_eq!(result, Value::Nil);
+    }
+
+    #[test]
+    fn test_array_to_list_single() {
+        let arr = make_array(vec![Value::Int(42)]);
+        let result = array_to_list(&arr).unwrap();
+
+        let expected = Value::vec_to_cons(vec![Value::Int(42)]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_array_to_list_multiple() {
+        let arr = make_array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let result = array_to_list(&arr).unwrap();
+
+        let expected = Value::vec_to_cons(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_array_to_list_type_error() {
+        let not_array = Value::Str("hello".to_string());
+        let result = array_to_list(&not_array);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_to_list_round_trip() {
+        let original = Value::vec_to_cons(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+        let arr = array_of_list(&original).unwrap();
+        let result = array_to_list(&arr).unwrap();
+        assert_eq!(result, original);
+    }
+
+    #[test]
+    fn test_array_create_empty() {
+        let arr = array_create(&Value::Int(0), &Value::Int(42)).unwrap();
+        let length = array_length(&arr).unwrap();
+        assert_eq!(length, Value::Int(0));
+    }
+
+    #[test]
+    fn test_array_create_single() {
+        let arr = array_create(&Value::Int(1), &Value::Int(42)).unwrap();
+        let length = array_length(&arr).unwrap();
+        assert_eq!(length, Value::Int(1));
+
+        let value = array_get(&Value::Int(0), &arr).unwrap();
+        assert_eq!(value, Value::Int(42));
+    }
+
+    #[test]
+    fn test_array_create_multiple() {
+        let arr = array_create(&Value::Int(5), &Value::Str("hello".to_string())).unwrap();
+        let length = array_length(&arr).unwrap();
+        assert_eq!(length, Value::Int(5));
+
+        for i in 0..5 {
+            let value = array_get(&Value::Int(i), &arr).unwrap();
+            assert_eq!(value, Value::Str("hello".to_string()));
+        }
+    }
+
+    #[test]
+    fn test_array_create_negative_length() {
+        let result = array_create(&Value::Int(-1), &Value::Int(42));
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_create_type_error() {
+        let result = array_create(&Value::Str("5".to_string()), &Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_init_empty() {
+        use crate::chunk::ChunkBuilder;
+        let mut vm = Vm::new();
+        let chunk = ChunkBuilder::new().build();
+        let func = Value::Closure(Arc::new(crate::closure::Closure::new(chunk)));
+
+        let result = array_init(&mut vm, &[Value::Int(0), func]);
+        assert!(result.is_ok());
+
+        let arr = result.unwrap();
+        let length = array_length(&arr).unwrap();
+        assert_eq!(length, Value::Int(0));
+    }
+
+    #[test]
+    fn test_array_init_negative_length() {
+        use crate::chunk::ChunkBuilder;
+        let mut vm = Vm::new();
+        let chunk = ChunkBuilder::new().build();
+        let func = Value::Closure(Arc::new(crate::closure::Closure::new(chunk)));
+
+        let result = array_init(&mut vm, &[Value::Int(-1), func]);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_init_wrong_arg_count() {
+        let mut vm = Vm::new();
+
+        let result = array_init(&mut vm, &[Value::Int(5)]);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+
+        let result = array_init(&mut vm, &[]);
+        assert!(matches!(result, Err(VmError::Runtime(_))));
+    }
+
+    #[test]
+    fn test_array_init_type_error() {
+        use crate::chunk::ChunkBuilder;
+        let mut vm = Vm::new();
+        let chunk = ChunkBuilder::new().build();
+        let func = Value::Closure(Arc::new(crate::closure::Closure::new(chunk)));
+
+        let result = array_init(&mut vm, &[Value::Str("5".to_string()), func]);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_array_mutation() {
+        let arr = make_array(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+
+        // Mutate the array
+        array_set(&Value::Int(0), &Value::Int(10), &arr).unwrap();
+        array_set(&Value::Int(1), &Value::Int(20), &arr).unwrap();
+        array_set(&Value::Int(2), &Value::Int(30), &arr).unwrap();
+
+        // Verify all mutations
+        assert_eq!(array_get(&Value::Int(0), &arr).unwrap(), Value::Int(10));
+        assert_eq!(array_get(&Value::Int(1), &arr).unwrap(), Value::Int(20));
+        assert_eq!(array_get(&Value::Int(2), &arr).unwrap(), Value::Int(30));
+    }
+
+    #[test]
+    fn test_array_mixed_types() {
+        let arr = make_array(vec![
+            Value::Int(42),
+            Value::Str("hello".to_string()),
+            Value::Bool(true),
+            Value::Unit,
+        ]);
+
+        assert_eq!(array_length(&arr).unwrap(), Value::Int(4));
+        assert_eq!(array_get(&Value::Int(0), &arr).unwrap(), Value::Int(42));
+        assert_eq!(array_get(&Value::Int(1), &arr).unwrap(), Value::Str("hello".to_string()));
+        assert_eq!(array_get(&Value::Int(2), &arr).unwrap(), Value::Bool(true));
+        assert_eq!(array_get(&Value::Int(3), &arr).unwrap(), Value::Unit);
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/mod.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/mod.rs
@@ -1,6 +1,7 @@
 // Fusabi Standard Library
-// Provides built-in functions for List, String, Map, and Option operations
+// Provides built-in functions for List, String, Map, Array, and Option operations
 
+pub mod array;
 pub mod list;
 pub mod map;
 pub mod option;
@@ -43,6 +44,36 @@ pub fn register_stdlib(vm: &mut Vm) {
             wrap_unary(args, list::list_concat)
         });
         registry.register("List.map", list::list_map);
+        registry.register("List.iter", list::list_iter);
+        registry.register("List.filter", list::list_filter);
+        registry.register("List.fold", list::list_fold);
+        registry.register("List.exists", list::list_exists);
+        registry.register("List.find", list::list_find);
+        registry.register("List.tryFind", list::list_try_find);
+
+        // Array functions
+        registry.register("Array.length", |_vm, args| {
+            wrap_unary(args, array::array_length)
+        });
+        registry.register("Array.isEmpty", |_vm, args| {
+            wrap_unary(args, array::array_is_empty)
+        });
+        registry.register("Array.get", |_vm, args| {
+            wrap_binary(args, array::array_get)
+        });
+        registry.register("Array.set", |_vm, args| {
+            wrap_ternary(args, array::array_set)
+        });
+        registry.register("Array.ofList", |_vm, args| {
+            wrap_unary(args, array::array_of_list)
+        });
+        registry.register("Array.toList", |_vm, args| {
+            wrap_unary(args, array::array_to_list)
+        });
+        registry.register("Array.init", array::array_init);
+        registry.register("Array.create", |_vm, args| {
+            wrap_binary(args, array::array_create)
+        });
 
         // String functions
         registry.register("String.length", |_vm, args| {
@@ -110,6 +141,8 @@ pub fn register_stdlib(vm: &mut Vm) {
         registry.register("Map.toList", |_vm, args| {
             wrap_unary(args, map::map_to_list)
         });
+        registry.register("Map.map", map::map_map);
+        registry.register("Map.iter", map::map_iter);
 
         // Option functions
         registry.register("Option.isSome", |_vm, args| {
@@ -199,6 +232,12 @@ pub fn register_stdlib(vm: &mut Vm) {
     list_fields.insert("append".to_string(), native("List.append", 2));
     list_fields.insert("concat".to_string(), native("List.concat", 1));
     list_fields.insert("map".to_string(), native("List.map", 2));
+    list_fields.insert("iter".to_string(), native("List.iter", 2));
+    list_fields.insert("filter".to_string(), native("List.filter", 2));
+    list_fields.insert("fold".to_string(), native("List.fold", 3));
+    list_fields.insert("exists".to_string(), native("List.exists", 2));
+    list_fields.insert("find".to_string(), native("List.find", 2));
+    list_fields.insert("tryFind".to_string(), native("List.tryFind", 2));
     vm.globals.insert(
         "List".to_string(),
         Value::Record(Arc::new(Mutex::new(list_fields))),
@@ -224,6 +263,21 @@ pub fn register_stdlib(vm: &mut Vm) {
     // Register sprintf as a global alias for String.format
     vm.globals.insert("sprintf".to_string(), native("sprintf", 2));
 
+    // Array Module
+    let mut array_fields = HashMap::new();
+    array_fields.insert("length".to_string(), native("Array.length", 1));
+    array_fields.insert("isEmpty".to_string(), native("Array.isEmpty", 1));
+    array_fields.insert("get".to_string(), native("Array.get", 2));
+    array_fields.insert("set".to_string(), native("Array.set", 3));
+    array_fields.insert("ofList".to_string(), native("Array.ofList", 1));
+    array_fields.insert("toList".to_string(), native("Array.toList", 1));
+    array_fields.insert("init".to_string(), native("Array.init", 2));
+    array_fields.insert("create".to_string(), native("Array.create", 2));
+    vm.globals.insert(
+        "Array".to_string(),
+        Value::Record(Arc::new(Mutex::new(array_fields))),
+    );
+
     // Map Module
     let mut map_fields = HashMap::new();
     map_fields.insert("empty".to_string(), native("Map.empty", 1));
@@ -236,6 +290,8 @@ pub fn register_stdlib(vm: &mut Vm) {
     map_fields.insert("count".to_string(), native("Map.count", 1));
     map_fields.insert("ofList".to_string(), native("Map.ofList", 1));
     map_fields.insert("toList".to_string(), native("Map.toList", 1));
+    map_fields.insert("map".to_string(), native("Map.map", 2));
+    map_fields.insert("iter".to_string(), native("Map.iter", 2));
     vm.globals.insert(
         "Map".to_string(),
         Value::Record(Arc::new(Mutex::new(map_fields))),


### PR DESCRIPTION
## Summary

- Add complete Array module with 8 core functions (length, isEmpty, get, set, ofList, toList, init, create)
- Add higher-order functions to List module (iter, filter, fold, exists, find, tryFind)
- Add higher-order functions to Map module (map, iter)

## Changes

| File | Change |
|------|--------|
| `rust/crates/fusabi-vm/src/stdlib/array.rs` | **New** - Complete Array module implementation |
| `rust/crates/fusabi-vm/src/stdlib/mod.rs` | Register Array + Map HOFs |
| `rust/crates/fusabi-vm/src/stdlib/list.rs` | Add 6 HOFs |
| `rust/crates/fusabi-vm/src/stdlib/map.rs` | Add 2 HOFs |
| `examples/stdlib_demo.fsx` | Update demo |

## Test plan

- [x] All 35+ new Array tests pass
- [x] All new List HOF tests pass
- [x] All new Map HOF tests pass
- [x] 520/521 tests passing (1 pre-existing failure unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)