### PR TITLE
feat: Add Config, Time, Url, Process stdlib modules (#152, #154)

### DIFF
--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 path = "src/lib.rs"
 
 [dependencies]
+lazy_static = "1.4"
 serde = { version = "1.0", features = ["derive", "rc"], optional = true }
 bincode = { version = "1.3", optional = true }
 serde_json = { version = "1.0", optional = true }

--- a/rust/crates/fusabi-vm/src/stdlib/config.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/config.rs
@@ -1,0 +1,676 @@
+// Fusabi Config Standard Library
+// Provides configuration management with schemas and validation
+
+use crate::value::Value;
+use crate::vm::{Vm, VmError};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+lazy_static::lazy_static! {
+    /// Global registry for configuration schemas and values
+    /// Key: config name, Value: (schema, current value)
+    static ref CONFIG_REGISTRY: Arc<Mutex<HashMap<String, (ConfigSchema, Option<Value>)>>> =
+        Arc::new(Mutex::new(HashMap::new()));
+}
+
+/// Internal representation of a configuration schema
+#[derive(Clone)]
+struct ConfigSchema {
+    name: String,
+    config_type: String,
+    default_value: Option<Value>,
+    validator: Option<Value>,
+}
+
+impl ConfigSchema {
+    /// Parse a ConfigSchema record from a Value
+    fn from_value(value: &Value) -> Result<Self, VmError> {
+        let record = value.as_record().ok_or_else(|| VmError::TypeMismatch {
+            expected: "record",
+            got: value.type_name(),
+        })?;
+
+        let fields = record.lock().unwrap();
+
+        let name = fields
+            .get("name")
+            .ok_or_else(|| VmError::Runtime("ConfigSchema missing 'name' field".to_string()))?
+            .as_str()
+            .ok_or_else(|| VmError::TypeMismatch {
+                expected: "string",
+                got: "other",
+            })?
+            .to_string();
+
+        let config_type = fields
+            .get("configType")
+            .ok_or_else(|| VmError::Runtime("ConfigSchema missing 'configType' field".to_string()))?
+            .as_str()
+            .ok_or_else(|| VmError::TypeMismatch {
+                expected: "string",
+                got: "other",
+            })?
+            .to_string();
+
+        // Validate configType
+        match config_type.as_str() {
+            "string" | "int" | "bool" | "list" | "map" => {}
+            _ => {
+                return Err(VmError::Runtime(format!(
+                    "Invalid configType '{}'. Must be one of: string, int, bool, list, map",
+                    config_type
+                )))
+            }
+        }
+
+        // Extract default value (Option)
+        let default_value = fields
+            .get("default")
+            .and_then(|v| match v {
+                Value::Variant { variant_name, fields, .. } if variant_name == "Some" => {
+                    fields.first().cloned()
+                }
+                Value::Variant { variant_name, .. } if variant_name == "None" => None,
+                _ => None,
+            });
+
+        // Extract validator function (Option)
+        let validator = fields
+            .get("validator")
+            .and_then(|v| match v {
+                Value::Variant { variant_name, fields, .. } if variant_name == "Some" => {
+                    fields.first().cloned()
+                }
+                Value::Variant { variant_name, .. } if variant_name == "None" => None,
+                _ => None,
+            });
+
+        Ok(ConfigSchema {
+            name,
+            config_type,
+            default_value,
+            validator,
+        })
+    }
+
+    /// Validate that a ConfigValue matches the expected type
+    fn validate_type(&self, config_value: &Value) -> Result<(), VmError> {
+        // Extract the variant name and fields from ConfigValue
+        let (type_name, variant_name, fields) = config_value.as_variant().ok_or_else(|| {
+            VmError::TypeMismatch {
+                expected: "ConfigValue variant",
+                got: config_value.type_name(),
+            }
+        })?;
+
+        if type_name != "ConfigValue" {
+            return Err(VmError::Runtime(format!(
+                "Expected ConfigValue variant, got {}",
+                type_name
+            )));
+        }
+
+        // Validate the variant matches the schema's configType
+        match (self.config_type.as_str(), variant_name) {
+            ("string", "String") => {
+                if fields.is_empty() || !matches!(fields[0], Value::Str(_)) {
+                    return Err(VmError::Runtime(
+                        "ConfigValue.String expects a string value".to_string(),
+                    ));
+                }
+            }
+            ("int", "Int") => {
+                if fields.is_empty() || !matches!(fields[0], Value::Int(_)) {
+                    return Err(VmError::Runtime(
+                        "ConfigValue.Int expects an int value".to_string(),
+                    ));
+                }
+            }
+            ("bool", "Bool") => {
+                if fields.is_empty() || !matches!(fields[0], Value::Bool(_)) {
+                    return Err(VmError::Runtime(
+                        "ConfigValue.Bool expects a bool value".to_string(),
+                    ));
+                }
+            }
+            ("list", "List") => {
+                if fields.is_empty() || (!fields[0].is_cons() && !fields[0].is_nil()) {
+                    return Err(VmError::Runtime(
+                        "ConfigValue.List expects a list value".to_string(),
+                    ));
+                }
+            }
+            ("map", "Map") => {
+                if fields.is_empty() || !matches!(fields[0], Value::Map(_)) {
+                    return Err(VmError::Runtime(
+                        "ConfigValue.Map expects a map value".to_string(),
+                    ));
+                }
+            }
+            (expected, got) => {
+                return Err(VmError::Runtime(format!(
+                    "Type mismatch: expected ConfigValue.{} for configType '{}', got ConfigValue.{}",
+                    expected, expected, got
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Config.define : ConfigSchema -> unit
+/// Register a configuration schema
+pub fn config_define(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Config.define expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let schema = ConfigSchema::from_value(&args[0])?;
+    let name = schema.name.clone();
+    let default_value = schema.default_value.clone();
+
+    // Validate default value if provided
+    if let Some(ref value) = default_value {
+        schema.validate_type(value)?;
+
+        // Run validator function if provided
+        if let Some(ref validator) = schema.validator {
+            let result = vm.call_value(validator.clone(), &[value.clone()])?;
+            match result {
+                Value::Bool(true) => {}
+                Value::Bool(false) => {
+                    return Err(VmError::Runtime(format!(
+                        "Default value validation failed for config '{}'",
+                        name
+                    )));
+                }
+                _ => {
+                    return Err(VmError::Runtime(
+                        "Validator function must return bool".to_string(),
+                    ));
+                }
+            }
+        }
+    }
+
+    // Register schema with default value
+    let mut registry = CONFIG_REGISTRY.lock().unwrap();
+    registry.insert(name.clone(), (schema, default_value));
+
+    Ok(Value::Unit)
+}
+
+/// Config.get : string -> ConfigValue
+/// Get a configuration value (throws if not found)
+pub fn config_get(name: &Value) -> Result<Value, VmError> {
+    let name_str = name.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: name.type_name(),
+    })?;
+
+    let registry = CONFIG_REGISTRY.lock().unwrap();
+    let (_, value) = registry.get(name_str).ok_or_else(|| {
+        VmError::Runtime(format!("Configuration '{}' not found", name_str))
+    })?;
+
+    value.clone().ok_or_else(|| {
+        VmError::Runtime(format!(
+            "Configuration '{}' has no value set and no default",
+            name_str
+        ))
+    })
+}
+
+/// Config.getOr : string -> ConfigValue -> ConfigValue
+/// Get a configuration value with a fallback default
+pub fn config_get_or(name: &Value, default: &Value) -> Result<Value, VmError> {
+    let name_str = name.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: name.type_name(),
+    })?;
+
+    let registry = CONFIG_REGISTRY.lock().unwrap();
+
+    match registry.get(name_str) {
+        Some((_, Some(value))) => Ok(value.clone()),
+        Some((_, None)) => Ok(default.clone()),
+        None => Ok(default.clone()),
+    }
+}
+
+/// Config.set : string -> ConfigValue -> unit
+/// Set a configuration value (validates against schema)
+pub fn config_set(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 2 {
+        return Err(VmError::Runtime(format!(
+            "Config.set expects 2 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    let name_str = args[0].as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: args[0].type_name(),
+    })?;
+
+    let value = &args[1];
+
+    let mut registry = CONFIG_REGISTRY.lock().unwrap();
+    let (schema, current_value) = registry
+        .get_mut(name_str)
+        .ok_or_else(|| VmError::Runtime(format!("Configuration '{}' not defined", name_str)))?;
+
+    // Validate type
+    schema.validate_type(value)?;
+
+    // Run validator function if provided
+    if let Some(ref validator) = schema.validator {
+        let result = vm.call_value(validator.clone(), &[value.clone()])?;
+        match result {
+            Value::Bool(true) => {}
+            Value::Bool(false) => {
+                return Err(VmError::Runtime(format!(
+                    "Value validation failed for config '{}'",
+                    name_str
+                )));
+            }
+            _ => {
+                return Err(VmError::Runtime(
+                    "Validator function must return bool".to_string(),
+                ));
+            }
+        }
+    }
+
+    *current_value = Some(value.clone());
+    Ok(Value::Unit)
+}
+
+/// Config.has : string -> bool
+/// Check if a configuration is defined
+pub fn config_has(name: &Value) -> Result<Value, VmError> {
+    let name_str = name.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: name.type_name(),
+    })?;
+
+    let registry = CONFIG_REGISTRY.lock().unwrap();
+    Ok(Value::Bool(registry.contains_key(name_str)))
+}
+
+/// Config.list : unit -> (string * ConfigValue) list
+/// List all defined configurations with their current values
+pub fn config_list(_unit: &Value) -> Result<Value, VmError> {
+    let registry = CONFIG_REGISTRY.lock().unwrap();
+    let mut entries = Vec::new();
+
+    for (name, (_, value)) in registry.iter() {
+        if let Some(val) = value {
+            let tuple = Value::Tuple(vec![Value::Str(name.clone()), val.clone()]);
+            entries.push(tuple);
+        }
+    }
+
+    // Sort by name for deterministic output
+    entries.sort_by(|a, b| {
+        let name_a = a.as_tuple().and_then(|t| t[0].as_str()).unwrap_or("");
+        let name_b = b.as_tuple().and_then(|t| t[0].as_str()).unwrap_or("");
+        name_a.cmp(name_b)
+    });
+
+    Ok(Value::vec_to_cons(entries))
+}
+
+/// Config.reset : string -> unit
+/// Reset a configuration to its default value
+pub fn config_reset(name: &Value) -> Result<Value, VmError> {
+    let name_str = name.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: name.type_name(),
+    })?;
+
+    let mut registry = CONFIG_REGISTRY.lock().unwrap();
+    let (schema, current_value) = registry
+        .get_mut(name_str)
+        .ok_or_else(|| VmError::Runtime(format!("Configuration '{}' not defined", name_str)))?;
+
+    *current_value = schema.default_value.clone();
+    Ok(Value::Unit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn create_config_schema(
+        name: &str,
+        config_type: &str,
+        default: Option<Value>,
+        validator: Option<Value>,
+    ) -> Value {
+        let mut fields = HashMap::new();
+        fields.insert("name".to_string(), Value::Str(name.to_string()));
+        fields.insert("configType".to_string(), Value::Str(config_type.to_string()));
+
+        let default_option = match default {
+            Some(val) => Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "Some".to_string(),
+                fields: vec![val],
+            },
+            None => Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "None".to_string(),
+                fields: vec![],
+            },
+        };
+        fields.insert("default".to_string(), default_option);
+
+        let validator_option = match validator {
+            Some(val) => Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "Some".to_string(),
+                fields: vec![val],
+            },
+            None => Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "None".to_string(),
+                fields: vec![],
+            },
+        };
+        fields.insert("validator".to_string(), validator_option);
+
+        Value::Record(Arc::new(Mutex::new(fields)))
+    }
+
+    fn create_config_value_string(s: &str) -> Value {
+        Value::Variant {
+            type_name: "ConfigValue".to_string(),
+            variant_name: "String".to_string(),
+            fields: vec![Value::Str(s.to_string())],
+        }
+    }
+
+    fn create_config_value_int(n: i64) -> Value {
+        Value::Variant {
+            type_name: "ConfigValue".to_string(),
+            variant_name: "Int".to_string(),
+            fields: vec![Value::Int(n)],
+        }
+    }
+
+    fn create_config_value_bool(b: bool) -> Value {
+        Value::Variant {
+            type_name: "ConfigValue".to_string(),
+            variant_name: "Bool".to_string(),
+            fields: vec![Value::Bool(b)],
+        }
+    }
+
+    fn clear_registry() {
+        CONFIG_REGISTRY.lock().unwrap().clear();
+    }
+
+    #[test]
+    fn test_config_define_simple() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema = create_config_schema(
+            "app.name",
+            "string",
+            Some(create_config_value_string("MyApp")),
+            None,
+        );
+
+        let result = config_define(&mut vm, &[schema]);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Unit);
+
+        // Verify it was registered
+        let registry = CONFIG_REGISTRY.lock().unwrap();
+        assert!(registry.contains_key("app.name"));
+    }
+
+    #[test]
+    fn test_config_define_invalid_type() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema = create_config_schema("test", "invalid_type", None, None);
+
+        let result = config_define(&mut vm, &[schema]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_get_success() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema = create_config_schema(
+            "port",
+            "int",
+            Some(create_config_value_int(8080)),
+            None,
+        );
+        config_define(&mut vm, &[schema]).unwrap();
+
+        let result = config_get(&Value::Str("port".to_string()));
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert_eq!(
+            value.variant_name().unwrap(),
+            "Int"
+        );
+    }
+
+    #[test]
+    fn test_config_get_not_found() {
+        clear_registry();
+
+        let result = config_get(&Value::Str("nonexistent".to_string()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_get_no_value_no_default() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema = create_config_schema("test", "string", None, None);
+        config_define(&mut vm, &[schema]).unwrap();
+
+        let result = config_get(&Value::Str("test".to_string()));
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_get_or_with_value() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema = create_config_schema(
+            "name",
+            "string",
+            Some(create_config_value_string("default")),
+            None,
+        );
+        config_define(&mut vm, &[schema]).unwrap();
+
+        let fallback = create_config_value_string("fallback");
+        let result = config_get_or(&Value::Str("name".to_string()), &fallback);
+        assert!(result.is_ok());
+        let value = result.unwrap();
+        assert_eq!(value.variant_name().unwrap(), "String");
+    }
+
+    #[test]
+    fn test_config_get_or_without_value() {
+        clear_registry();
+
+        let fallback = create_config_value_string("fallback");
+        let result = config_get_or(&Value::Str("nonexistent".to_string()), &fallback);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), fallback);
+    }
+
+    #[test]
+    fn test_config_has_true() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema = create_config_schema("test", "bool", None, None);
+        config_define(&mut vm, &[schema]).unwrap();
+
+        let result = config_has(&Value::Str("test".to_string()));
+        assert_eq!(result.unwrap(), Value::Bool(true));
+    }
+
+    #[test]
+    fn test_config_has_false() {
+        clear_registry();
+
+        let result = config_has(&Value::Str("nonexistent".to_string()));
+        assert_eq!(result.unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_config_list_empty() {
+        clear_registry();
+
+        let result = config_list(&Value::Unit);
+        assert_eq!(result.unwrap(), Value::Nil);
+    }
+
+    #[test]
+    fn test_config_list_with_values() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let schema1 = create_config_schema(
+            "a",
+            "int",
+            Some(create_config_value_int(1)),
+            None,
+        );
+        let schema2 = create_config_schema(
+            "b",
+            "int",
+            Some(create_config_value_int(2)),
+            None,
+        );
+        config_define(&mut vm, &[schema1]).unwrap();
+        config_define(&mut vm, &[schema2]).unwrap();
+
+        let result = config_list(&Value::Unit);
+        assert!(result.is_ok());
+        let list = result.unwrap();
+        assert!(list.is_cons());
+    }
+
+    #[test]
+    fn test_config_reset() {
+        clear_registry();
+        let mut vm = Vm::new();
+        crate::stdlib::register_stdlib(&mut vm);
+
+        let schema = create_config_schema(
+            "test",
+            "int",
+            Some(create_config_value_int(100)),
+            None,
+        );
+        config_define(&mut vm, &[schema]).unwrap();
+
+        // Set a new value
+        config_set(
+            &mut vm,
+            &[
+                Value::Str("test".to_string()),
+                create_config_value_int(200),
+            ],
+        )
+        .unwrap();
+
+        // Verify new value
+        let value = config_get(&Value::Str("test".to_string())).unwrap();
+        if let Value::Variant { fields, .. } = value {
+            assert_eq!(fields[0], Value::Int(200));
+        }
+
+        // Reset to default
+        config_reset(&Value::Str("test".to_string())).unwrap();
+
+        // Verify default value
+        let value = config_get(&Value::Str("test".to_string())).unwrap();
+        if let Value::Variant { fields, .. } = value {
+            assert_eq!(fields[0], Value::Int(100));
+        }
+    }
+
+    #[test]
+    fn test_config_type_validation_string() {
+        clear_registry();
+        let mut vm = Vm::new();
+        crate::stdlib::register_stdlib(&mut vm);
+
+        let schema = create_config_schema("test", "string", None, None);
+        config_define(&mut vm, &[schema]).unwrap();
+
+        // Valid string
+        let result = config_set(
+            &mut vm,
+            &[
+                Value::Str("test".to_string()),
+                create_config_value_string("hello"),
+            ],
+        );
+        assert!(result.is_ok());
+
+        // Invalid type (int instead of string)
+        let result = config_set(
+            &mut vm,
+            &[
+                Value::Str("test".to_string()),
+                create_config_value_int(42),
+            ],
+        );
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_config_type_validation_bool() {
+        clear_registry();
+        let mut vm = Vm::new();
+        crate::stdlib::register_stdlib(&mut vm);
+
+        let schema = create_config_schema("enabled", "bool", None, None);
+        config_define(&mut vm, &[schema]).unwrap();
+
+        // Valid bool
+        let result = config_set(
+            &mut vm,
+            &[
+                Value::Str("enabled".to_string()),
+                create_config_value_bool(true),
+            ],
+        );
+        assert!(result.is_ok());
+
+        // Invalid type
+        let result = config_set(
+            &mut vm,
+            &[
+                Value::Str("enabled".to_string()),
+                create_config_value_int(1),
+            ],
+        );
+        assert!(result.is_err());
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/process.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/process.rs
@@ -1,0 +1,566 @@
+// Fusabi Process Standard Library
+// Provides process execution and environment variable access
+//
+// SECURITY NOTE: This module executes real system commands and modifies environment variables.
+// It is designed for plugin/script runtime environments where controlled system access is desired.
+// Consider your security requirements before exposing these functions to untrusted code.
+
+use crate::value::Value;
+use crate::vm::VmError;
+use std::collections::HashMap;
+use std::process::Command;
+use std::sync::{Arc, Mutex};
+
+/// Process.run : string -> string list -> ProcessResult
+/// Runs a command with the given arguments and returns the result.
+/// The command is executed directly (not through a shell).
+///
+/// Example:
+///   Process.run "echo" ["hello"; "world"]
+///   // Returns { exitCode = 0; stdout = "hello world\n"; stderr = "" }
+pub fn process_run(cmd: &Value, args: &Value) -> Result<Value, VmError> {
+    let cmd_str = cmd.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: cmd.type_name(),
+    })?;
+
+    // Convert list to Vec<String>
+    let args_vec = list_to_string_vec(args)?;
+
+    // Execute the command
+    let output = Command::new(cmd_str)
+        .args(&args_vec)
+        .output()
+        .map_err(|e| VmError::Runtime(format!("Failed to execute command '{}': {}", cmd_str, e)))?;
+
+    // Build ProcessResult record
+    create_process_result(output.status.code().unwrap_or(-1), output.stdout, output.stderr)
+}
+
+/// Process.runShell : string -> ProcessResult
+/// Runs a shell command string and returns the result.
+/// The command is executed through the system shell (sh on Unix, cmd.exe on Windows).
+///
+/// Example:
+///   Process.runShell "echo hello | grep h"
+///   // Returns { exitCode = 0; stdout = "hello\n"; stderr = "" }
+pub fn process_run_shell(cmd: &Value) -> Result<Value, VmError> {
+    let cmd_str = cmd.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: cmd.type_name(),
+    })?;
+
+    // Execute through shell
+    #[cfg(unix)]
+    let output = Command::new("sh")
+        .arg("-c")
+        .arg(cmd_str)
+        .output()
+        .map_err(|e| VmError::Runtime(format!("Failed to execute shell command: {}", e)))?;
+
+    #[cfg(windows)]
+    let output = Command::new("cmd")
+        .arg("/C")
+        .arg(cmd_str)
+        .output()
+        .map_err(|e| VmError::Runtime(format!("Failed to execute shell command: {}", e)))?;
+
+    // Build ProcessResult record
+    create_process_result(output.status.code().unwrap_or(-1), output.stdout, output.stderr)
+}
+
+/// Process.env : string -> string option
+/// Gets an environment variable value.
+/// Returns Some(value) if the variable exists, None otherwise.
+///
+/// Example:
+///   Process.env "PATH"
+///   // Returns Some("/usr/bin:/bin:...")
+pub fn process_env(var_name: &Value) -> Result<Value, VmError> {
+    let var_name_str = var_name
+        .as_str()
+        .ok_or_else(|| VmError::TypeMismatch {
+            expected: "string",
+            got: var_name.type_name(),
+        })?;
+
+    match std::env::var(var_name_str) {
+        Ok(value) => Ok(Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Str(value)],
+        }),
+        Err(_) => Ok(Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        }),
+    }
+}
+
+/// Process.setEnv : string -> string -> unit
+/// Sets an environment variable for the current process and child processes.
+/// Note: This only affects the current process and its children, not the parent process.
+///
+/// Example:
+///   Process.setEnv "MY_VAR" "my_value"
+///   // Returns ()
+pub fn process_set_env(var_name: &Value, value: &Value) -> Result<Value, VmError> {
+    let var_name_str = var_name
+        .as_str()
+        .ok_or_else(|| VmError::TypeMismatch {
+            expected: "string",
+            got: var_name.type_name(),
+        })?;
+
+    let value_str = value.as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: value.type_name(),
+    })?;
+
+    std::env::set_var(var_name_str, value_str);
+    Ok(Value::Unit)
+}
+
+/// Process.cwd : unit -> string
+/// Gets the current working directory.
+///
+/// Example:
+///   Process.cwd ()
+///   // Returns "/home/user/project"
+pub fn process_cwd(_unit: &Value) -> Result<Value, VmError> {
+    let cwd = std::env::current_dir()
+        .map_err(|e| VmError::Runtime(format!("Failed to get current directory: {}", e)))?;
+
+    let cwd_str = cwd.to_str().ok_or_else(|| {
+        VmError::Runtime("Current directory path contains invalid Unicode".to_string())
+    })?;
+
+    Ok(Value::Str(cwd_str.to_string()))
+}
+
+// Helper functions
+
+/// Convert a Fusabi list to Vec<String>, validating that all elements are strings
+fn list_to_string_vec(list: &Value) -> Result<Vec<String>, VmError> {
+    let mut result = Vec::new();
+    let mut current = list.clone();
+
+    loop {
+        match current {
+            Value::Nil => break,
+            Value::Cons { head, tail } => {
+                let arg_str = head.as_str().ok_or_else(|| VmError::TypeMismatch {
+                    expected: "string list",
+                    got: "list with non-string elements",
+                })?;
+                result.push(arg_str.to_string());
+                current = (*tail).clone();
+            }
+            _ => {
+                return Err(VmError::TypeMismatch {
+                    expected: "list",
+                    got: current.type_name(),
+                })
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Create a ProcessResult record from exit code and output
+fn create_process_result(exit_code: i32, stdout: Vec<u8>, stderr: Vec<u8>) -> Result<Value, VmError> {
+    let stdout_str = String::from_utf8(stdout).unwrap_or_else(|e| {
+        // If stdout is not valid UTF-8, replace invalid sequences
+        String::from_utf8_lossy(&e.into_bytes()).to_string()
+    });
+
+    let stderr_str = String::from_utf8(stderr).unwrap_or_else(|e| {
+        // If stderr is not valid UTF-8, replace invalid sequences
+        String::from_utf8_lossy(&e.into_bytes()).to_string()
+    });
+
+    let mut fields = HashMap::new();
+    fields.insert("exitCode".to_string(), Value::Int(exit_code as i64));
+    fields.insert("stdout".to_string(), Value::Str(stdout_str));
+    fields.insert("stderr".to_string(), Value::Str(stderr_str));
+
+    Ok(Value::Record(Arc::new(Mutex::new(fields))))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_process_run_echo() {
+        let cmd = Value::Str("echo".to_string());
+        let args = Value::vec_to_cons(vec![Value::Str("hello".to_string())]);
+        let result = process_run(&cmd, &args).unwrap();
+
+        // Verify it's a record
+        assert!(result.is_record());
+
+        // Check exit code
+        let exit_code = result.record_get("exitCode").unwrap();
+        assert_eq!(exit_code, Value::Int(0));
+
+        // Check stdout contains "hello"
+        let stdout = result.record_get("stdout").unwrap();
+        if let Value::Str(s) = stdout {
+            assert!(s.contains("hello"));
+        } else {
+            panic!("stdout should be a string");
+        }
+
+        // Check stderr is empty
+        let stderr = result.record_get("stderr").unwrap();
+        assert_eq!(stderr, Value::Str("".to_string()));
+    }
+
+    #[test]
+    fn test_process_run_multiple_args() {
+        let cmd = Value::Str("echo".to_string());
+        let args = Value::vec_to_cons(vec![
+            Value::Str("hello".to_string()),
+            Value::Str("world".to_string()),
+        ]);
+        let result = process_run(&cmd, &args).unwrap();
+
+        let exit_code = result.record_get("exitCode").unwrap();
+        assert_eq!(exit_code, Value::Int(0));
+
+        let stdout = result.record_get("stdout").unwrap();
+        if let Value::Str(s) = stdout {
+            assert!(s.contains("hello"));
+            assert!(s.contains("world"));
+        } else {
+            panic!("stdout should be a string");
+        }
+    }
+
+    #[test]
+    fn test_process_run_empty_args() {
+        let cmd = Value::Str("pwd".to_string());
+        let args = Value::Nil;
+        let result = process_run(&cmd, &args).unwrap();
+
+        let exit_code = result.record_get("exitCode").unwrap();
+        assert_eq!(exit_code, Value::Int(0));
+
+        let stdout = result.record_get("stdout").unwrap();
+        if let Value::Str(s) = stdout {
+            assert!(!s.is_empty());
+        } else {
+            panic!("stdout should be a string");
+        }
+    }
+
+    #[test]
+    fn test_process_run_command_not_found() {
+        let cmd = Value::Str("this_command_does_not_exist_12345".to_string());
+        let args = Value::Nil;
+        let result = process_run(&cmd, &args);
+
+        assert!(result.is_err());
+        if let Err(VmError::Runtime(msg)) = result {
+            assert!(msg.contains("Failed to execute command"));
+        } else {
+            panic!("Expected Runtime error");
+        }
+    }
+
+    #[test]
+    fn test_process_run_type_error_cmd() {
+        let cmd = Value::Int(42);
+        let args = Value::Nil;
+        let result = process_run(&cmd, &args);
+
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_process_run_type_error_args() {
+        let cmd = Value::Str("echo".to_string());
+        let args = Value::Int(42);
+        let result = process_run(&cmd, &args);
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_process_run_args_not_strings() {
+        let cmd = Value::Str("echo".to_string());
+        let args = Value::vec_to_cons(vec![Value::Int(42)]);
+        let result = process_run(&cmd, &args);
+
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, .. }) = result {
+            assert_eq!(expected, "string list");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_process_run_shell_basic() {
+        let cmd = Value::Str("echo hello".to_string());
+        let result = process_run_shell(&cmd).unwrap();
+
+        let exit_code = result.record_get("exitCode").unwrap();
+        assert_eq!(exit_code, Value::Int(0));
+
+        let stdout = result.record_get("stdout").unwrap();
+        if let Value::Str(s) = stdout {
+            assert!(s.contains("hello"));
+        } else {
+            panic!("stdout should be a string");
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_process_run_shell_pipe() {
+        let cmd = Value::Str("echo hello | grep hello".to_string());
+        let result = process_run_shell(&cmd).unwrap();
+
+        let exit_code = result.record_get("exitCode").unwrap();
+        assert_eq!(exit_code, Value::Int(0));
+
+        let stdout = result.record_get("stdout").unwrap();
+        if let Value::Str(s) = stdout {
+            assert!(s.contains("hello"));
+        } else {
+            panic!("stdout should be a string");
+        }
+    }
+
+    #[test]
+    fn test_process_run_shell_type_error() {
+        let cmd = Value::Int(42);
+        let result = process_run_shell(&cmd);
+
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_process_env_existing() {
+        // Set a test environment variable
+        std::env::set_var("FUSABI_TEST_VAR", "test_value");
+
+        let var_name = Value::Str("FUSABI_TEST_VAR".to_string());
+        let result = process_env(&var_name).unwrap();
+
+        assert!(result.is_variant());
+        assert!(result.is_variant_named("Some"));
+
+        let fields = result.variant_fields().unwrap();
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0], Value::Str("test_value".to_string()));
+
+        // Clean up
+        std::env::remove_var("FUSABI_TEST_VAR");
+    }
+
+    #[test]
+    fn test_process_env_nonexistent() {
+        let var_name = Value::Str("THIS_VAR_DOES_NOT_EXIST_12345".to_string());
+        let result = process_env(&var_name).unwrap();
+
+        assert!(result.is_variant());
+        assert!(result.is_variant_named("None"));
+
+        let fields = result.variant_fields().unwrap();
+        assert_eq!(fields.len(), 0);
+    }
+
+    #[test]
+    fn test_process_env_type_error() {
+        let var_name = Value::Int(42);
+        let result = process_env(&var_name);
+
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_process_set_env() {
+        let var_name = Value::Str("FUSABI_TEST_SET_VAR".to_string());
+        let value = Value::Str("test_set_value".to_string());
+        let result = process_set_env(&var_name, &value).unwrap();
+
+        assert_eq!(result, Value::Unit);
+
+        // Verify the variable was set
+        assert_eq!(
+            std::env::var("FUSABI_TEST_SET_VAR").unwrap(),
+            "test_set_value"
+        );
+
+        // Clean up
+        std::env::remove_var("FUSABI_TEST_SET_VAR");
+    }
+
+    #[test]
+    fn test_process_set_env_type_error_name() {
+        let var_name = Value::Int(42);
+        let value = Value::Str("value".to_string());
+        let result = process_set_env(&var_name, &value);
+
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_process_set_env_type_error_value() {
+        let var_name = Value::Str("TEST_VAR".to_string());
+        let value = Value::Int(42);
+        let result = process_set_env(&var_name, &value);
+
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_process_cwd() {
+        let unit = Value::Unit;
+        let result = process_cwd(&unit).unwrap();
+
+        if let Value::Str(s) = result {
+            // Should be a non-empty path
+            assert!(!s.is_empty());
+            // Should be an absolute path
+            assert!(s.starts_with('/') || s.chars().nth(1) == Some(':'));
+        } else {
+            panic!("cwd should return a string");
+        }
+    }
+
+    #[test]
+    fn test_list_to_string_vec_empty() {
+        let list = Value::Nil;
+        let result = list_to_string_vec(&list).unwrap();
+        assert_eq!(result, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_list_to_string_vec_single() {
+        let list = Value::vec_to_cons(vec![Value::Str("hello".to_string())]);
+        let result = list_to_string_vec(&list).unwrap();
+        assert_eq!(result, vec!["hello".to_string()]);
+    }
+
+    #[test]
+    fn test_list_to_string_vec_multiple() {
+        let list = Value::vec_to_cons(vec![
+            Value::Str("one".to_string()),
+            Value::Str("two".to_string()),
+            Value::Str("three".to_string()),
+        ]);
+        let result = list_to_string_vec(&list).unwrap();
+        assert_eq!(
+            result,
+            vec![
+                "one".to_string(),
+                "two".to_string(),
+                "three".to_string()
+            ]
+        );
+    }
+
+    #[test]
+    fn test_list_to_string_vec_non_string() {
+        let list = Value::vec_to_cons(vec![Value::Int(42)]);
+        let result = list_to_string_vec(&list);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_list_to_string_vec_not_list() {
+        let not_list = Value::Int(42);
+        let result = list_to_string_vec(&not_list);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_create_process_result() {
+        let exit_code = 0;
+        let stdout = b"hello world".to_vec();
+        let stderr = b"".to_vec();
+
+        let result = create_process_result(exit_code, stdout, stderr).unwrap();
+
+        assert!(result.is_record());
+        assert_eq!(result.record_get("exitCode").unwrap(), Value::Int(0));
+        assert_eq!(
+            result.record_get("stdout").unwrap(),
+            Value::Str("hello world".to_string())
+        );
+        assert_eq!(
+            result.record_get("stderr").unwrap(),
+            Value::Str("".to_string())
+        );
+    }
+
+    #[test]
+    fn test_create_process_result_with_stderr() {
+        let exit_code = 1;
+        let stdout = b"".to_vec();
+        let stderr = b"error occurred".to_vec();
+
+        let result = create_process_result(exit_code, stdout, stderr).unwrap();
+
+        assert_eq!(result.record_get("exitCode").unwrap(), Value::Int(1));
+        assert_eq!(
+            result.record_get("stdout").unwrap(),
+            Value::Str("".to_string())
+        );
+        assert_eq!(
+            result.record_get("stderr").unwrap(),
+            Value::Str("error occurred".to_string())
+        );
+    }
+
+    #[test]
+    fn test_create_process_result_invalid_utf8() {
+        let exit_code = 0;
+        // Invalid UTF-8 sequence
+        let stdout = vec![0xFF, 0xFE, 0xFD];
+        let stderr = vec![];
+
+        let result = create_process_result(exit_code, stdout, stderr).unwrap();
+
+        assert!(result.is_record());
+        // Should have replaced invalid sequences with � or similar
+        let stdout_val = result.record_get("stdout").unwrap();
+        assert!(stdout_val.as_str().is_some());
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/time.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/time.rs
@@ -1,0 +1,686 @@
+// Fusabi Time Standard Library
+// Provides time-related functions for working with timestamps and time formatting
+
+use crate::value::Value;
+use crate::vm::VmError;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+// ============================================================================
+// Time Functions
+// ============================================================================
+
+/// Time.now : unit -> int
+/// Returns the current Unix timestamp in milliseconds since the epoch
+pub fn time_now(_unit: &Value) -> Result<Value, VmError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| Value::Int(duration.as_millis() as i64))
+        .map_err(|e| VmError::Runtime(format!("Failed to get current time: {}", e)))
+}
+
+/// Time.nowSeconds : unit -> int
+/// Returns the current Unix timestamp in seconds since the epoch
+pub fn time_now_seconds(_unit: &Value) -> Result<Value, VmError> {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|duration| Value::Int(duration.as_secs() as i64))
+        .map_err(|e| VmError::Runtime(format!("Failed to get current time: {}", e)))
+}
+
+/// Time.format : string -> int -> string
+/// Formats a Unix timestamp (in milliseconds) according to a format string
+///
+/// Supported format specifiers:
+/// - %Y - Year (4 digits)
+/// - %m - Month (01-12)
+/// - %d - Day of month (01-31)
+/// - %H - Hour (00-23)
+/// - %M - Minute (00-59)
+/// - %S - Second (00-59)
+/// - %% - Literal '%'
+///
+/// Example: Time.format "%Y-%m-%d %H:%M:%S" timestamp
+pub fn time_format(format_str: &Value, timestamp: &Value) -> Result<Value, VmError> {
+    let fmt = match format_str {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: format_str.type_name(),
+            })
+        }
+    };
+
+    let timestamp_ms = match timestamp {
+        Value::Int(ts) => *ts,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int",
+                got: timestamp.type_name(),
+            })
+        }
+    };
+
+    // Convert milliseconds to seconds for SystemTime
+    let timestamp_secs = timestamp_ms / 1000;
+    let _timestamp_millis = (timestamp_ms % 1000) as u32; // Reserved for future millisecond formatting
+
+    // Create SystemTime from timestamp
+    let system_time = if timestamp_secs >= 0 {
+        UNIX_EPOCH
+            .checked_add(std::time::Duration::from_secs(timestamp_secs as u64))
+            .ok_or_else(|| VmError::Runtime("Timestamp overflow".to_string()))?
+    } else {
+        let abs_secs = timestamp_secs.unsigned_abs();
+        UNIX_EPOCH
+            .checked_sub(std::time::Duration::from_secs(abs_secs))
+            .ok_or_else(|| VmError::Runtime("Timestamp underflow".to_string()))?
+    };
+
+    // Convert to calendar time (simplified UTC calculation)
+    let duration = system_time
+        .duration_since(UNIX_EPOCH)
+        .map_err(|_| VmError::Runtime("Invalid timestamp".to_string()))?;
+
+    let total_seconds = duration.as_secs();
+    let days_since_epoch = total_seconds / 86400;
+    let seconds_today = total_seconds % 86400;
+
+    let hours = (seconds_today / 3600) as u32;
+    let minutes = ((seconds_today % 3600) / 60) as u32;
+    let seconds = (seconds_today % 60) as u32;
+
+    // Simple calendar calculation (approximation for demonstration)
+    // This is a simplified algorithm that works for most modern dates
+    let mut year = 1970;
+    let mut days_remaining = days_since_epoch;
+
+    loop {
+        let days_in_year = if is_leap_year(year) { 366 } else { 365 };
+        if days_remaining < days_in_year {
+            break;
+        }
+        days_remaining -= days_in_year;
+        year += 1;
+    }
+
+    let (month, day) = days_to_month_day(days_remaining as u32, is_leap_year(year));
+
+    // Format the string
+    let mut result = String::new();
+    let mut chars = fmt.chars().peekable();
+
+    while let Some(ch) = chars.next() {
+        if ch == '%' {
+            if let Some(&next_ch) = chars.peek() {
+                match next_ch {
+                    '%' => {
+                        result.push('%');
+                        chars.next();
+                    }
+                    'Y' => {
+                        result.push_str(&format!("{:04}", year));
+                        chars.next();
+                    }
+                    'm' => {
+                        result.push_str(&format!("{:02}", month));
+                        chars.next();
+                    }
+                    'd' => {
+                        result.push_str(&format!("{:02}", day));
+                        chars.next();
+                    }
+                    'H' => {
+                        result.push_str(&format!("{:02}", hours));
+                        chars.next();
+                    }
+                    'M' => {
+                        result.push_str(&format!("{:02}", minutes));
+                        chars.next();
+                    }
+                    'S' => {
+                        result.push_str(&format!("{:02}", seconds));
+                        chars.next();
+                    }
+                    _ => {
+                        return Err(VmError::Runtime(format!(
+                            "Unknown time format specifier: %{}",
+                            next_ch
+                        )))
+                    }
+                }
+            } else {
+                return Err(VmError::Runtime(
+                    "Incomplete format specifier at end of string".to_string(),
+                ));
+            }
+        } else {
+            result.push(ch);
+        }
+    }
+
+    Ok(Value::Str(result))
+}
+
+/// Time.parse : string -> string -> int option
+/// Parses a time string according to a format string, returning Some timestamp or None
+///
+/// Supported format specifiers:
+/// - %Y - Year (4 digits)
+/// - %m - Month (01-12)
+/// - %d - Day of month (01-31)
+/// - %H - Hour (00-23)
+/// - %M - Minute (00-59)
+/// - %S - Second (00-59)
+///
+/// Example: Time.parse "%Y-%m-%d" "2024-03-15"
+pub fn time_parse(format_str: &Value, time_str: &Value) -> Result<Value, VmError> {
+    let fmt = match format_str {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: format_str.type_name(),
+            })
+        }
+    };
+
+    let input = match time_str {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: time_str.type_name(),
+            })
+        }
+    };
+
+    // Parse the format string and extract values
+    let parse_result = parse_time_string(fmt, input);
+
+    match parse_result {
+        Ok((year, month, day, hour, minute, second)) => {
+            // Validate parsed values
+            if month < 1 || month > 12 {
+                return Ok(create_none());
+            }
+            if day < 1 || day > days_in_month(month, is_leap_year(year as i64)) {
+                return Ok(create_none());
+            }
+            if hour > 23 || minute > 59 || second > 59 {
+                return Ok(create_none());
+            }
+
+            // Convert to Unix timestamp
+            match calculate_timestamp(year, month, day, hour, minute, second) {
+                Ok(timestamp) => Ok(create_some(Value::Int(timestamp))),
+                Err(_) => Ok(create_none()),
+            }
+        }
+        Err(_) => Ok(create_none()),
+    }
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+fn is_leap_year(year: i64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0)
+}
+
+fn days_in_month(month: u32, leap_year: bool) -> u32 {
+    match month {
+        1 | 3 | 5 | 7 | 8 | 10 | 12 => 31,
+        4 | 6 | 9 | 11 => 30,
+        2 => if leap_year { 29 } else { 28 },
+        _ => 0,
+    }
+}
+
+fn days_to_month_day(mut days: u32, leap_year: bool) -> (u32, u32) {
+    for month in 1..=12 {
+        let days_in_this_month = days_in_month(month, leap_year);
+        if days < days_in_this_month {
+            return (month, days + 1);
+        }
+        days -= days_in_this_month;
+    }
+    (12, 31) // Fallback
+}
+
+fn calculate_timestamp(
+    year: i32,
+    month: u32,
+    day: u32,
+    hour: u32,
+    minute: u32,
+    second: u32,
+) -> Result<i64, String> {
+    // Calculate days since epoch (1970-01-01)
+    if year < 1970 {
+        return Err("Year before 1970 not supported".to_string());
+    }
+
+    let mut days = 0i64;
+
+    // Add days for complete years
+    for y in 1970..year {
+        days += if is_leap_year(y as i64) { 366 } else { 365 };
+    }
+
+    // Add days for complete months in current year
+    for m in 1..month {
+        days += days_in_month(m, is_leap_year(year as i64)) as i64;
+    }
+
+    // Add remaining days
+    days += (day - 1) as i64;
+
+    // Convert to milliseconds
+    let total_seconds = days * 86400 + hour as i64 * 3600 + minute as i64 * 60 + second as i64;
+    Ok(total_seconds * 1000)
+}
+
+fn parse_time_string(format: &str, input: &str) -> Result<(i32, u32, u32, u32, u32, u32), String> {
+    let mut year = 1970i32;
+    let mut month = 1u32;
+    let mut day = 1u32;
+    let mut hour = 0u32;
+    let mut minute = 0u32;
+    let mut second = 0u32;
+
+    let mut fmt_chars = format.chars().peekable();
+    let mut input_chars = input.chars().peekable();
+
+    while let Some(fmt_ch) = fmt_chars.next() {
+        if fmt_ch == '%' {
+            if let Some(&specifier) = fmt_chars.peek() {
+                fmt_chars.next(); // consume specifier
+
+                match specifier {
+                    'Y' => {
+                        // Read 4 digits
+                        let mut year_str = String::new();
+                        for _ in 0..4 {
+                            if let Some(&ch) = input_chars.peek() {
+                                if ch.is_ascii_digit() {
+                                    year_str.push(ch);
+                                    input_chars.next();
+                                } else {
+                                    return Err("Expected digit for year".to_string());
+                                }
+                            } else {
+                                return Err("Unexpected end of input".to_string());
+                            }
+                        }
+                        year = year_str.parse().map_err(|_| "Invalid year".to_string())?;
+                    }
+                    'm' => {
+                        month = parse_two_digits(&mut input_chars)?;
+                    }
+                    'd' => {
+                        day = parse_two_digits(&mut input_chars)?;
+                    }
+                    'H' => {
+                        hour = parse_two_digits(&mut input_chars)?;
+                    }
+                    'M' => {
+                        minute = parse_two_digits(&mut input_chars)?;
+                    }
+                    'S' => {
+                        second = parse_two_digits(&mut input_chars)?;
+                    }
+                    _ => {
+                        return Err(format!("Unknown format specifier: %{}", specifier));
+                    }
+                }
+            } else {
+                return Err("Incomplete format specifier".to_string());
+            }
+        } else {
+            // Match literal character
+            if let Some(&input_ch) = input_chars.peek() {
+                if input_ch == fmt_ch {
+                    input_chars.next();
+                } else {
+                    return Err(format!("Expected '{}', got '{}'", fmt_ch, input_ch));
+                }
+            } else {
+                return Err("Unexpected end of input".to_string());
+            }
+        }
+    }
+
+    Ok((year, month, day, hour, minute, second))
+}
+
+fn parse_two_digits(chars: &mut std::iter::Peekable<std::str::Chars>) -> Result<u32, String> {
+    let mut num_str = String::new();
+    for _ in 0..2 {
+        if let Some(&ch) = chars.peek() {
+            if ch.is_ascii_digit() {
+                num_str.push(ch);
+                chars.next();
+            } else {
+                return Err("Expected digit".to_string());
+            }
+        } else {
+            return Err("Unexpected end of input".to_string());
+        }
+    }
+    num_str.parse().map_err(|_| "Invalid number".to_string())
+}
+
+fn create_some(value: Value) -> Value {
+    Value::Variant {
+        type_name: "Option".to_string(),
+        variant_name: "Some".to_string(),
+        fields: vec![value],
+    }
+}
+
+fn create_none() -> Value {
+    Value::Variant {
+        type_name: "Option".to_string(),
+        variant_name: "None".to_string(),
+        fields: vec![],
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_time_now() {
+        let unit = Value::Variant {
+            type_name: "Unit".to_string(),
+            variant_name: "()".to_string(),
+            fields: vec![],
+        };
+
+        let result = time_now(&unit).unwrap();
+        match result {
+            Value::Int(ts) => {
+                // Timestamp should be a reasonable value (after 2020-01-01 and before 2100-01-01)
+                assert!(ts > 1577836800000); // 2020-01-01 in ms
+                assert!(ts < 4102444800000); // 2100-01-01 in ms
+            }
+            _ => panic!("Expected Int, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_time_now_seconds() {
+        let unit = Value::Variant {
+            type_name: "Unit".to_string(),
+            variant_name: "()".to_string(),
+            fields: vec![],
+        };
+
+        let result = time_now_seconds(&unit).unwrap();
+        match result {
+            Value::Int(ts) => {
+                // Timestamp should be a reasonable value (after 2020-01-01 and before 2100-01-01)
+                assert!(ts > 1577836800); // 2020-01-01 in seconds
+                assert!(ts < 4102444800); // 2100-01-01 in seconds
+            }
+            _ => panic!("Expected Int, got {:?}", result),
+        }
+    }
+
+    #[test]
+    fn test_time_now_vs_now_seconds() {
+        let unit = Value::Variant {
+            type_name: "Unit".to_string(),
+            variant_name: "()".to_string(),
+            fields: vec![],
+        };
+
+        let ms_result = time_now(&unit).unwrap();
+        let s_result = time_now_seconds(&unit).unwrap();
+
+        if let (Value::Int(ms), Value::Int(s)) = (ms_result, s_result) {
+            // The millisecond timestamp divided by 1000 should be close to the second timestamp
+            let ms_in_seconds = ms / 1000;
+            assert!((ms_in_seconds - s).abs() <= 1); // Allow 1 second difference
+        } else {
+            panic!("Expected Int values");
+        }
+    }
+
+    #[test]
+    fn test_time_format_basic() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        // 2024-03-15 00:00:00 UTC = 1710460800000 ms
+        let timestamp = Value::Int(1710460800000);
+
+        let result = time_format(&fmt, &timestamp).unwrap();
+        assert_eq!(result, Value::Str("2024-03-15".to_string()));
+    }
+
+    #[test]
+    fn test_time_format_with_time() {
+        let fmt = Value::Str("%Y-%m-%d %H:%M:%S".to_string());
+        // 2024-03-15 14:30:45 UTC = 1710513045000 ms
+        let timestamp = Value::Int(1710513045000);
+
+        let result = time_format(&fmt, &timestamp).unwrap();
+        assert_eq!(result, Value::Str("2024-03-15 14:30:45".to_string()));
+    }
+
+    #[test]
+    fn test_time_format_epoch() {
+        let fmt = Value::Str("%Y-%m-%d %H:%M:%S".to_string());
+        let timestamp = Value::Int(0); // Unix epoch
+
+        let result = time_format(&fmt, &timestamp).unwrap();
+        assert_eq!(result, Value::Str("1970-01-01 00:00:00".to_string()));
+    }
+
+    #[test]
+    fn test_time_format_literal_percent() {
+        let fmt = Value::Str("Date: %Y-%m-%d %%".to_string());
+        let timestamp = Value::Int(1710460800000);
+
+        let result = time_format(&fmt, &timestamp).unwrap();
+        assert_eq!(result, Value::Str("Date: 2024-03-15 %".to_string()));
+    }
+
+    #[test]
+    fn test_time_format_invalid_format_string() {
+        let fmt = Value::Int(42);
+        let timestamp = Value::Int(1710460800000);
+
+        let result = time_format(&fmt, &timestamp);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_time_format_invalid_timestamp() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let timestamp = Value::Str("not a number".to_string());
+
+        let result = time_format(&fmt, &timestamp);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_time_format_unknown_specifier() {
+        let fmt = Value::Str("%Y-%m-%d %X".to_string());
+        let timestamp = Value::Int(1710460800000);
+
+        let result = time_format(&fmt, &timestamp);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_time_parse_basic() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let input = Value::Str("2024-03-15".to_string());
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+                // 2024-03-15 00:00:00 UTC = 1710460800000 ms
+                assert_eq!(fields[0], Value::Int(1710460800000));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_with_time() {
+        let fmt = Value::Str("%Y-%m-%d %H:%M:%S".to_string());
+        let input = Value::Str("2024-03-15 14:30:45".to_string());
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+                // 2024-03-15 14:30:45 UTC = 1710513045000 ms
+                assert_eq!(fields[0], Value::Int(1710513045000));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_epoch() {
+        let fmt = Value::Str("%Y-%m-%d %H:%M:%S".to_string());
+        let input = Value::Str("1970-01-01 00:00:00".to_string());
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0], Value::Int(0));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_invalid_month() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let input = Value::Str("2024-13-15".to_string());
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_invalid_day() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let input = Value::Str("2024-02-30".to_string()); // February doesn't have 30 days
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_malformed_input() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let input = Value::Str("not-a-date".to_string());
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_format_mismatch() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let input = Value::Str("2024/03/15".to_string()); // Wrong separator
+
+        let result = time_parse(&fmt, &input).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_time_parse_invalid_format_string() {
+        let fmt = Value::Int(42);
+        let input = Value::Str("2024-03-15".to_string());
+
+        let result = time_parse(&fmt, &input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_time_parse_invalid_input_type() {
+        let fmt = Value::Str("%Y-%m-%d".to_string());
+        let input = Value::Int(42);
+
+        let result = time_parse(&fmt, &input);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_is_leap_year() {
+        assert!(is_leap_year(2000)); // Divisible by 400
+        assert!(is_leap_year(2004)); // Divisible by 4, not by 100
+        assert!(!is_leap_year(1900)); // Divisible by 100, not by 400
+        assert!(!is_leap_year(2001)); // Not divisible by 4
+        assert!(is_leap_year(2024));
+    }
+
+    #[test]
+    fn test_days_in_month() {
+        assert_eq!(days_in_month(1, false), 31);
+        assert_eq!(days_in_month(2, false), 28);
+        assert_eq!(days_in_month(2, true), 29);
+        assert_eq!(days_in_month(4, false), 30);
+        assert_eq!(days_in_month(12, false), 31);
+    }
+
+    #[test]
+    fn test_time_roundtrip() {
+        let fmt = Value::Str("%Y-%m-%d %H:%M:%S".to_string());
+        let timestamp = Value::Int(1710512645000);
+
+        // Format timestamp to string
+        let formatted = time_format(&fmt, &timestamp).unwrap();
+
+        // Parse string back to timestamp
+        let parsed = time_parse(&fmt, &formatted).unwrap();
+
+        match parsed {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields[0], timestamp);
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/url.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/url.rs
@@ -1,0 +1,740 @@
+// Fusabi Url Standard Library
+// Provides URL parsing and encoding/decoding functionality
+
+use crate::value::Value;
+use crate::vm::VmError;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Url.parse : string -> UrlInfo option
+/// Parses a URL string into its components
+/// Returns None if the URL is invalid
+pub fn url_parse(url_str: &Value) -> Result<Value, VmError> {
+    let url = match url_str {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: url_str.type_name(),
+            })
+        }
+    };
+
+    match parse_url_internal(url) {
+        Some(url_info) => {
+            // Return Some(UrlInfo)
+            Ok(Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "Some".to_string(),
+                fields: vec![url_info],
+            })
+        }
+        None => {
+            // Return None
+            Ok(Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "None".to_string(),
+                fields: vec![],
+            })
+        }
+    }
+}
+
+/// Url.isValid : string -> bool
+/// Check if a string is a valid URL
+pub fn url_is_valid(url_str: &Value) -> Result<Value, VmError> {
+    let url = match url_str {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: url_str.type_name(),
+            })
+        }
+    };
+
+    Ok(Value::Bool(parse_url_internal(url).is_some()))
+}
+
+/// Url.encode : string -> string
+/// URL-encode a string (percent encoding)
+pub fn url_encode(s: &Value) -> Result<Value, VmError> {
+    let string = match s {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: s.type_name(),
+            })
+        }
+    };
+
+    let encoded = percent_encode(string);
+    Ok(Value::Str(encoded))
+}
+
+/// Url.decode : string -> string option
+/// URL-decode a string (percent decoding)
+/// Returns None if the string contains invalid percent encoding
+pub fn url_decode(s: &Value) -> Result<Value, VmError> {
+    let string = match s {
+        Value::Str(s) => s,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "string",
+                got: s.type_name(),
+            })
+        }
+    };
+
+    match percent_decode(string) {
+        Some(decoded) => Ok(Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Str(decoded)],
+        }),
+        None => Ok(Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        }),
+    }
+}
+
+// Internal helper functions
+
+/// UrlInfo record type
+/// Contains: scheme, host, port (option), path, query (option), fragment (option)
+fn create_url_info(
+    scheme: String,
+    host: String,
+    port: Option<i64>,
+    path: String,
+    query: Option<String>,
+    fragment: Option<String>,
+) -> Value {
+    let mut fields = HashMap::new();
+
+    fields.insert("scheme".to_string(), Value::Str(scheme));
+    fields.insert("host".to_string(), Value::Str(host));
+
+    // port: int option
+    let port_value = match port {
+        Some(p) => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Int(p)],
+        },
+        None => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        },
+    };
+    fields.insert("port".to_string(), port_value);
+
+    fields.insert("path".to_string(), Value::Str(path));
+
+    // query: string option
+    let query_value = match query {
+        Some(q) => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Str(q)],
+        },
+        None => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        },
+    };
+    fields.insert("query".to_string(), query_value);
+
+    // fragment: string option
+    let fragment_value = match fragment {
+        Some(f) => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Str(f)],
+        },
+        None => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        },
+    };
+    fields.insert("fragment".to_string(), fragment_value);
+
+    Value::Record(Arc::new(Mutex::new(fields)))
+}
+
+/// Parse URL string into components
+/// Returns None if URL is invalid
+fn parse_url_internal(url: &str) -> Option<Value> {
+    // Basic URL parsing: scheme://host[:port][/path][?query][#fragment]
+
+    // Empty URL is invalid
+    if url.is_empty() {
+        return None;
+    }
+
+    let mut remaining = url;
+
+    // 1. Parse scheme
+    let scheme_end = remaining.find("://")?;
+    let scheme = remaining[..scheme_end].to_string();
+
+    // Validate scheme (must be alphanumeric with +, -, .)
+    if !is_valid_scheme(&scheme) {
+        return None;
+    }
+
+    remaining = &remaining[scheme_end + 3..];
+
+    // 2. Extract fragment first (if present)
+    let (remaining, fragment) = if let Some(hash_pos) = remaining.find('#') {
+        let frag = remaining[hash_pos + 1..].to_string();
+        (&remaining[..hash_pos], Some(frag))
+    } else {
+        (remaining, None)
+    };
+
+    // 3. Extract query (if present)
+    let (remaining, query) = if let Some(question_pos) = remaining.find('?') {
+        let q = remaining[question_pos + 1..].to_string();
+        (&remaining[..question_pos], Some(q))
+    } else {
+        (remaining, None)
+    };
+
+    // 4. Extract path (if present)
+    let (authority, path) = if let Some(slash_pos) = remaining.find('/') {
+        let p = remaining[slash_pos..].to_string();
+        (&remaining[..slash_pos], p)
+    } else {
+        (remaining, "/".to_string())
+    };
+
+    // 5. Parse authority (host[:port])
+    let (host, port) = if let Some(colon_pos) = authority.rfind(':') {
+        // Check if this colon is for port (not part of IPv6 address)
+        // Simple heuristic: if there's a [ before ], it's IPv6
+        let has_ipv6_bracket = authority.contains('[');
+
+        if has_ipv6_bracket {
+            // IPv6 address - only parse port if colon comes after ]
+            if let Some(bracket_pos) = authority.rfind(']') {
+                if colon_pos > bracket_pos {
+                    // Port after IPv6 address
+                    let h = authority[..colon_pos].to_string();
+                    let port_str = &authority[colon_pos + 1..];
+                    match port_str.parse::<i64>() {
+                        Ok(p) if p > 0 && p <= 65535 => (h, Some(p)),
+                        _ => return None, // Invalid port
+                    }
+                } else {
+                    // Colon is part of IPv6 address
+                    (authority.to_string(), None)
+                }
+            } else {
+                // Malformed IPv6
+                return None;
+            }
+        } else {
+            // Regular host with port
+            let h = authority[..colon_pos].to_string();
+            let port_str = &authority[colon_pos + 1..];
+            match port_str.parse::<i64>() {
+                Ok(p) if p > 0 && p <= 65535 => (h, Some(p)),
+                _ => return None, // Invalid port
+            }
+        }
+    } else {
+        (authority.to_string(), None)
+    };
+
+    // Validate host is not empty
+    if host.is_empty() {
+        return None;
+    }
+
+    Some(create_url_info(scheme, host, port, path, query, fragment))
+}
+
+/// Check if scheme is valid (alphanumeric with +, -, .)
+fn is_valid_scheme(scheme: &str) -> bool {
+    if scheme.is_empty() {
+        return false;
+    }
+
+    // First character must be alphabetic
+    let mut chars = scheme.chars();
+    if let Some(first) = chars.next() {
+        if !first.is_ascii_alphabetic() {
+            return false;
+        }
+    } else {
+        return false;
+    }
+
+    // Remaining characters can be alphanumeric or +, -, .
+    for c in chars {
+        if !c.is_ascii_alphanumeric() && c != '+' && c != '-' && c != '.' {
+            return false;
+        }
+    }
+
+    true
+}
+
+/// Percent-encode a string for use in URLs
+/// Encodes all characters except unreserved: A-Z a-z 0-9 - _ . ~
+fn percent_encode(s: &str) -> String {
+    let mut result = String::with_capacity(s.len() * 3);
+
+    for byte in s.bytes() {
+        match byte {
+            // Unreserved characters (RFC 3986)
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            // Everything else gets percent-encoded
+            _ => {
+                result.push('%');
+                result.push_str(&format!("{:02X}", byte));
+            }
+        }
+    }
+
+    result
+}
+
+/// Percent-decode a URL-encoded string
+/// Returns None if the string contains invalid percent encoding
+fn percent_decode(s: &str) -> Option<String> {
+    let mut result = Vec::new();
+    let bytes = s.as_bytes();
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == b'%' {
+            // Need at least 2 more characters
+            if i + 2 >= bytes.len() {
+                return None;
+            }
+
+            // Parse hex digits
+            let hex_str = std::str::from_utf8(&bytes[i + 1..i + 3]).ok()?;
+            let decoded_byte = u8::from_str_radix(hex_str, 16).ok()?;
+            result.push(decoded_byte);
+            i += 3;
+        } else {
+            result.push(bytes[i]);
+            i += 1;
+        }
+    }
+
+    // Convert bytes to UTF-8 string
+    String::from_utf8(result).ok()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_url_parse_simple() {
+        let url = Value::Str("https://example.com".to_string());
+        let result = url_parse(&url).unwrap();
+
+        // Should be Some(UrlInfo)
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+
+                // Check the UrlInfo record
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert_eq!(r.get("scheme"), Some(&Value::Str("https".to_string())));
+                    assert_eq!(r.get("host"), Some(&Value::Str("example.com".to_string())));
+                    assert_eq!(r.get("path"), Some(&Value::Str("/".to_string())));
+
+                    // port should be None
+                    if let Some(Value::Variant { variant_name, .. }) = r.get("port") {
+                        assert_eq!(variant_name, "None");
+                    } else {
+                        panic!("port field missing or wrong type");
+                    }
+                } else {
+                    panic!("Expected Record");
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_with_port() {
+        let url = Value::Str("http://localhost:8080".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert_eq!(r.get("scheme"), Some(&Value::Str("http".to_string())));
+                    assert_eq!(r.get("host"), Some(&Value::Str("localhost".to_string())));
+
+                    // port should be Some(8080)
+                    if let Some(Value::Variant { variant_name, fields, .. }) = r.get("port") {
+                        assert_eq!(variant_name, "Some");
+                        assert_eq!(fields.len(), 1);
+                        assert_eq!(fields[0], Value::Int(8080));
+                    } else {
+                        panic!("port field missing or wrong type");
+                    }
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_with_path() {
+        let url = Value::Str("https://example.com/api/v1/users".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert_eq!(r.get("path"), Some(&Value::Str("/api/v1/users".to_string())));
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_with_query() {
+        let url = Value::Str("https://example.com/search?q=fusabi&lang=en".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+
+                    // query should be Some("q=fusabi&lang=en")
+                    if let Some(Value::Variant { variant_name, fields, .. }) = r.get("query") {
+                        assert_eq!(variant_name, "Some");
+                        assert_eq!(fields.len(), 1);
+                        assert_eq!(fields[0], Value::Str("q=fusabi&lang=en".to_string()));
+                    } else {
+                        panic!("query field missing or wrong type");
+                    }
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_with_fragment() {
+        let url = Value::Str("https://example.com/page#section".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+
+                    // fragment should be Some("section")
+                    if let Some(Value::Variant { variant_name, fields, .. }) = r.get("fragment") {
+                        assert_eq!(variant_name, "Some");
+                        assert_eq!(fields.len(), 1);
+                        assert_eq!(fields[0], Value::Str("section".to_string()));
+                    } else {
+                        panic!("fragment field missing or wrong type");
+                    }
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_complex() {
+        let url = Value::Str("https://user:pass@example.com:8443/path/to/resource?key=value#anchor".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert_eq!(r.get("scheme"), Some(&Value::Str("https".to_string())));
+                    // Note: our simple parser doesn't separate user:pass from host
+                    assert_eq!(r.get("host"), Some(&Value::Str("user:pass@example.com".to_string())));
+                    assert_eq!(r.get("path"), Some(&Value::Str("/path/to/resource".to_string())));
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_invalid() {
+        // No scheme
+        let url = Value::Str("example.com".to_string());
+        let result = url_parse(&url).unwrap();
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+
+        // Empty string
+        let url = Value::Str("".to_string());
+        let result = url_parse(&url).unwrap();
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+
+        // Invalid port
+        let url = Value::Str("http://example.com:99999".to_string());
+        let result = url_parse(&url).unwrap();
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_is_valid() {
+        assert_eq!(
+            url_is_valid(&Value::Str("https://example.com".to_string())).unwrap(),
+            Value::Bool(true)
+        );
+
+        assert_eq!(
+            url_is_valid(&Value::Str("http://localhost:8080/api".to_string())).unwrap(),
+            Value::Bool(true)
+        );
+
+        assert_eq!(
+            url_is_valid(&Value::Str("example.com".to_string())).unwrap(),
+            Value::Bool(false)
+        );
+
+        assert_eq!(
+            url_is_valid(&Value::Str("".to_string())).unwrap(),
+            Value::Bool(false)
+        );
+    }
+
+    #[test]
+    fn test_url_encode() {
+        let input = Value::Str("hello world".to_string());
+        let result = url_encode(&input).unwrap();
+        assert_eq!(result, Value::Str("hello%20world".to_string()));
+
+        let input = Value::Str("test@example.com".to_string());
+        let result = url_encode(&input).unwrap();
+        assert_eq!(result, Value::Str("test%40example.com".to_string()));
+
+        let input = Value::Str("a+b=c&d".to_string());
+        let result = url_encode(&input).unwrap();
+        assert_eq!(result, Value::Str("a%2Bb%3Dc%26d".to_string()));
+
+        // Unreserved characters should not be encoded
+        let input = Value::Str("ABCabc123-_._~".to_string());
+        let result = url_encode(&input).unwrap();
+        assert_eq!(result, Value::Str("ABCabc123-_._~".to_string()));
+    }
+
+    #[test]
+    fn test_url_decode() {
+        let input = Value::Str("hello%20world".to_string());
+        let result = url_decode(&input).unwrap();
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields[0], Value::Str("hello world".to_string()));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+
+        let input = Value::Str("test%40example.com".to_string());
+        let result = url_decode(&input).unwrap();
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields[0], Value::Str("test@example.com".to_string()));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+
+        // Invalid encoding
+        let input = Value::Str("test%2".to_string());
+        let result = url_decode(&input).unwrap();
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+
+        let input = Value::Str("test%ZZ".to_string());
+        let result = url_decode(&input).unwrap();
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_encode_decode_roundtrip() {
+        let original = "Hello World! 你好 @#$%^&*()";
+        let input = Value::Str(original.to_string());
+
+        let encoded = url_encode(&input).unwrap();
+        let decoded = url_decode(&encoded).unwrap();
+
+        match decoded {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields[0], Value::Str(original.to_string()));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_ipv6() {
+        let url = Value::Str("http://[2001:db8::1]:8080/path".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert_eq!(r.get("host"), Some(&Value::Str("[2001:db8::1]".to_string())));
+
+                    // port should be Some(8080)
+                    if let Some(Value::Variant { variant_name, fields, .. }) = r.get("port") {
+                        assert_eq!(variant_name, "Some");
+                        assert_eq!(fields[0], Value::Int(8080));
+                    } else {
+                        panic!("port field missing");
+                    }
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+
+    #[test]
+    fn test_url_parse_various_schemes() {
+        let schemes = vec!["http", "https", "ftp", "ws", "wss", "file"];
+
+        for scheme in schemes {
+            let url = Value::Str(format!("{}://example.com", scheme));
+            let result = url_parse(&url).unwrap();
+
+            match result {
+                Value::Variant { variant_name, fields, .. } => {
+                    assert_eq!(variant_name, "Some");
+
+                    if let Value::Record(record) = &fields[0] {
+                        let r = record.lock().unwrap();
+                        assert_eq!(r.get("scheme"), Some(&Value::Str(scheme.to_string())));
+                    }
+                }
+                _ => panic!("Expected Some variant for scheme {}", scheme),
+            }
+        }
+    }
+
+    #[test]
+    fn test_url_type_errors() {
+        let not_string = Value::Int(42);
+        assert!(url_parse(&not_string).is_err());
+        assert!(url_is_valid(&not_string).is_err());
+        assert!(url_encode(&not_string).is_err());
+        assert!(url_decode(&not_string).is_err());
+    }
+
+    #[test]
+    fn test_is_valid_scheme() {
+        assert!(is_valid_scheme("http"));
+        assert!(is_valid_scheme("https"));
+        assert!(is_valid_scheme("ftp"));
+        assert!(is_valid_scheme("file"));
+        assert!(is_valid_scheme("ws"));
+        assert!(is_valid_scheme("wss"));
+        assert!(is_valid_scheme("http+tls"));
+        assert!(is_valid_scheme("git+ssh"));
+
+        assert!(!is_valid_scheme("")); // Empty
+        assert!(!is_valid_scheme("123")); // Starts with digit
+        assert!(!is_valid_scheme("ht@tp")); // Invalid character
+        assert!(!is_valid_scheme("ht tp")); // Space
+    }
+
+    #[test]
+    fn test_percent_encode_all_ascii() {
+        // Test that percent encoding handles all ASCII characters correctly
+        let input = Value::Str("!\"#$%&'()*+,/:;=?@[]".to_string());
+        let result = url_encode(&input).unwrap();
+
+        // All special characters should be encoded
+        if let Value::Str(s) = result {
+            assert!(s.contains("%21")); // !
+            assert!(s.contains("%3D")); // =
+            assert!(s.contains("%3F")); // ?
+            assert!(s.contains("%40")); // @
+        } else {
+            panic!("Expected string result");
+        }
+    }
+
+    #[test]
+    fn test_url_parse_missing_path() {
+        // URL without explicit path should get default "/"
+        let url = Value::Str("https://example.com".to_string());
+        let result = url_parse(&url).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert_eq!(r.get("path"), Some(&Value::Str("/".to_string())));
+                }
+            }
+            _ => panic!("Expected Some variant"),
+        }
+    }
+}

--- a/rust/crates/fusabi-vm/tests/test_url_stdlib.rs
+++ b/rust/crates/fusabi-vm/tests/test_url_stdlib.rs
@@ -1,0 +1,126 @@
+// Integration tests for Url stdlib module
+
+use fusabi_vm::vm::Vm;
+use fusabi_vm::stdlib::register_stdlib;
+use fusabi_vm::stdlib::url::{url_parse, url_is_valid, url_encode, url_decode};
+use fusabi_vm::value::Value;
+
+#[test]
+fn test_url_parse_integration() {
+    let mut vm = Vm::new();
+    register_stdlib(&mut vm);
+
+    // Check that Url module is registered
+    assert!(vm.globals.contains_key("Url"));
+
+    // Check that Url module has the expected functions
+    if let Some(Value::Record(url_module)) = vm.globals.get("Url") {
+        let module = url_module.lock().unwrap();
+        assert!(module.contains_key("parse"));
+        assert!(module.contains_key("isValid"));
+        assert!(module.contains_key("encode"));
+        assert!(module.contains_key("decode"));
+    } else {
+        panic!("Url module not found in globals");
+    }
+
+    // Test that functions are registered in host registry
+    let registry = vm.host_registry.lock().unwrap();
+    assert!(registry.has_function("Url.parse"));
+    assert!(registry.has_function("Url.isValid"));
+    assert!(registry.has_function("Url.encode"));
+    assert!(registry.has_function("Url.decode"));
+}
+
+#[test]
+fn test_url_parse_call() {
+    // Call Url.parse directly
+    let url_str = Value::Str("https://example.com:8080/path?query=value#fragment".to_string());
+    let result = url_parse(&url_str).unwrap();
+
+    // Should return Some(UrlInfo)
+    match result {
+        Value::Variant { variant_name, fields, .. } => {
+            assert_eq!(variant_name, "Some");
+            assert_eq!(fields.len(), 1);
+
+            // Check that we got a record back
+            if let Value::Record(record) = &fields[0] {
+                let r = record.lock().unwrap();
+                assert_eq!(r.get("scheme"), Some(&Value::Str("https".to_string())));
+                assert_eq!(r.get("host"), Some(&Value::Str("example.com".to_string())));
+                assert_eq!(r.get("path"), Some(&Value::Str("/path".to_string())));
+
+                // Check port is Some(8080)
+                if let Some(Value::Variant { variant_name, fields, .. }) = r.get("port") {
+                    assert_eq!(variant_name, "Some");
+                    assert_eq!(fields[0], Value::Int(8080));
+                }
+
+                // Check query is Some("query=value")
+                if let Some(Value::Variant { variant_name, fields, .. }) = r.get("query") {
+                    assert_eq!(variant_name, "Some");
+                    assert_eq!(fields[0], Value::Str("query=value".to_string()));
+                }
+
+                // Check fragment is Some("fragment")
+                if let Some(Value::Variant { variant_name, fields, .. }) = r.get("fragment") {
+                    assert_eq!(variant_name, "Some");
+                    assert_eq!(fields[0], Value::Str("fragment".to_string()));
+                }
+            } else {
+                panic!("Expected Record");
+            }
+        }
+        _ => panic!("Expected Some variant"),
+    }
+}
+
+#[test]
+fn test_url_is_valid_call() {
+    // Valid URL
+    let valid_url = Value::Str("https://example.com".to_string());
+    let result = url_is_valid(&valid_url).unwrap();
+    assert_eq!(result, Value::Bool(true));
+
+    // Invalid URL
+    let invalid_url = Value::Str("not-a-url".to_string());
+    let result = url_is_valid(&invalid_url).unwrap();
+    assert_eq!(result, Value::Bool(false));
+}
+
+#[test]
+fn test_url_encode_call() {
+    let input = Value::Str("hello world".to_string());
+    let result = url_encode(&input).unwrap();
+    assert_eq!(result, Value::Str("hello%20world".to_string()));
+}
+
+#[test]
+fn test_url_decode_call() {
+    let input = Value::Str("hello%20world".to_string());
+    let result = url_decode(&input).unwrap();
+
+    // Should return Some("hello world")
+    match result {
+        Value::Variant { variant_name, fields, .. } => {
+            assert_eq!(variant_name, "Some");
+            assert_eq!(fields[0], Value::Str("hello world".to_string()));
+        }
+        _ => panic!("Expected Some variant"),
+    }
+}
+
+#[test]
+fn test_url_decode_invalid() {
+    let input = Value::Str("invalid%ZZ".to_string());
+    let result = url_decode(&input).unwrap();
+
+    // Should return None
+    match result {
+        Value::Variant { variant_name, .. } => {
+            assert_eq!(variant_name, "None");
+        }
+        _ => panic!("Expected None variant"),
+    }
+}

--- a/rust/docs/STDLIB_REFERENCE.md
+++ b/rust/docs/STDLIB_REFERENCE.md
@@ -13,6 +13,10 @@ This document provides a comprehensive reference for all functions in the Fusabi
 - [Result]
 - [String]
 - [Math]
+- [Config]
+- [Time]
+- [Url]
+- [Process]
 - [Json]
 - [Print]
 
@@ -148,6 +152,54 @@ Mathematical constants and functions
 | `Math.ceil : float -> float` | Returns the smallest integer greater than or equal to the number |
 | `Math.round : float -> float` | Returns the nearest integer, rounding half-way cases away from 0.0 |
 | `Math.truncate : float -> float` | Returns the integer part of a number, removing any fractional digits |
+
+## Config
+
+Typed configuration with schema validation
+
+| Function | Description |
+|----------|-------------|
+| `Config.define : ConfigSchema -> unit` | Register a configuration schema |
+| `Config.get : string -> ConfigValue` | Get a configuration value (throws if not found) |
+| `Config.getOr : string -> ConfigValue -> ConfigValue` | Get a configuration value with a fallback default |
+| `Config.set : string -> ConfigValue -> unit` | Set a configuration value (validates against schema) |
+| `Config.has : string -> bool` | Check if a configuration is defined |
+| `Config.list : unit -> (string * ConfigValue) list` | List all defined configurations with their current values |
+| `Config.reset : string -> unit` | Reset a configuration to its default value |
+
+## Time
+
+Time and date functions
+
+| Function | Description |
+|----------|-------------|
+| `Time.now : unit -> int` | Returns the current Unix timestamp in milliseconds since the epoch |
+| `Time.nowSeconds : unit -> int` | Returns the current Unix timestamp in seconds since the epoch |
+| `Time.format : string -> int -> string` | Formats a Unix timestamp (in milliseconds) according to a format string  Supported format specifiers: - %Y - Year (4 digits) - %m - Month (01-12) - %d - Day of month (01-31) - %H - Hour (00-23) - %M - Minute (00-59) - %S - Second (00-59) - %% - Literal '%'  Example: Time.format "%Y-%m-%d %H:%M:%S" timestamp |
+| `Time.parse : string -> string -> int option` | Parses a time string according to a format string, returning Some timestamp or None  Supported format specifiers: - %Y - Year (4 digits) - %m - Month (01-12) - %d - Day of month (01-31) - %H - Hour (00-23) - %M - Minute (00-59) - %S - Second (00-59)  Example: Time.parse "%Y-%m-%d" "2024-03-15" |
+
+## Url
+
+URL parsing and manipulation
+
+| Function | Description |
+|----------|-------------|
+| `Url.parse : string -> UrlInfo option` | Parses a URL string into its components Returns None if the URL is invalid |
+| `Url.isValid : string -> bool` | Check if a string is a valid URL |
+| `Url.encode : string -> string` | URL-encode a string (percent encoding) |
+| `Url.decode : string -> string option` | URL-decode a string (percent decoding) Returns None if the string contains invalid percent encoding |
+
+## Process
+
+Process execution and environment
+
+| Function | Description |
+|----------|-------------|
+| `Process.run : string -> string list -> ProcessResult` | Runs a command with the given arguments and returns the result. The command is executed directly (not through a shell).  Example:   Process.run "echo" ["hello"; "world"]   // Returns { exitCode = 0; stdout = "hello world\n"; stderr = "" } |
+| `Process.runShell : string -> ProcessResult` | Runs a shell command string and returns the result. The command is executed through the system shell (sh on Unix, cmd.exe on Windows).  Example:   Process.runShell "echo hello \| grep h"   // Returns { exitCode = 0; stdout = "hello\n"; stderr = "" } |
+| `Process.env : string -> string option` | Gets an environment variable value. Returns Some(value) if the variable exists, None otherwise.  Example:   Process.env "PATH"   // Returns Some("/usr/bin:/bin:...") |
+| `Process.setEnv : string -> string -> unit` | Sets an environment variable for the current process and child processes. Note: This only affects the current process and its children, not the parent process.  Example:   Process.setEnv "MY_VAR" "my_value"   // Returns () |
+| `Process.cwd : unit -> string` | Gets the current working directory.  Example:   Process.cwd ()   // Returns "/home/user/project" |
 
 ## Json
 

--- a/rust/scripts/gen-docs.nu
+++ b/rust/scripts/gen-docs.nu
@@ -15,6 +15,10 @@ let modules = [
     { name: "Result", file: "result.rs", description: "Functions for error handling (Ok/Error)" }
     { name: "String", file: "string.rs", description: "Functions for string manipulation" }
     { name: "Math", file: "math.rs", description: "Mathematical constants and functions" }
+    { name: "Config", file: "config.rs", description: "Typed configuration with schema validation" }
+    { name: "Time", file: "time.rs", description: "Time and date functions" }
+    { name: "Url", file: "url.rs", description: "URL parsing and manipulation" }
+    { name: "Process", file: "process.rs", description: "Process execution and environment" }
     { name: "Json", file: "json.rs", description: "JSON parsing and serialization" }
     { name: "Print", file: "print.rs", description: "Output functions" }
 ]


### PR DESCRIPTION
## Summary

Wave 1 of stdlib expansion implementing core utility modules requested in issues #152 and #154:

### Config Module (#152)
- **Config.define**: Register typed config schema with defaults and validation
- **Config.get/getOr**: Retrieve config values with type safety
- **Config.set**: Set values with schema validation
- **Config.has/list/reset**: Query and manage configurations
- Thread-safe global registry using `lazy_static`

### Time Module (#154)
- **Time.now**: Current Unix timestamp in milliseconds
- **Time.nowSeconds**: Current Unix timestamp in seconds
- **Time.format**: Format timestamps with strftime-like patterns (%Y, %m, %d, %H, %M, %S)
- **Time.parse**: Parse time strings to Option<timestamp>
- Pure Rust implementation using `std::time`

### Url Module (#154)
- **Url.parse**: Parse URL into UrlInfo record (scheme, host, port, path, query, fragment)
- **Url.isValid**: Validate URL syntax
- **Url.encode/decode**: Percent encoding/decoding
- Custom parser implementation for portability

### Process Module (#154)
- **Process.run**: Execute commands with arguments, returns ProcessResult record
- **Process.runShell**: Run shell commands through system shell
- **Process.env/setEnv**: Get/set environment variables
- **Process.cwd**: Get current working directory
- Cross-platform support (Unix/Windows)

## Test Plan

- [x] 75+ unit tests across all modules
- [x] Integration tests for URL parsing
- [x] All existing tests pass (521+ tests)
- [x] Documentation regenerated with new modules

## Related Issues

Closes #152 (Config module)
Partially addresses #154 (Time, Url, Process modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)