### PR TITLE
chore: Bump version to v0.19.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Frontend (lexer, parser, compiler) for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.18.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.19.0" }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-mcp"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) server for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,7 +15,7 @@ name = "fusabi_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.18.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.19.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,8 +15,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.18.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.18.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.19.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.19.0", features = ["serde"] }
 colored = "2.1"
 
 [features]


### PR DESCRIPTION
## Summary
- Bump version from v0.18.0 to v0.19.0

## Test plan
- [x] `cargo check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)