### PR TITLE
chore: Bump version to v0.18.0

### DIFF
--- a/docs/audits/gemini-2025-12-02-stdlib-audit-v2/01-verification-report.md
+++ b/docs/audits/gemini-2025-12-02-stdlib-audit-v2/01-verification-report.md
@@ -1,0 +1,25 @@
+# Verification Report: "Claude's Iteration"
+
+**Date**: 2025-12-02
+**Auditor**: Gemini Agent
+**Status**: ❌ FAILED / NO CHANGES DETECTED
+
+## Executive Summary
+The user reported that "Claude has iterated" on previous feedback. However, a filesystem audit reveals **no implementation changes** corresponding to the requested features. The codebase appears to be in the exact same state as the previous audit.
+
+## Detailed Findings
+
+### 1. Array Module - ❌ MISSING
+- **Expectation**: Existence of `rust/crates/fusabi-vm/src/stdlib/array.rs` and registration in `mod.rs`.
+- **Reality**: File does not exist. No references in `mod.rs`.
+
+### 2. List Module - ⚠️ UNCHANGED
+- **Expectation**: Addition of `list_filter`, `list_fold`, `list_iter`.
+- **Reality**: File contains only previously existing functions (`map`, `length`, `head`, etc.). No new HOFs.
+
+### 3. Documentation/Examples - ⚠️ OUTDATED
+- **Expectation**: `examples/stdlib_demo.fsx` updated to remove false "Not implemented yet" claims about `List.map`.
+- **Reality**: The file is unchanged and still incorrectly claims `List.map` is unimplemented, despite `list_map` existing in the Rust code.
+
+## Conclusion
+It appears the implementation phase did not occur or failed to persist to disk. The roadmap remains effectively identical to the previous iteration.

--- a/docs/audits/gemini-2025-12-02-stdlib-audit-v2/02-roadmap.md
+++ b/docs/audits/gemini-2025-12-02-stdlib-audit-v2/02-roadmap.md
@@ -1,0 +1,58 @@
+# Fusabi Standard Library Roadmap (v2)
+
+**Date**: 2025-12-02
+**Status**: Pending Implementation
+
+## Phase 1: The Array Foundation (CRITICAL)
+The language has syntax for arrays (`[| |]`) but no standard library support. This is the highest priority gap.
+
+### 1.1 Create `stdlib/array.rs`
+Implement the following native functions. Use `Value::Array` (which is `Arc<Mutex<Vec<Value>>>`) for storage.
+- `Array.length : 'a array -> int`
+- `Array.isEmpty : 'a array -> bool`
+- `Array.get : int -> 'a array -> 'a` (Safe indexing, throws if OOB)
+- `Array.set : int -> 'a -> 'a array -> unit` (Mutable update in place? Or copy? *Note: Language spec says `<-` creates new array, but `set` func usually implies mutation. Stick to F# semantics: `Array.set` mutates.*)
+- `Array.ofList : 'a list -> 'a array`
+- `Array.toList : 'a array -> 'a list`
+- `Array.init : int -> (int -> 'a) -> 'a array` (Requires `vm.call_value`)
+- `Array.create : int -> 'a -> 'a array`
+
+### 1.2 Register Array Module
+Update `stdlib/mod.rs`:
+- Add `pub mod array;`
+- In `register_stdlib`, add `Array` record to `vm.globals`.
+- Register all functions in `HostRegistry`.
+
+## Phase 2: Higher-Order Functions (HOF) Completeness
+Leverage `vm.call_value` to complete the functional programming toolkit.
+
+### 2.1 List Module Expansion
+Update `stdlib/list.rs`:
+- `List.iter : ('a -> unit) -> 'a list -> unit`
+- `List.filter : ('a -> bool) -> 'a list -> 'a list`
+- `List.fold : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a`
+- `List.exists : ('a -> bool) -> 'a list -> bool`
+- `List.find : ('a -> bool) -> 'a list -> 'a` (Throw error if not found)
+- `List.tryFind : ('a -> bool) -> 'a list -> 'a option`
+
+### 2.2 Map Module Expansion
+Update `stdlib/map.rs`:
+- `Map.map : ('a -> 'b) -> 'k map -> 'b map`
+- `Map.iter : ('k -> 'v -> unit) -> 'k map -> unit`
+
+## Phase 3: Cleanup & Polish
+
+### 3.1 Global Functions
+In `stdlib/mod.rs`:
+- Ensure `print` and `printfn` are registered in the global scope (not just as part of a module).
+
+### 3.2 Documentation & Examples
+- Update `examples/stdlib_demo.fsx`:
+  - Remove false "unimplemented" comments.
+  - Add examples for new Array and List functions.
+- Generate updated `docs/stdlib-summary.md`.
+
+## Instructions for Developer/Agent
+1.  **Start with Phase 1**. Create `array.rs`. This is a new file and won't conflict with existing code.
+2.  **Proceed to Phase 2**. Add the missing functions to `list.rs`.
+3.  **Verify**. Run `cargo test` in `fusabi-vm`.

--- a/docs/audits/gemini-2025-12-02-stdlib-audit-v2/SUMMARY.md
+++ b/docs/audits/gemini-2025-12-02-stdlib-audit-v2/SUMMARY.md
@@ -1,0 +1,18 @@
+# Audit V2 Summary
+
+**Date**: 2025-12-02
+**Status**: **Failed** (No changes detected)
+
+## Findings
+The implementation work scheduled from the previous audit was **not performed**. 
+- `array.rs` is missing.
+- `list.rs` is unchanged.
+- Documentation is stale.
+
+## Next Steps
+Please instruct the agent/developer to strictly follow the **Roadmap v2** (`docs/audits/gemini-2025-12-02-stdlib-audit-v2/02-roadmap.md`). 
+
+**Immediate Action Required:**
+1.  Implement `Array` module.
+2.  Implement `List.filter`, `List.fold`.
+3.  Fix `stdlib_demo.fsx`.

--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Frontend (lexer, parser, compiler) for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.17.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.18.0" }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-mcp"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) server for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,7 +15,7 @@ name = "fusabi_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.17.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.18.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,8 +15,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.17.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.17.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.18.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.18.0", features = ["serde"] }
 colored = "2.1"
 
 [features]


### PR DESCRIPTION
## Summary

- Bump version to v0.18.0
- Include audit docs from gemini-2025-12-02-stdlib-audit-v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)