### PR TITLE
docs: Add gen-docs.nu script and STDLIB_REFERENCE.md (Phase 4)

### DIFF
--- a/rust/crates/fusabi-vm/src/stdlib/json.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/json.rs
@@ -13,15 +13,8 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 #[cfg(feature = "json")]
-/// Parse a JSON string into a Fusabi Value
-/// Mapping:
-/// - JSON null -> Value::Unit
-/// - JSON bool -> Value::Bool
-/// - JSON number (integer) -> Value::Int
-/// - JSON number (float) -> Value::Float
-/// - JSON string -> Value::Str
-/// - JSON array -> Value::Array
-/// - JSON object -> Value::Record
+/// Json.parse : string -> 'a
+/// Parses a JSON string into a Fusabi value
 pub fn json_parse(arg: &Value) -> Result<Value, VmError> {
     match arg {
         Value::Str(json_str) => {
@@ -72,18 +65,8 @@ fn json_value_to_fusabi(json: &serde_json::Value) -> Result<Value, VmError> {
 }
 
 #[cfg(feature = "json")]
-/// Convert a Fusabi Value to a JSON string
-/// Mapping:
-/// - Value::Unit -> "null"
-/// - Value::Bool -> "true" or "false"
-/// - Value::Int -> number
-/// - Value::Float -> number
-/// - Value::Str -> string
-/// - Value::Array -> array
-/// - Value::Record -> object
-/// - Value::Map -> object
-/// - Value::Tuple -> array
-/// - Value::Cons/Nil -> array (converted from list)
+/// Json.stringify : 'a -> string
+/// Converts a Fusabi value to a JSON string
 pub fn json_stringify(arg: &Value) -> Result<Value, VmError> {
     let json_value = fusabi_value_to_json(arg)?;
     let json_str = serde_json::to_string(&json_value).map_err(|e| {
@@ -168,7 +151,8 @@ fn cons_to_vec(value: &Value) -> Result<Vec<Value>, VmError> {
 }
 
 #[cfg(feature = "json")]
-/// Pretty-print a Fusabi Value as formatted JSON
+/// Json.stringifyPretty : 'a -> string
+/// Converts a Fusabi value to a pretty-printed JSON string
 pub fn json_stringify_pretty(arg: &Value) -> Result<Value, VmError> {
     let json_value = fusabi_value_to_json(arg)?;
     let json_str = serde_json::to_string_pretty(&json_value).map_err(|e| {

--- a/rust/crates/fusabi-vm/src/stdlib/map.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/map.rs
@@ -5,10 +5,14 @@ use std::sync::Mutex;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+/// Map.empty : unit -> 'a map
+/// Creates an empty map
 pub fn map_empty(_unit: &Value) -> Result<Value, VmError> {
     Ok(Value::Map(Arc::new(Mutex::new(HashMap::new()))))
 }
 
+/// Map.add : string -> 'a -> 'a map -> 'a map
+/// Adds a key-value pair to the map, returning a new map
 pub fn map_add(key: &Value, value: &Value, map: &Value) -> Result<Value, VmError> {
     let key_str = key.as_str().ok_or_else(|| VmError::TypeMismatch {
         expected: "string",
@@ -27,6 +31,8 @@ pub fn map_add(key: &Value, value: &Value, map: &Value) -> Result<Value, VmError
     }
 }
 
+/// Map.remove : string -> 'a map -> 'a map
+/// Removes a key from the map, returning a new map
 pub fn map_remove(key: &Value, map: &Value) -> Result<Value, VmError> {
     let key_str = key.as_str().ok_or_else(|| VmError::TypeMismatch {
         expected: "string",
@@ -45,6 +51,8 @@ pub fn map_remove(key: &Value, map: &Value) -> Result<Value, VmError> {
     }
 }
 
+/// Map.find : string -> 'a map -> 'a
+/// Looks up a key in the map, throws error if not found
 pub fn map_find(key: &Value, map: &Value) -> Result<Value, VmError> {
     let key_str = key.as_str().ok_or_else(|| VmError::TypeMismatch {
         expected: "string",
@@ -64,6 +72,8 @@ pub fn map_find(key: &Value, map: &Value) -> Result<Value, VmError> {
     }
 }
 
+/// Map.tryFind : string -> 'a map -> 'a option
+/// Looks up a key in the map, returns Some(value) or None
 pub fn map_try_find(key: &Value, map: &Value) -> Result<Value, VmError> {
     let key_str = key.as_str().ok_or_else(|| VmError::TypeMismatch {
         expected: "string",
@@ -92,6 +102,8 @@ pub fn map_try_find(key: &Value, map: &Value) -> Result<Value, VmError> {
     }
 }
 
+/// Map.containsKey : string -> 'a map -> bool
+/// Returns true if the map contains the given key
 pub fn map_contains_key(key: &Value, map: &Value) -> Result<Value, VmError> {
     let key_str = key.as_str().ok_or_else(|| VmError::TypeMismatch {
         expected: "string",
@@ -109,6 +121,8 @@ pub fn map_contains_key(key: &Value, map: &Value) -> Result<Value, VmError> {
     }
 }
 
+/// Map.isEmpty : 'a map -> bool
+/// Returns true if the map is empty
 pub fn map_is_empty(map: &Value) -> Result<Value, VmError> {
     match map {
         Value::Map(m) => Ok(Value::Bool(m.lock().unwrap().is_empty())),
@@ -119,6 +133,8 @@ pub fn map_is_empty(map: &Value) -> Result<Value, VmError> {
     }
 }
 
+/// Map.count : 'a map -> int
+/// Returns the number of key-value pairs in the map
 pub fn map_count(map: &Value) -> Result<Value, VmError> {
     match map {
         Value::Map(m) => Ok(Value::Int(m.lock().unwrap().len() as i64)),
@@ -129,6 +145,8 @@ pub fn map_count(map: &Value) -> Result<Value, VmError> {
     }
 }
 
+/// Map.ofList : (string * 'a) list -> 'a map
+/// Creates a map from a list of key-value tuples
 pub fn map_of_list(list: &Value) -> Result<Value, VmError> {
     let mut map = HashMap::new();
     let mut current = list.clone();
@@ -165,6 +183,8 @@ pub fn map_of_list(list: &Value) -> Result<Value, VmError> {
     Ok(Value::Map(Arc::new(Mutex::new(map))))
 }
 
+/// Map.toList : 'a map -> (string * 'a) list
+/// Converts a map to a list of key-value tuples (sorted by key)
 pub fn map_to_list(map: &Value) -> Result<Value, VmError> {
     match map {
         Value::Map(m) => {
@@ -192,9 +212,8 @@ pub fn map_to_list(map: &Value) -> Result<Value, VmError> {
     }
 }
 
-/// Apply a function to each value in a map, returning a new map with transformed values.
-/// Signature: ('v -> 'v2) -> string map -> 'v2 map
-/// Keys remain the same, only values are transformed.
+/// Map.map : ('a -> 'b) -> 'a map -> 'b map
+/// Applies a function to each value in the map, returning a new map
 pub fn map_map(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
     if args.len() != 2 {
         return Err(VmError::Runtime(format!(
@@ -225,9 +244,8 @@ pub fn map_map(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
     }
 }
 
-/// Iterate over a map, calling a function on each key-value pair for side effects.
-/// Signature: (string -> 'v -> unit) -> string map -> unit
-/// Returns Unit after calling the function on all entries.
+/// Map.iter : (string -> 'a -> unit) -> 'a map -> unit
+/// Calls a function on each key-value pair for side effects
 pub fn map_iter(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
     if args.len() != 2 {
         return Err(VmError::Runtime(format!(

--- a/rust/crates/fusabi-vm/src/stdlib/print.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/print.rs
@@ -4,15 +4,15 @@
 use crate::value::Value;
 use crate::vm::VmError;
 
-/// Print a value to stdout without a newline
-/// Signature: print : 'a -> unit
+/// print : 'a -> unit
+/// Prints a value to stdout without a trailing newline
 pub fn print_value(value: &Value) -> Result<Value, VmError> {
     print!("{}", value);
     Ok(Value::Unit)
 }
 
-/// Print a value to stdout with a newline
-/// Signature: printfn : 'a -> unit
+/// printfn : 'a -> unit
+/// Prints a value to stdout with a trailing newline
 pub fn printfn_value(value: &Value) -> Result<Value, VmError> {
     println!("{}", value);
     Ok(Value::Unit)

--- a/rust/docs/STDLIB_REFERENCE.md
+++ b/rust/docs/STDLIB_REFERENCE.md
@@ -1,0 +1,203 @@
+# Fusabi Standard Library Reference
+
+*Auto-generated from source code on 2025-12-02*
+
+This document provides a comprehensive reference for all functions in the Fusabi standard library.
+
+## Table of Contents
+
+- [List]
+- [Array]
+- [Map]
+- [Option]
+- [Result]
+- [String]
+- [Math]
+- [Json]
+- [Print]
+
+---
+
+## List
+
+Functions for working with cons-based linked lists
+
+| Function | Description |
+|----------|-------------|
+| `List.length : 'a list -> int` | Returns the number of elements in a list |
+| `List.head : 'a list -> 'a` | Returns the first element of a list Throws error if list is empty |
+| `List.tail : 'a list -> 'a list` | Returns the list without its first element Throws error if list is empty |
+| `List.reverse : 'a list -> 'a list` | Returns a list with elements in reverse order |
+| `List.isEmpty : 'a list -> bool` | Returns true if the list is empty (Nil) |
+| `List.append : 'a list -> 'a list -> 'a list` | Concatenates two lists |
+| `List.concat : 'a list list -> 'a list` | Concatenates a list of lists into a single list |
+| `List.map : ('a -> 'b) -> 'a list -> 'b list` | Applies a function to each element of the list |
+| `List.iter : ('a -> unit) -> 'a list -> unit` | Calls a function on each element for side effects, returns Unit |
+| `List.filter : ('a -> bool) -> 'a list -> 'a list` | Returns list of elements where predicate returns true |
+| `List.fold : ('a -> 'b -> 'a) -> 'a -> 'b list -> 'a` | Applies folder function to accumulator and each element |
+| `List.exists : ('a -> bool) -> 'a list -> bool` | Returns true if any element satisfies the predicate |
+| `List.find : ('a -> bool) -> 'a list -> 'a` | Returns first element satisfying predicate Throws error if not found |
+| `List.tryFind : ('a -> bool) -> 'a list -> 'a option` | Returns Some(elem) if found, None otherwise |
+
+## Array
+
+Functions for mutable fixed-size arrays
+
+| Function | Description |
+|----------|-------------|
+| `Array.length : 'a array -> int` | Returns the number of elements in the array |
+| `Array.isEmpty : 'a array -> bool` | Returns true if the array is empty |
+| `Array.get : int -> 'a array -> 'a` | Safe array indexing - throws error if index is out of bounds |
+| `Array.set : int -> 'a -> 'a array -> unit` | Mutates array in place by setting the element at the given index Throws error if index is out of bounds |
+| `Array.ofList : 'a list -> 'a array` | Converts a cons list to an array |
+| `Array.toList : 'a array -> 'a list` | Converts an array to a cons list |
+| `Array.init : int -> (int -> 'a) -> 'a array` | Creates an array of given length by calling the function for each index Takes (length: int, fn: int -> 'a) and creates array by calling fn for each index from 0 to length-1 |
+| `Array.create : int -> 'a -> 'a array` | Creates an array of given length filled with the specified value |
+
+## Map
+
+Functions for string-keyed hash maps
+
+| Function | Description |
+|----------|-------------|
+| `Map.empty : unit -> 'a map` | Creates an empty map |
+| `Map.add : string -> 'a -> 'a map -> 'a map` | Adds a key-value pair to the map, returning a new map |
+| `Map.remove : string -> 'a map -> 'a map` | Removes a key from the map, returning a new map |
+| `Map.find : string -> 'a map -> 'a` | Looks up a key in the map, throws error if not found |
+| `Map.tryFind : string -> 'a map -> 'a option` | Looks up a key in the map, returns Some(value) or None |
+| `Map.containsKey : string -> 'a map -> bool` | Returns true if the map contains the given key |
+| `Map.isEmpty : 'a map -> bool` | Returns true if the map is empty |
+| `Map.count : 'a map -> int` | Returns the number of key-value pairs in the map |
+| `Map.ofList : (string * 'a) list -> 'a map` | Creates a map from a list of key-value tuples |
+| `Map.toList : 'a map -> (string * 'a) list` | Converts a map to a list of key-value tuples (sorted by key) |
+| `Map.map : ('a -> 'b) -> 'a map -> 'b map` | Applies a function to each value in the map, returning a new map |
+| `Map.iter : (string -> 'a -> unit) -> 'a map -> unit` | Calls a function on each key-value pair for side effects |
+
+## Option
+
+Functions for optional values (Some/None)
+
+| Function | Description |
+|----------|-------------|
+| `Option.isSome : 'a option -> bool` | Returns true if the option is Some, false if None |
+| `Option.isNone : 'a option -> bool` | Returns true if the option is None, false if Some |
+| `Option.defaultValue : 'a -> 'a option -> 'a` | Returns the value inside Some, or the default value if None |
+| `Option.defaultWith : (unit -> 'a) -> 'a option -> 'a` | Returns the value inside Some, or calls the default function if None |
+| `Option.map : ('a -> 'b) -> 'a option -> 'b option` | Transforms the value inside Some with the given function |
+| `Option.bind : ('a -> 'b option) -> 'a option -> 'b option` | Monadic bind for Option (also known as flatMap or andThen) |
+| `Option.iter : ('a -> unit) -> 'a option -> unit` | Calls the function with the value if Some, does nothing if None |
+| `Option.map2 : ('a -> 'b -> 'c) -> 'a option -> 'b option -> 'c option` | Combines two options with a function |
+| `Option.orElse : 'a option -> 'a option -> 'a option` | Returns the first option if Some, otherwise returns the second option |
+
+## Result
+
+Functions for error handling (Ok/Error)
+
+| Function | Description |
+|----------|-------------|
+| `Result.isOk : Result<'a, 'b> -> bool` | Returns true if the result is Ok, false if Error |
+| `Result.isError : Result<'a, 'b> -> bool` | Returns true if the result is Error, false if Ok |
+| `Result.defaultValue : 'a -> Result<'a, 'b> -> 'a` | Returns the value inside Ok, or the default value if Error |
+| `Result.defaultWith : ('b -> 'a) -> Result<'a, 'b> -> 'a` | Returns the value inside Ok, or calls the default function with the error if Error |
+| `Result.map : ('a -> 'c) -> Result<'a, 'b> -> Result<'c, 'b>` | Transforms the value inside Ok with the given function, passes through Error |
+| `Result.mapError : ('b -> 'c) -> Result<'a, 'b> -> Result<'a, 'c>` | Transforms the error inside Error with the given function, passes through Ok |
+| `Result.bind : ('a -> Result<'c, 'b>) -> Result<'a, 'b> -> Result<'c, 'b>` | Monadic bind for Result (also known as flatMap or andThen) |
+| `Result.iter : ('a -> unit) -> Result<'a, 'b> -> unit` | Calls the function with the Ok value if Ok, does nothing if Error |
+
+## String
+
+Functions for string manipulation
+
+| Function | Description |
+|----------|-------------|
+| `String.length : string -> int` | Returns the length of a string in characters (not bytes) |
+| `String.trim : string -> string` | Removes leading and trailing whitespace |
+| `String.toLower : string -> string` | Converts string to lowercase |
+| `String.toUpper : string -> string` | Converts string to uppercase |
+| `String.split : string -> string -> string list` | Splits a string by a delimiter into a list of strings |
+| `String.concat : string list -> string` | Concatenates a list of strings into a single string |
+| `String.contains : string -> string -> bool` | Returns true if haystack contains needle |
+| `String.startsWith : string -> string -> bool` | Returns true if string starts with the given prefix |
+| `String.endsWith : string -> string -> bool` | Returns true if string ends with the given suffix |
+| `String.format : string -> any list -> string` | Formats a string using printf-style formatting Supported specifiers: %s (string), %d (int), %f (float), %.Nf (float with precision), %% (literal %) Example: String.format "%s version %d.%d" ["MyApp"; 1; 0] returns "MyApp version 1.0" |
+
+## Math
+
+Mathematical constants and functions
+
+| Function | Description |
+|----------|-------------|
+| `Math.pi : unit -> float` | Returns the mathematical constant π (pi) |
+| `Math.e : unit -> float` | Returns the mathematical constant e (Euler's number) |
+| `Math.abs : int -> int` | Math.abs : float -> float Returns the absolute value of a number |
+| `Math.sqrt : float -> float` | Returns the square root of a number |
+| `Math.pow : float -> float -> float` | Returns base raised to the power of exponent |
+| `Math.max : int -> int -> int` | Math.max : float -> float -> float Returns the maximum of two values |
+| `Math.min : int -> int -> int` | Math.min : float -> float -> float Returns the minimum of two values |
+| `Math.sin : float -> float` | Returns the sine of an angle in radians |
+| `Math.cos : float -> float` | Returns the cosine of an angle in radians |
+| `Math.tan : float -> float` | Returns the tangent of an angle in radians |
+| `Math.asin : float -> float` | Returns the arcsine (inverse sine) of a value, result in radians |
+| `Math.acos : float -> float` | Returns the arccosine (inverse cosine) of a value, result in radians |
+| `Math.atan : float -> float` | Returns the arctangent (inverse tangent) of a value, result in radians |
+| `Math.atan2 : float -> float -> float` | Returns the arctangent of y/x in radians, using the signs to determine the quadrant |
+| `Math.log : float -> float` | Returns the natural logarithm (base e) of a number |
+| `Math.log10 : float -> float` | Returns the base-10 logarithm of a number |
+| `Math.exp : float -> float` | Returns e raised to the power of x |
+| `Math.floor : float -> float` | Returns the largest integer less than or equal to the number |
+| `Math.ceil : float -> float` | Returns the smallest integer greater than or equal to the number |
+| `Math.round : float -> float` | Returns the nearest integer, rounding half-way cases away from 0.0 |
+| `Math.truncate : float -> float` | Returns the integer part of a number, removing any fractional digits |
+
+## Json
+
+JSON parsing and serialization
+
+| Function | Description |
+|----------|-------------|
+| `Json.parse : string -> 'a` | Parses a JSON string into a Fusabi value |
+| `Json.stringify : 'a -> string` | Converts a Fusabi value to a JSON string |
+| `Json.stringifyPretty : 'a -> string` | Converts a Fusabi value to a pretty-printed JSON string |
+
+## Print
+
+Output functions
+
+| Function | Description |
+|----------|-------------|
+| `print : 'a -> unit` | Prints a value to stdout without a trailing newline |
+| `printfn : 'a -> unit` | Prints a value to stdout with a trailing newline |
+
+## Usage Examples
+
+### List Operations
+```fsharp
+let nums = [1; 2; 3; 4; 5]
+let doubled = List.map (fun x -> x * 2) nums
+let sum = List.fold (fun acc x -> acc + x) 0 nums
+```
+
+### Option Handling
+```fsharp
+let maybeValue = Some 42
+let value = Option.defaultValue 0 maybeValue  // 42
+let mapped = Option.map (fun x -> x * 2) maybeValue  // Some 84
+```
+
+### Result Error Handling
+```fsharp
+let result = Ok 100
+let value = Result.defaultValue 0 result  // 100
+let mapped = Result.map (fun x -> x / 2) result  // Ok 50
+```
+
+### Math Functions
+```fsharp
+let pi = Math.pi ()
+let sqrt2 = Math.sqrt 2.0
+let angle = Math.atan2 1.0 1.0  // pi/4
+```
+
+---
+
+*For more examples, see the `examples/` directory in the repository.*

--- a/rust/scripts/gen-docs.nu
+++ b/rust/scripts/gen-docs.nu
@@ -1,0 +1,155 @@
+#!/usr/bin/env nu
+# Fusabi Standard Library Documentation Generator
+# Parses /// doc comments from stdlib/*.rs and generates STDLIB_REFERENCE.md
+
+# Configuration
+let stdlib_path = "crates/fusabi-vm/src/stdlib"
+let output_path = "docs/STDLIB_REFERENCE.md"
+
+# Module display order and metadata
+let modules = [
+    { name: "List", file: "list.rs", description: "Functions for working with cons-based linked lists" }
+    { name: "Array", file: "array.rs", description: "Functions for mutable fixed-size arrays" }
+    { name: "Map", file: "map.rs", description: "Functions for string-keyed hash maps" }
+    { name: "Option", file: "option.rs", description: "Functions for optional values (Some/None)" }
+    { name: "Result", file: "result.rs", description: "Functions for error handling (Ok/Error)" }
+    { name: "String", file: "string.rs", description: "Functions for string manipulation" }
+    { name: "Math", file: "math.rs", description: "Mathematical constants and functions" }
+    { name: "Json", file: "json.rs", description: "JSON parsing and serialization" }
+    { name: "Print", file: "print.rs", description: "Output functions" }
+]
+
+# Parse doc comments from a Rust file
+def parse_doc_comments [file_path: string]: nothing -> list<any> {
+    let content = open $file_path | lines
+
+    mut functions = []
+    mut current_docs = []
+    mut in_doc_block = false
+
+    for line in $content {
+        if ($line | str starts-with "///") {
+            # Extract doc comment content (remove /// prefix)
+            let doc_line = $line | str replace "^///\\s?" "" --regex
+            $current_docs = ($current_docs | append $doc_line)
+            $in_doc_block = true
+        } else if $in_doc_block and ($line | str starts-with "pub fn") {
+            # Found a public function after doc comments
+            if ($current_docs | length) > 0 {
+                # First line is typically the signature
+                let signature = $current_docs | first
+                # Remaining lines are the description
+                let description = $current_docs | skip 1 | str join " " | str trim
+
+                $functions = ($functions | append {
+                    signature: $signature
+                    description: $description
+                })
+            }
+            $current_docs = []
+            $in_doc_block = false
+        } else if not ($line | str starts-with "///") {
+            # Reset if we hit a non-doc, non-function line
+            if not ($line | str starts-with "pub fn") {
+                $current_docs = []
+                $in_doc_block = false
+            }
+        }
+    }
+
+    $functions
+}
+
+# Generate markdown for a module
+def generate_module_markdown [module: record, functions: list]: nothing -> string {
+    mut md = $"## ($module.name)\n\n"
+    $md = $md + $"($module.description)\n\n"
+
+    if ($functions | length) == 0 {
+        $md = $md + "*No documented functions*\n\n"
+        return $md
+    }
+
+    $md = $md + "| Function | Description |\n"
+    $md = $md + "|----------|-------------|\n"
+
+    for func in $functions {
+        let sig = $func.signature | str replace "|" "\\|" --all
+        let desc = $func.description | str replace "|" "\\|" --all
+        $md = $md + $"| `($sig)` | ($desc) |\n"
+    }
+
+    $md = $md + "\n"
+    $md
+}
+
+# Main script
+def main [] {
+    print "Generating Fusabi Standard Library Reference..."
+
+    # Header
+    mut output = "# Fusabi Standard Library Reference\n\n"
+    $output = $output + $"*Auto-generated from source code on (date now | format date '%Y-%m-%d')*\n\n"
+    $output = $output + "This document provides a comprehensive reference for all functions in the Fusabi standard library.\n\n"
+    $output = $output + "## Table of Contents\n\n"
+
+    # Generate TOC
+    for module in $modules {
+        $output = $output + $"- [($module.name)](#($module.name | str downcase))\n"
+    }
+    $output = $output + "\n---\n\n"
+
+    # Process each module
+    for module in $modules {
+        let file_path = $"($stdlib_path)/($module.file)"
+
+        if ($file_path | path exists) {
+            print $"  Processing ($module.name) module..."
+            let functions = parse_doc_comments $file_path
+            let module_md = generate_module_markdown $module $functions
+            $output = $output + $module_md
+        } else {
+            print $"  Warning: ($file_path) not found, skipping..."
+        }
+    }
+
+    # Add usage examples section
+    $output = $output + "## Usage Examples\n\n"
+    $output = $output + "### List Operations\n"
+    $output = $output + "```fsharp\n"
+    $output = $output + "let nums = [1; 2; 3; 4; 5]\n"
+    $output = $output + "let doubled = List.map (fun x -> x * 2) nums\n"
+    $output = $output + "let sum = List.fold (fun acc x -> acc + x) 0 nums\n"
+    $output = $output + "```\n\n"
+
+    $output = $output + "### Option Handling\n"
+    $output = $output + "```fsharp\n"
+    $output = $output + "let maybeValue = Some 42\n"
+    $output = $output + "let value = Option.defaultValue 0 maybeValue  // 42\n"
+    $output = $output + "let mapped = Option.map (fun x -> x * 2) maybeValue  // Some 84\n"
+    $output = $output + "```\n\n"
+
+    $output = $output + "### Result Error Handling\n"
+    $output = $output + "```fsharp\n"
+    $output = $output + "let result = Ok 100\n"
+    $output = $output + "let value = Result.defaultValue 0 result  // 100\n"
+    $output = $output + "let mapped = Result.map (fun x -> x / 2) result  // Ok 50\n"
+    $output = $output + "```\n\n"
+
+    $output = $output + "### Math Functions\n"
+    $output = $output + "```fsharp\n"
+    $output = $output + "let pi = Math.pi ()\n"
+    $output = $output + "let sqrt2 = Math.sqrt 2.0\n"
+    $output = $output + "let angle = Math.atan2 1.0 1.0  // pi/4\n"
+    $output = $output + "```\n\n"
+
+    # Footer
+    $output = $output + "---\n\n"
+    $output = $output + "*For more examples, see the `examples/` directory in the repository.*\n"
+
+    # Write output
+    $output | save -f $output_path
+    print $"Documentation generated: ($output_path)"
+}
+
+# Entry point - main is called automatically when script runs


### PR DESCRIPTION
## Summary
- Add `scripts/gen-docs.nu` - Nushell script for auto-generating stdlib documentation
- Add `docs/STDLIB_REFERENCE.md` - Complete API reference for all stdlib modules
- Standardize doc comment format across Map, Json, and Print modules

## Implementation Details

### gen-docs.nu Script
Parses `///` doc comments from stdlib Rust source files and generates markdown documentation:
- Extracts function signatures and descriptions
- Groups functions by module
- Generates table-formatted reference docs
- Includes usage examples

### STDLIB_REFERENCE.md
Auto-generated reference covering:
- **List** (14 functions) - Cons-based linked list operations
- **Array** (8 functions) - Mutable fixed-size arrays
- **Map** (12 functions) - String-keyed hash maps
- **Option** (9 functions) - Optional value handling
- **Result** (8 functions) - Error handling
- **String** (10 functions) - String manipulation
- **Math** (21 functions) - Mathematical operations
- **Json** (3 functions) - JSON parsing/serialization
- **Print** (2 functions) - Output functions

### Doc Comment Standardization
Updated Map, Json, and Print modules to use consistent format:
```rust
/// Module.function : signature
/// Description text
```

## Usage
```bash
# Regenerate docs from source
nu scripts/gen-docs.nu
```

## Test plan
- [x] Script runs without errors
- [x] All modules documented
- [x] Existing tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)