### PR TITLE
feat: Add Math, Result modules and print functions (v0.20.0)

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-frontend"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Frontend (lexer, parser, compiler) for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -10,4 +10,4 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.19.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.20.0" }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-mcp"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "Model Context Protocol (MCP) server for Fusabi scripting language"
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,7 +15,7 @@ name = "fusabi_mcp"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.19.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.20.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "High-performance bytecode VM for Fusabi scripting language."
 repository = "https://github.com/fusabi-lang/fusabi"

--- a/rust/crates/fusabi-vm/src/stdlib/math.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/math.rs
@@ -1,0 +1,635 @@
+// Fusabi Math Standard Library
+// Provides mathematical constants and functions
+
+use crate::value::Value;
+use crate::vm::VmError;
+
+// ============================================================================
+// Mathematical Constants (as functions taking unit)
+// ============================================================================
+
+/// Math.pi : unit -> float
+/// Returns the mathematical constant π (pi)
+pub fn math_pi(_unit: &Value) -> Result<Value, VmError> {
+    Ok(Value::Float(std::f64::consts::PI))
+}
+
+/// Math.e : unit -> float
+/// Returns the mathematical constant e (Euler's number)
+pub fn math_e(_unit: &Value) -> Result<Value, VmError> {
+    Ok(Value::Float(std::f64::consts::E))
+}
+
+// ============================================================================
+// Basic Math Functions
+// ============================================================================
+
+/// Math.abs : int -> int
+/// Math.abs : float -> float
+/// Returns the absolute value of a number
+pub fn math_abs(n: &Value) -> Result<Value, VmError> {
+    match n {
+        Value::Int(i) => Ok(Value::Int(i.abs())),
+        Value::Float(f) => Ok(Value::Float(f.abs())),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: n.type_name(),
+        }),
+    }
+}
+
+/// Math.sqrt : float -> float
+/// Returns the square root of a number
+pub fn math_sqrt(n: &Value) -> Result<Value, VmError> {
+    match n {
+        Value::Float(f) => {
+            if *f < 0.0 {
+                Err(VmError::Runtime(
+                    "Cannot compute square root of negative number".to_string(),
+                ))
+            } else {
+                Ok(Value::Float(f.sqrt()))
+            }
+        }
+        Value::Int(i) => {
+            let f = *i as f64;
+            if f < 0.0 {
+                Err(VmError::Runtime(
+                    "Cannot compute square root of negative number".to_string(),
+                ))
+            } else {
+                Ok(Value::Float(f.sqrt()))
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: n.type_name(),
+        }),
+    }
+}
+
+/// Math.pow : float -> float -> float
+/// Returns base raised to the power of exponent
+pub fn math_pow(base: &Value, exponent: &Value) -> Result<Value, VmError> {
+    let base_f = match base {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: base.type_name(),
+            })
+        }
+    };
+
+    let exp_f = match exponent {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: exponent.type_name(),
+            })
+        }
+    };
+
+    Ok(Value::Float(base_f.powf(exp_f)))
+}
+
+/// Math.max : int -> int -> int
+/// Math.max : float -> float -> float
+/// Returns the maximum of two values
+pub fn math_max(a: &Value, b: &Value) -> Result<Value, VmError> {
+    match (a, b) {
+        (Value::Int(x), Value::Int(y)) => Ok(Value::Int((*x).max(*y))),
+        (Value::Float(x), Value::Float(y)) => Ok(Value::Float(x.max(*y))),
+        (Value::Int(x), Value::Float(y)) => Ok(Value::Float((*x as f64).max(*y))),
+        (Value::Float(x), Value::Int(y)) => Ok(Value::Float(x.max(*y as f64))),
+        _ => Err(VmError::Runtime(format!(
+            "Math.max expects int or float, got {} and {}",
+            a.type_name(),
+            b.type_name()
+        ))),
+    }
+}
+
+/// Math.min : int -> int -> int
+/// Math.min : float -> float -> float
+/// Returns the minimum of two values
+pub fn math_min(a: &Value, b: &Value) -> Result<Value, VmError> {
+    match (a, b) {
+        (Value::Int(x), Value::Int(y)) => Ok(Value::Int((*x).min(*y))),
+        (Value::Float(x), Value::Float(y)) => Ok(Value::Float(x.min(*y))),
+        (Value::Int(x), Value::Float(y)) => Ok(Value::Float((*x as f64).min(*y))),
+        (Value::Float(x), Value::Int(y)) => Ok(Value::Float(x.min(*y as f64))),
+        _ => Err(VmError::Runtime(format!(
+            "Math.min expects int or float, got {} and {}",
+            a.type_name(),
+            b.type_name()
+        ))),
+    }
+}
+
+// ============================================================================
+// Trigonometric Functions (radians)
+// ============================================================================
+
+/// Math.sin : float -> float
+/// Returns the sine of an angle in radians
+pub fn math_sin(angle: &Value) -> Result<Value, VmError> {
+    match angle {
+        Value::Float(f) => Ok(Value::Float(f.sin())),
+        Value::Int(i) => Ok(Value::Float((*i as f64).sin())),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: angle.type_name(),
+        }),
+    }
+}
+
+/// Math.cos : float -> float
+/// Returns the cosine of an angle in radians
+pub fn math_cos(angle: &Value) -> Result<Value, VmError> {
+    match angle {
+        Value::Float(f) => Ok(Value::Float(f.cos())),
+        Value::Int(i) => Ok(Value::Float((*i as f64).cos())),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: angle.type_name(),
+        }),
+    }
+}
+
+/// Math.tan : float -> float
+/// Returns the tangent of an angle in radians
+pub fn math_tan(angle: &Value) -> Result<Value, VmError> {
+    match angle {
+        Value::Float(f) => Ok(Value::Float(f.tan())),
+        Value::Int(i) => Ok(Value::Float((*i as f64).tan())),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: angle.type_name(),
+        }),
+    }
+}
+
+/// Math.asin : float -> float
+/// Returns the arcsine (inverse sine) of a value, result in radians
+pub fn math_asin(x: &Value) -> Result<Value, VmError> {
+    let f = match x {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: x.type_name(),
+            })
+        }
+    };
+
+    if f < -1.0 || f > 1.0 {
+        return Err(VmError::Runtime(
+            "asin argument must be in range [-1, 1]".to_string(),
+        ));
+    }
+
+    Ok(Value::Float(f.asin()))
+}
+
+/// Math.acos : float -> float
+/// Returns the arccosine (inverse cosine) of a value, result in radians
+pub fn math_acos(x: &Value) -> Result<Value, VmError> {
+    let f = match x {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: x.type_name(),
+            })
+        }
+    };
+
+    if f < -1.0 || f > 1.0 {
+        return Err(VmError::Runtime(
+            "acos argument must be in range [-1, 1]".to_string(),
+        ));
+    }
+
+    Ok(Value::Float(f.acos()))
+}
+
+/// Math.atan : float -> float
+/// Returns the arctangent (inverse tangent) of a value, result in radians
+pub fn math_atan(x: &Value) -> Result<Value, VmError> {
+    match x {
+        Value::Float(f) => Ok(Value::Float(f.atan())),
+        Value::Int(i) => Ok(Value::Float((*i as f64).atan())),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: x.type_name(),
+        }),
+    }
+}
+
+/// Math.atan2 : float -> float -> float
+/// Returns the arctangent of y/x in radians, using the signs to determine the quadrant
+pub fn math_atan2(y: &Value, x: &Value) -> Result<Value, VmError> {
+    let y_f = match y {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: y.type_name(),
+            })
+        }
+    };
+
+    let x_f = match x {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: x.type_name(),
+            })
+        }
+    };
+
+    Ok(Value::Float(y_f.atan2(x_f)))
+}
+
+// ============================================================================
+// Logarithmic and Exponential Functions
+// ============================================================================
+
+/// Math.log : float -> float
+/// Returns the natural logarithm (base e) of a number
+pub fn math_log(x: &Value) -> Result<Value, VmError> {
+    let f = match x {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: x.type_name(),
+            })
+        }
+    };
+
+    if f <= 0.0 {
+        return Err(VmError::Runtime(
+            "log argument must be positive".to_string(),
+        ));
+    }
+
+    Ok(Value::Float(f.ln()))
+}
+
+/// Math.log10 : float -> float
+/// Returns the base-10 logarithm of a number
+pub fn math_log10(x: &Value) -> Result<Value, VmError> {
+    let f = match x {
+        Value::Float(f) => *f,
+        Value::Int(i) => *i as f64,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int or float",
+                got: x.type_name(),
+            })
+        }
+    };
+
+    if f <= 0.0 {
+        return Err(VmError::Runtime(
+            "log10 argument must be positive".to_string(),
+        ));
+    }
+
+    Ok(Value::Float(f.log10()))
+}
+
+/// Math.exp : float -> float
+/// Returns e raised to the power of x
+pub fn math_exp(x: &Value) -> Result<Value, VmError> {
+    match x {
+        Value::Float(f) => Ok(Value::Float(f.exp())),
+        Value::Int(i) => Ok(Value::Float((*i as f64).exp())),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: x.type_name(),
+        }),
+    }
+}
+
+// ============================================================================
+// Rounding Functions
+// ============================================================================
+
+/// Math.floor : float -> float
+/// Returns the largest integer less than or equal to the number
+pub fn math_floor(x: &Value) -> Result<Value, VmError> {
+    match x {
+        Value::Float(f) => Ok(Value::Float(f.floor())),
+        Value::Int(i) => Ok(Value::Float(*i as f64)),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: x.type_name(),
+        }),
+    }
+}
+
+/// Math.ceil : float -> float
+/// Returns the smallest integer greater than or equal to the number
+pub fn math_ceil(x: &Value) -> Result<Value, VmError> {
+    match x {
+        Value::Float(f) => Ok(Value::Float(f.ceil())),
+        Value::Int(i) => Ok(Value::Float(*i as f64)),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: x.type_name(),
+        }),
+    }
+}
+
+/// Math.round : float -> float
+/// Returns the nearest integer, rounding half-way cases away from 0.0
+pub fn math_round(x: &Value) -> Result<Value, VmError> {
+    match x {
+        Value::Float(f) => Ok(Value::Float(f.round())),
+        Value::Int(i) => Ok(Value::Float(*i as f64)),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: x.type_name(),
+        }),
+    }
+}
+
+/// Math.truncate : float -> float
+/// Returns the integer part of a number, removing any fractional digits
+pub fn math_truncate(x: &Value) -> Result<Value, VmError> {
+    match x {
+        Value::Float(f) => Ok(Value::Float(f.trunc())),
+        Value::Int(i) => Ok(Value::Float(*i as f64)),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int or float",
+            got: x.type_name(),
+        }),
+    }
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Helper for float comparison with tolerance
+    fn assert_float_eq(a: f64, b: f64, epsilon: f64) {
+        assert!((a - b).abs() < epsilon, "{} != {}", a, b);
+    }
+
+    #[test]
+    fn test_math_pi() {
+        let result = math_pi(&Value::Unit).unwrap();
+        match result {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::PI, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_e() {
+        let result = math_e(&Value::Unit).unwrap();
+        match result {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::E, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_abs_int() {
+        assert_eq!(math_abs(&Value::Int(-5)).unwrap(), Value::Int(5));
+        assert_eq!(math_abs(&Value::Int(5)).unwrap(), Value::Int(5));
+        assert_eq!(math_abs(&Value::Int(0)).unwrap(), Value::Int(0));
+    }
+
+    #[test]
+    fn test_math_abs_float() {
+        assert_eq!(math_abs(&Value::Float(-3.14)).unwrap(), Value::Float(3.14));
+        assert_eq!(math_abs(&Value::Float(3.14)).unwrap(), Value::Float(3.14));
+    }
+
+    #[test]
+    fn test_math_sqrt() {
+        match math_sqrt(&Value::Float(9.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 3.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_sqrt(&Value::Int(16)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 4.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        assert!(math_sqrt(&Value::Float(-1.0)).is_err());
+    }
+
+    #[test]
+    fn test_math_pow() {
+        match math_pow(&Value::Float(2.0), &Value::Float(3.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 8.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_pow(&Value::Int(2), &Value::Int(10)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 1024.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_max() {
+        assert_eq!(math_max(&Value::Int(5), &Value::Int(3)).unwrap(), Value::Int(5));
+        assert_eq!(
+            math_max(&Value::Float(3.14), &Value::Float(2.71)).unwrap(),
+            Value::Float(3.14)
+        );
+        assert_eq!(
+            math_max(&Value::Int(5), &Value::Float(3.14)).unwrap(),
+            Value::Float(5.0)
+        );
+    }
+
+    #[test]
+    fn test_math_min() {
+        assert_eq!(math_min(&Value::Int(5), &Value::Int(3)).unwrap(), Value::Int(3));
+        assert_eq!(
+            math_min(&Value::Float(3.14), &Value::Float(2.71)).unwrap(),
+            Value::Float(2.71)
+        );
+        assert_eq!(
+            math_min(&Value::Int(5), &Value::Float(3.14)).unwrap(),
+            Value::Float(3.14)
+        );
+    }
+
+    #[test]
+    fn test_math_sin() {
+        match math_sin(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 0.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_sin(&Value::Float(std::f64::consts::PI / 2.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 1.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_cos() {
+        match math_cos(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 1.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_cos(&Value::Float(std::f64::consts::PI)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, -1.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_tan() {
+        match math_tan(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 0.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_tan(&Value::Float(std::f64::consts::PI / 4.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 1.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_asin() {
+        match math_asin(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 0.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_asin(&Value::Float(1.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::PI / 2.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        assert!(math_asin(&Value::Float(1.5)).is_err());
+    }
+
+    #[test]
+    fn test_math_acos() {
+        match math_acos(&Value::Float(1.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 0.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_acos(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::PI / 2.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        assert!(math_acos(&Value::Float(1.5)).is_err());
+    }
+
+    #[test]
+    fn test_math_atan() {
+        match math_atan(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 0.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_atan(&Value::Float(1.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::PI / 4.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_atan2() {
+        match math_atan2(&Value::Float(0.0), &Value::Float(1.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 0.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_atan2(&Value::Float(1.0), &Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::PI / 2.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_log() {
+        match math_log(&Value::Float(std::f64::consts::E)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 1.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        assert!(math_log(&Value::Float(0.0)).is_err());
+        assert!(math_log(&Value::Float(-1.0)).is_err());
+    }
+
+    #[test]
+    fn test_math_log10() {
+        match math_log10(&Value::Float(100.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 2.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_log10(&Value::Int(1000)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 3.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        assert!(math_log10(&Value::Float(0.0)).is_err());
+    }
+
+    #[test]
+    fn test_math_exp() {
+        match math_exp(&Value::Float(0.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, 1.0, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+        match math_exp(&Value::Float(1.0)).unwrap() {
+            Value::Float(f) => assert_float_eq(f, std::f64::consts::E, 1e-10),
+            _ => panic!("Expected Float"),
+        }
+    }
+
+    #[test]
+    fn test_math_floor() {
+        assert_eq!(math_floor(&Value::Float(3.7)).unwrap(), Value::Float(3.0));
+        assert_eq!(math_floor(&Value::Float(-3.7)).unwrap(), Value::Float(-4.0));
+        assert_eq!(math_floor(&Value::Int(5)).unwrap(), Value::Float(5.0));
+    }
+
+    #[test]
+    fn test_math_ceil() {
+        assert_eq!(math_ceil(&Value::Float(3.2)).unwrap(), Value::Float(4.0));
+        assert_eq!(math_ceil(&Value::Float(-3.2)).unwrap(), Value::Float(-3.0));
+        assert_eq!(math_ceil(&Value::Int(5)).unwrap(), Value::Float(5.0));
+    }
+
+    #[test]
+    fn test_math_round() {
+        assert_eq!(math_round(&Value::Float(3.4)).unwrap(), Value::Float(3.0));
+        assert_eq!(math_round(&Value::Float(3.5)).unwrap(), Value::Float(4.0));
+        assert_eq!(math_round(&Value::Float(-3.5)).unwrap(), Value::Float(-4.0));
+    }
+
+    #[test]
+    fn test_math_truncate() {
+        assert_eq!(math_truncate(&Value::Float(3.7)).unwrap(), Value::Float(3.0));
+        assert_eq!(math_truncate(&Value::Float(-3.7)).unwrap(), Value::Float(-3.0));
+        assert_eq!(math_truncate(&Value::Int(5)).unwrap(), Value::Float(5.0));
+    }
+
+    #[test]
+    fn test_type_errors() {
+        let not_number = Value::Str("hello".to_string());
+        assert!(math_abs(&not_number).is_err());
+        assert!(math_sqrt(&not_number).is_err());
+        assert!(math_sin(&not_number).is_err());
+        assert!(math_log(&not_number).is_err());
+        assert!(math_floor(&not_number).is_err());
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/mod.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/mod.rs
@@ -5,6 +5,9 @@ pub mod array;
 pub mod list;
 pub mod map;
 pub mod option;
+pub mod math;
+pub mod result;
+pub mod print;
 pub mod string;
 
 #[cfg(feature = "json")]
@@ -110,6 +113,79 @@ pub fn register_stdlib(vm: &mut Vm) {
             wrap_binary(args, string::string_format)
         });
 
+        // Print functions (global functions, not in a module)
+        registry.register("print", |_vm, args| {
+            wrap_unary(args, print::print_value)
+        });
+        registry.register("printfn", |_vm, args| {
+            wrap_unary(args, print::printfn_value)
+        });
+
+        // Math functions
+        registry.register("Math.pi", |_vm, args| {
+            wrap_unary(args, math::math_pi)
+        });
+        registry.register("Math.e", |_vm, args| {
+            wrap_unary(args, math::math_e)
+        });
+        registry.register("Math.abs", |_vm, args| {
+            wrap_unary(args, math::math_abs)
+        });
+        registry.register("Math.sqrt", |_vm, args| {
+            wrap_unary(args, math::math_sqrt)
+        });
+        registry.register("Math.pow", |_vm, args| {
+            wrap_binary(args, math::math_pow)
+        });
+        registry.register("Math.max", |_vm, args| {
+            wrap_binary(args, math::math_max)
+        });
+        registry.register("Math.min", |_vm, args| {
+            wrap_binary(args, math::math_min)
+        });
+        registry.register("Math.sin", |_vm, args| {
+            wrap_unary(args, math::math_sin)
+        });
+        registry.register("Math.cos", |_vm, args| {
+            wrap_unary(args, math::math_cos)
+        });
+        registry.register("Math.tan", |_vm, args| {
+            wrap_unary(args, math::math_tan)
+        });
+        registry.register("Math.asin", |_vm, args| {
+            wrap_unary(args, math::math_asin)
+        });
+        registry.register("Math.acos", |_vm, args| {
+            wrap_unary(args, math::math_acos)
+        });
+        registry.register("Math.atan", |_vm, args| {
+            wrap_unary(args, math::math_atan)
+        });
+        registry.register("Math.atan2", |_vm, args| {
+            wrap_binary(args, math::math_atan2)
+        });
+        registry.register("Math.log", |_vm, args| {
+            wrap_unary(args, math::math_log)
+        });
+        registry.register("Math.log10", |_vm, args| {
+            wrap_unary(args, math::math_log10)
+        });
+        registry.register("Math.exp", |_vm, args| {
+            wrap_unary(args, math::math_exp)
+        });
+        registry.register("Math.floor", |_vm, args| {
+            wrap_unary(args, math::math_floor)
+        });
+        registry.register("Math.ceil", |_vm, args| {
+            wrap_unary(args, math::math_ceil)
+        });
+        registry.register("Math.round", |_vm, args| {
+            wrap_unary(args, math::math_round)
+        });
+        registry.register("Math.truncate", |_vm, args| {
+            wrap_unary(args, math::math_truncate)
+        });
+
         // Map functions
         registry.register("Map.empty", |_vm, args| {
             wrap_unary(args, map::map_empty)
@@ -191,6 +267,50 @@ pub fn register_stdlib(vm: &mut Vm) {
             })
         });
 
+        // Result functions
+        registry.register("Result.isOk", |_vm, args| {
+            wrap_unary(args, result::result_is_ok)
+        });
+        registry.register("Result.isError", |_vm, args| {
+            wrap_unary(args, result::result_is_error)
+        });
+        registry.register("Result.defaultValue", |_vm, args| {
+            wrap_binary(args, result::result_default_value)
+        });
+        registry.register("Result.defaultWith", result::result_default_with);
+        registry.register("Result.map", result::result_map);
+        registry.register("Result.mapError", result::result_map_error);
+        registry.register("Result.bind", result::result_bind);
+        registry.register("Result.iter", result::result_iter);
+
+        // Result constructors - Ok and Error
+        registry.register("Ok", |_vm, args| {
+            if args.len() != 1 {
+                return Err(VmError::Runtime(format!(
+                    "Ok expects 1 argument, got {}",
+                    args.len()
+                )));
+            }
+            Ok(Value::Variant {
+                type_name: "Result".to_string(),
+                variant_name: "Ok".to_string(),
+                fields: vec![args[0].clone()],
+            })
+        });
+        registry.register("Error", |_vm, args| {
+            if args.len() != 1 {
+                return Err(VmError::Runtime(format!(
+                    "Error expects 1 argument, got {}",
+                    args.len()
+                )));
+            }
+            Ok(Value::Variant {
+                type_name: "Result".to_string(),
+                variant_name: "Error".to_string(),
+                fields: vec![args[0].clone()],
+            })
+        });
+
         // Json functions (if json feature is enabled)
         #[cfg(feature = "json")]
         {
@@ -263,6 +383,38 @@ pub fn register_stdlib(vm: &mut Vm) {
     // Register sprintf as a global alias for String.format
     vm.globals.insert("sprintf".to_string(), native("sprintf", 2));
 
+    // Register print functions as globals
+    vm.globals.insert("print".to_string(), native("print", 1));
+    vm.globals.insert("printfn".to_string(), native("printfn", 1));
+
+    // Math Module
+    let mut math_fields = HashMap::new();
+    math_fields.insert("pi".to_string(), native("Math.pi", 1));
+    math_fields.insert("e".to_string(), native("Math.e", 1));
+    math_fields.insert("abs".to_string(), native("Math.abs", 1));
+    math_fields.insert("sqrt".to_string(), native("Math.sqrt", 1));
+    math_fields.insert("pow".to_string(), native("Math.pow", 2));
+    math_fields.insert("max".to_string(), native("Math.max", 2));
+    math_fields.insert("min".to_string(), native("Math.min", 2));
+    math_fields.insert("sin".to_string(), native("Math.sin", 1));
+    math_fields.insert("cos".to_string(), native("Math.cos", 1));
+    math_fields.insert("tan".to_string(), native("Math.tan", 1));
+    math_fields.insert("asin".to_string(), native("Math.asin", 1));
+    math_fields.insert("acos".to_string(), native("Math.acos", 1));
+    math_fields.insert("atan".to_string(), native("Math.atan", 1));
+    math_fields.insert("atan2".to_string(), native("Math.atan2", 2));
+    math_fields.insert("log".to_string(), native("Math.log", 1));
+    math_fields.insert("log10".to_string(), native("Math.log10", 1));
+    math_fields.insert("exp".to_string(), native("Math.exp", 1));
+    math_fields.insert("floor".to_string(), native("Math.floor", 1));
+    math_fields.insert("ceil".to_string(), native("Math.ceil", 1));
+    math_fields.insert("round".to_string(), native("Math.round", 1));
+    math_fields.insert("truncate".to_string(), native("Math.truncate", 1));
+    vm.globals.insert(
+        "Math".to_string(),
+        Value::Record(Arc::new(Mutex::new(math_fields))),
+    );
+
     // Array Module
     let mut array_fields = HashMap::new();
     array_fields.insert("length".to_string(), native("Array.length", 1));
@@ -316,6 +468,25 @@ pub fn register_stdlib(vm: &mut Vm) {
     // Register Option constructors as globals
     vm.globals.insert("Some".to_string(), native("Some", 1));
     vm.globals.insert("None".to_string(), native("None", 0));
+
+    // Result Module
+    let mut result_fields = HashMap::new();
+    result_fields.insert("isOk".to_string(), native("Result.isOk", 1));
+    result_fields.insert("isError".to_string(), native("Result.isError", 1));
+    result_fields.insert("defaultValue".to_string(), native("Result.defaultValue", 2));
+    result_fields.insert("defaultWith".to_string(), native("Result.defaultWith", 2));
+    result_fields.insert("map".to_string(), native("Result.map", 2));
+    result_fields.insert("mapError".to_string(), native("Result.mapError", 2));
+    result_fields.insert("bind".to_string(), native("Result.bind", 2));
+    result_fields.insert("iter".to_string(), native("Result.iter", 2));
+    vm.globals.insert(
+        "Result".to_string(),
+        Value::Record(Arc::new(Mutex::new(result_fields))),
+    );
+
+    // Register Result constructors as globals
+    vm.globals.insert("Ok".to_string(), native("Ok", 1));
+    vm.globals.insert("Error".to_string(), native("Error", 1));
 
     // Json Module (if json feature is enabled)
     #[cfg(feature = "json")]

--- a/rust/crates/fusabi-vm/src/stdlib/print.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/print.rs
@@ -1,0 +1,66 @@
+// Fusabi Standard Library - Print Functions
+// Provides output functions similar to F#'s print/printfn
+
+use crate::value::Value;
+use crate::vm::VmError;
+
+/// Print a value to stdout without a newline
+/// Signature: print : 'a -> unit
+pub fn print_value(value: &Value) -> Result<Value, VmError> {
+    print!("{}", value);
+    Ok(Value::Unit)
+}
+
+/// Print a value to stdout with a newline
+/// Signature: printfn : 'a -> unit
+pub fn printfn_value(value: &Value) -> Result<Value, VmError> {
+    println!("{}", value);
+    Ok(Value::Unit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_print_basic_types() {
+        // Test with various types - these would print to stdout
+        assert_eq!(print_value(&Value::Int(42)), Ok(Value::Unit));
+        assert_eq!(print_value(&Value::Float(3.14)), Ok(Value::Unit));
+        assert_eq!(print_value(&Value::Bool(true)), Ok(Value::Unit));
+        assert_eq!(print_value(&Value::Str("hello".to_string())), Ok(Value::Unit));
+        assert_eq!(print_value(&Value::Unit), Ok(Value::Unit));
+    }
+
+    #[test]
+    fn test_printfn_basic_types() {
+        // Test with various types - these would print to stdout with newline
+        assert_eq!(printfn_value(&Value::Int(42)), Ok(Value::Unit));
+        assert_eq!(printfn_value(&Value::Float(3.14)), Ok(Value::Unit));
+        assert_eq!(printfn_value(&Value::Bool(true)), Ok(Value::Unit));
+        assert_eq!(printfn_value(&Value::Str("hello".to_string())), Ok(Value::Unit));
+        assert_eq!(printfn_value(&Value::Unit), Ok(Value::Unit));
+    }
+
+    #[test]
+    fn test_print_list() {
+        // Test with list type
+        let list = Value::Cons {
+            head: Box::new(Value::Int(1)),
+            tail: Box::new(Value::Cons {
+                head: Box::new(Value::Int(2)),
+                tail: Box::new(Value::Nil),
+            }),
+        };
+        assert_eq!(print_value(&list), Ok(Value::Unit));
+        assert_eq!(printfn_value(&list), Ok(Value::Unit));
+    }
+
+    #[test]
+    fn test_print_tuple() {
+        // Test with tuple
+        let tuple = Value::Tuple(vec![Value::Int(1), Value::Str("test".to_string())]);
+        assert_eq!(print_value(&tuple), Ok(Value::Unit));
+        assert_eq!(printfn_value(&tuple), Ok(Value::Unit));
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/result.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/result.rs
@@ -1,0 +1,321 @@
+// Fusabi Result Standard Library
+// Provides helper functions for working with Result variants
+
+use crate::value::Value;
+use crate::vm::{Vm, VmError};
+
+/// Result.isOk : Result<'a, 'b> -> bool
+/// Returns true if the result is Ok, false if Error
+pub fn result_is_ok(result: &Value) -> Result<Value, VmError> {
+    match result {
+        Value::Variant { variant_name, .. } => Ok(Value::Bool(variant_name == "Ok")),
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.isError : Result<'a, 'b> -> bool
+/// Returns true if the result is Error, false if Ok
+pub fn result_is_error(result: &Value) -> Result<Value, VmError> {
+    match result {
+        Value::Variant { variant_name, .. } => Ok(Value::Bool(variant_name == "Error")),
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.defaultValue : 'a -> Result<'a, 'b> -> 'a
+/// Returns the value inside Ok, or the default value if Error
+pub fn result_default_value(default: &Value, result: &Value) -> Result<Value, VmError> {
+    match result {
+        Value::Variant {
+            variant_name,
+            fields,
+            ..
+        } => {
+            if variant_name == "Ok" && !fields.is_empty() {
+                Ok(fields[0].clone())
+            } else {
+                Ok(default.clone())
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.defaultWith : ('b -> 'a) -> Result<'a, 'b> -> 'a
+/// Returns the value inside Ok, or calls the default function with the error if Error
+pub fn result_default_with(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Result.defaultWith expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let default_fn = &args[0];
+    let result = &args[1];
+
+    match result {
+        Value::Variant {
+            variant_name,
+            fields,
+            ..
+        } => {
+            if variant_name == "Ok" && !fields.is_empty() {
+                Ok(fields[0].clone())
+            } else if variant_name == "Error" && !fields.is_empty() {
+                vm.call_value(default_fn.clone(), &[fields[0].clone()])
+            } else {
+                // Error with no fields - call with Unit
+                vm.call_value(default_fn.clone(), &[Value::Unit])
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.map : ('a -> 'c) -> Result<'a, 'b> -> Result<'c, 'b>
+/// Transforms the value inside Ok with the given function, passes through Error
+pub fn result_map(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Result.map expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let f = &args[0];
+    let result = &args[1];
+
+    match result {
+        Value::Variant {
+            type_name,
+            variant_name,
+            fields,
+        } => {
+            if variant_name == "Ok" && !fields.is_empty() {
+                let mapped_value = vm.call_value(f.clone(), &[fields[0].clone()])?;
+                Ok(Value::Variant {
+                    type_name: type_name.clone(),
+                    variant_name: "Ok".to_string(),
+                    fields: vec![mapped_value],
+                })
+            } else {
+                Ok(result.clone())
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.mapError : ('b -> 'c) -> Result<'a, 'b> -> Result<'a, 'c>
+/// Transforms the error inside Error with the given function, passes through Ok
+pub fn result_map_error(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Result.mapError expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let f = &args[0];
+    let result = &args[1];
+
+    match result {
+        Value::Variant {
+            type_name,
+            variant_name,
+            fields,
+        } => {
+            if variant_name == "Error" && !fields.is_empty() {
+                let mapped_error = vm.call_value(f.clone(), &[fields[0].clone()])?;
+                Ok(Value::Variant {
+                    type_name: type_name.clone(),
+                    variant_name: "Error".to_string(),
+                    fields: vec![mapped_error],
+                })
+            } else {
+                Ok(result.clone())
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.bind : ('a -> Result<'c, 'b>) -> Result<'a, 'b> -> Result<'c, 'b>
+/// Monadic bind for Result (also known as flatMap or andThen)
+pub fn result_bind(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Result.bind expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let f = &args[0];
+    let result = &args[1];
+
+    match result {
+        Value::Variant {
+            variant_name,
+            fields,
+            ..
+        } => {
+            if variant_name == "Ok" && !fields.is_empty() {
+                vm.call_value(f.clone(), &[fields[0].clone()])
+            } else {
+                Ok(result.clone())
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+/// Result.iter : ('a -> unit) -> Result<'a, 'b> -> unit
+/// Calls the function with the Ok value if Ok, does nothing if Error
+pub fn result_iter(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Result.iter expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let f = &args[0];
+    let result = &args[1];
+
+    match result {
+        Value::Variant {
+            variant_name,
+            fields,
+            ..
+        } => {
+            if variant_name == "Ok" && !fields.is_empty() {
+                vm.call_value(f.clone(), &[fields[0].clone()])?;
+            }
+            Ok(Value::Unit)
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "Result variant",
+            got: result.type_name(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_ok(value: Value) -> Value {
+        Value::Variant {
+            type_name: "Result".to_string(),
+            variant_name: "Ok".to_string(),
+            fields: vec![value],
+        }
+    }
+
+    fn make_error(error: Value) -> Value {
+        Value::Variant {
+            type_name: "Result".to_string(),
+            variant_name: "Error".to_string(),
+            fields: vec![error],
+        }
+    }
+
+    #[test]
+    fn test_result_is_ok_true() {
+        let result = make_ok(Value::Int(42));
+        let output = result_is_ok(&result).unwrap();
+        assert_eq!(output, Value::Bool(true));
+    }
+
+    #[test]
+    fn test_result_is_ok_false() {
+        let result = make_error(Value::Str("error".to_string()));
+        let output = result_is_ok(&result).unwrap();
+        assert_eq!(output, Value::Bool(false));
+    }
+
+    #[test]
+    fn test_result_is_error_true() {
+        let result = make_error(Value::Str("error".to_string()));
+        let output = result_is_error(&result).unwrap();
+        assert_eq!(output, Value::Bool(true));
+    }
+
+    #[test]
+    fn test_result_is_error_false() {
+        let result = make_ok(Value::Int(42));
+        let output = result_is_error(&result).unwrap();
+        assert_eq!(output, Value::Bool(false));
+    }
+
+    #[test]
+    fn test_result_default_value_ok() {
+        let result = make_ok(Value::Int(42));
+        let default = Value::Int(0);
+        let output = result_default_value(&default, &result).unwrap();
+        assert_eq!(output, Value::Int(42));
+    }
+
+    #[test]
+    fn test_result_default_value_error() {
+        let result = make_error(Value::Str("error".to_string()));
+        let default = Value::Int(99);
+        let output = result_default_value(&default, &result).unwrap();
+        assert_eq!(output, Value::Int(99));
+    }
+
+    #[test]
+    fn test_result_default_value_different_types() {
+        let result = make_ok(Value::Str("success".to_string()));
+        let default = Value::Str("default".to_string());
+        let output = result_default_value(&default, &result).unwrap();
+        assert_eq!(output, Value::Str("success".to_string()));
+    }
+
+    #[test]
+    fn test_result_type_error() {
+        let not_result = Value::Int(42);
+        assert!(result_is_ok(&not_result).is_err());
+        assert!(result_is_error(&not_result).is_err());
+        assert!(result_default_value(&Value::Int(0), &not_result).is_err());
+    }
+
+    #[test]
+    fn test_result_different_variant_type() {
+        // Test with a non-Result variant
+        let other_variant = Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Int(42)],
+        };
+
+        // Should still work - we only check variant_name, not type_name
+        let is_ok = result_is_ok(&other_variant).unwrap();
+        assert_eq!(is_ok, Value::Bool(false));
+
+        let is_error = result_is_error(&other_variant).unwrap();
+        assert_eq!(is_error, Value::Bool(false));
+    }
+}

--- a/rust/crates/fusabi-vm/tests/test_stdlib.rs
+++ b/rust/crates/fusabi-vm/tests/test_stdlib.rs
@@ -549,3 +549,56 @@ fn test_option_iter_through_vm() {
     let result = call_stdlib_function(&mut vm, "Option.iter", &[Value::Closure(func_closure), some_val]).unwrap();
     assert_eq!(result, Value::Unit);
 }
+
+// ========== Print Function Tests ==========
+
+#[test]
+fn test_print_function_exists() {
+    let vm = get_test_vm();
+    // Check print is registered as a global
+    assert!(vm.globals.contains_key("print"));
+    assert!(vm.globals.contains_key("printfn"));
+}
+
+#[test]
+fn test_print_returns_unit() {
+    let mut vm = get_test_vm();
+    // Both print and printfn should return Unit
+    let result_print = call_stdlib_function(&mut vm, "print", &[Value::Int(42)]).unwrap();
+    assert_eq!(result_print, Value::Unit);
+
+    let result_printfn = call_stdlib_function(&mut vm, "printfn", &[Value::Str("test".to_string())]).unwrap();
+    assert_eq!(result_printfn, Value::Unit);
+}
+
+#[test]
+fn test_print_various_types() {
+    let mut vm = get_test_vm();
+
+    // Test with different types - all should return Unit without error
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[Value::Int(42)]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[Value::Float(3.14)]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[Value::Bool(true)]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[Value::Str("hello".to_string())]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[Value::Unit]).unwrap(), Value::Unit);
+
+    let list = Value::vec_to_cons(vec![Value::Int(1), Value::Int(2), Value::Int(3)]);
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[list]).unwrap(), Value::Unit);
+
+    let tuple = Value::Tuple(vec![Value::Int(1), Value::Str("test".to_string())]);
+    assert_eq!(call_stdlib_function(&mut vm, "print", &[tuple]).unwrap(), Value::Unit);
+}
+
+#[test]
+fn test_printfn_various_types() {
+    let mut vm = get_test_vm();
+
+    // Test with different types - all should return Unit without error
+    assert_eq!(call_stdlib_function(&mut vm, "printfn", &[Value::Int(42)]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "printfn", &[Value::Float(3.14)]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "printfn", &[Value::Bool(false)]).unwrap(), Value::Unit);
+    assert_eq!(call_stdlib_function(&mut vm, "printfn", &[Value::Str("world".to_string())]).unwrap(), Value::Unit);
+
+    let list = Value::vec_to_cons(vec![Value::Int(10), Value::Int(20)]);
+    assert_eq!(call_stdlib_function(&mut vm, "printfn", &[list]).unwrap(), Value::Unit);
+}

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 description = "A potent, functional scripting layer for Rust infrastructure."
 repository = "https://github.com/fusabi-lang/fusabi"
@@ -15,8 +15,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.19.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.19.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.20.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.20.0", features = ["serde"] }
 colored = "2.1"
 
 [features]

--- a/rust/examples/math_demo.fsa
+++ b/rust/examples/math_demo.fsa
@@ -1,0 +1,45 @@
+// Fusabi Math Module Demonstration
+
+printfn "=== Math Module Demo ==="
+printfn ""
+
+// Constants
+printfn "Constants:"
+let pi = Math.pi ()
+let e = Math.e ()
+printfn (sprintf "  Pi = %.5f" [pi])
+printfn (sprintf "  e = %.5f" [e])
+printfn ""
+
+// Basic operations
+printfn "Basic Operations:"
+printfn (sprintf "  abs(-42) = %d" [Math.abs -42])
+printfn (sprintf "  sqrt(25.0) = %.1f" [Math.sqrt 25.0])
+printfn (sprintf "  pow(2.0, 8.0) = %.0f" [Math.pow 2.0 8.0])
+printfn (sprintf "  max(10, 20) = %d" [Math.max 10 20])
+printfn (sprintf "  min(10, 20) = %d" [Math.min 10 20])
+printfn ""
+
+// Trigonometry
+printfn "Trigonometry (radians):"
+printfn (sprintf "  sin(0.0) = %.2f" [Math.sin 0.0])
+printfn (sprintf "  cos(0.0) = %.2f" [Math.cos 0.0])
+printfn (sprintf "  tan(0.0) = %.2f" [Math.tan 0.0])
+printfn ""
+
+// Logarithms
+printfn "Logarithms:"
+printfn (sprintf "  log(e) = %.2f" [Math.log e])
+printfn (sprintf "  log10(100.0) = %.1f" [Math.log10 100.0])
+printfn (sprintf "  exp(1.0) = %.5f" [Math.exp 1.0])
+printfn ""
+
+// Rounding
+printfn "Rounding:"
+printfn (sprintf "  floor(3.7) = %.0f" [Math.floor 3.7])
+printfn (sprintf "  ceil(3.2) = %.0f" [Math.ceil 3.2])
+printfn (sprintf "  round(3.5) = %.0f" [Math.round 3.5])
+printfn (sprintf "  truncate(3.9) = %.0f" [Math.truncate 3.9])
+printfn ""
+
+printfn "=== Demo Complete ==="


### PR DESCRIPTION
## Summary
- Add **Math module** with 21 mathematical functions (pi, e, abs, sqrt, pow, min/max, trig, log, rounding)
- Add **Result module** with 8 functions and Ok/Error constructors for error handling
- Add global **print/printfn** functions for output
- Bump version to v0.20.0

## Implementation Details

### Math Module
| Category | Functions |
|----------|-----------|
| Constants | `pi`, `e` |
| Basic | `abs`, `sqrt`, `pow`, `max`, `min` |
| Trigonometric | `sin`, `cos`, `tan`, `asin`, `acos`, `atan`, `atan2` |
| Logarithmic | `log`, `log10`, `exp` |
| Rounding | `floor`, `ceil`, `round`, `truncate` |

### Result Module
| Function | Signature | Description |
|----------|-----------|-------------|
| `isOk` | `Result<'a,'b> -> bool` | Check if Ok |
| `isError` | `Result<'a,'b> -> bool` | Check if Error |
| `defaultValue` | `'a -> Result<'a,'b> -> 'a` | Get value or default |
| `defaultWith` | `('b -> 'a) -> Result<'a,'b> -> 'a` | Get value or compute default |
| `map` | `('a -> 'c) -> Result<'a,'b> -> Result<'c,'b>` | Transform Ok value |
| `mapError` | `('b -> 'c) -> Result<'a,'b> -> Result<'a,'c>` | Transform Error value |
| `bind` | `('a -> Result<'c,'b>) -> Result<'a,'b> -> Result<'c,'b>` | Monadic bind |
| `iter` | `('a -> unit) -> Result<'a,'b> -> unit` | Execute on Ok |

### Print Functions
- `print value` - Output without newline
- `printfn value` - Output with newline

## Test plan
- [x] All Math module tests pass
- [x] All Result module tests pass
- [x] All print function tests pass
- [x] Existing fusabi-vm tests pass (521 tests)
- [x] Version bump verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)