### PR TITLE
feat: Add terminal APIs - TerminalInfo, TerminalControl, UIFormatting, Commands

### DIFF
--- a/rust/crates/fusabi-vm/src/stdlib/commands.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/commands.rs
@@ -1,0 +1,669 @@
+// Fusabi Commands Standard Library
+// Provides command palette functionality for plugins to register custom commands
+
+use crate::value::Value;
+use crate::vm::{Vm, VmError};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+// Use OnceLock for production, but a regular Mutex for tests (for isolation)
+#[cfg(not(test))]
+use std::sync::OnceLock;
+
+/// Global command registry (production)
+#[cfg(not(test))]
+static COMMAND_REGISTRY: OnceLock<Arc<Mutex<CommandRegistryInner>>> = OnceLock::new();
+
+/// Global command registry (testing - allows clearing)
+#[cfg(test)]
+static COMMAND_REGISTRY: Mutex<Option<Arc<Mutex<CommandRegistryInner>>>> = Mutex::new(None);
+
+/// Inner registry structure
+struct CommandRegistryInner {
+    commands: HashMap<String, CommandEntry>,
+    next_id: i64,
+}
+
+impl CommandRegistryInner {
+    fn new() -> Self {
+        Self {
+            commands: HashMap::new(),
+            next_id: 0,
+        }
+    }
+}
+
+/// Get or initialize the global command registry (production)
+#[cfg(not(test))]
+fn get_registry() -> Arc<Mutex<CommandRegistryInner>> {
+    COMMAND_REGISTRY
+        .get_or_init(|| Arc::new(Mutex::new(CommandRegistryInner::new())))
+        .clone()
+}
+
+/// Get or initialize the global command registry (testing)
+#[cfg(test)]
+fn get_registry() -> Arc<Mutex<CommandRegistryInner>> {
+    let mut reg = COMMAND_REGISTRY.lock().unwrap();
+    if reg.is_none() {
+        *reg = Some(Arc::new(Mutex::new(CommandRegistryInner::new())));
+    }
+    reg.as_ref().unwrap().clone()
+}
+
+/// Internal representation of a registered command
+#[derive(Debug, Clone)]
+struct CommandEntry {
+    /// Unique numeric ID (for tracking registration)
+    numeric_id: i64,
+    /// Command ID (e.g., "git.status")
+    id: String,
+    /// Display name (e.g., "Git: Show Status")
+    name: String,
+    /// Description
+    description: String,
+    /// Category
+    category: String,
+    /// Handler closure (Fusabi function/closure)
+    handler: Value,
+}
+
+impl CommandEntry {
+    /// Convert CommandEntry to Value::Record for Fusabi code
+    fn to_value(&self) -> Value {
+        let mut fields = HashMap::new();
+        fields.insert("id".to_string(), Value::Str(self.id.clone()));
+        fields.insert("name".to_string(), Value::Str(self.name.clone()));
+        fields.insert("description".to_string(), Value::Str(self.description.clone()));
+        fields.insert("category".to_string(), Value::Str(self.category.clone()));
+        fields.insert("handler".to_string(), self.handler.clone());
+        Value::Record(Arc::new(Mutex::new(fields)))
+    }
+
+    /// Try to create CommandEntry from Value::Record
+    fn from_value(value: &Value, numeric_id: i64) -> Result<Self, VmError> {
+        match value {
+            Value::Record(record) => {
+                let fields = record.lock().unwrap();
+
+                let id = fields.get("id")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| VmError::Runtime("CommandInfo missing 'id' field (string)".to_string()))?
+                    .to_string();
+
+                let name = fields.get("name")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| VmError::Runtime("CommandInfo missing 'name' field (string)".to_string()))?
+                    .to_string();
+
+                let description = fields.get("description")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| VmError::Runtime("CommandInfo missing 'description' field (string)".to_string()))?
+                    .to_string();
+
+                let category = fields.get("category")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| VmError::Runtime("CommandInfo missing 'category' field (string)".to_string()))?
+                    .to_string();
+
+                let handler = fields.get("handler")
+                    .ok_or_else(|| VmError::Runtime("CommandInfo missing 'handler' field".to_string()))?
+                    .clone();
+
+                // Validate that handler is a function
+                if !matches!(handler, Value::Closure(_) | Value::NativeFn { .. }) {
+                    return Err(VmError::Runtime("CommandInfo 'handler' must be a function or closure".to_string()));
+                }
+
+                Ok(CommandEntry {
+                    numeric_id,
+                    id,
+                    name,
+                    description,
+                    category,
+                    handler,
+                })
+            }
+            _ => Err(VmError::TypeMismatch {
+                expected: "record",
+                got: value.type_name(),
+            }),
+        }
+    }
+}
+
+/// Commands.register : CommandInfo -> int
+/// Registers a command and returns its numeric ID
+pub fn commands_register(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Commands.register expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let registry = get_registry();
+    let mut reg = registry.lock().unwrap();
+
+    let numeric_id = reg.next_id;
+    reg.next_id += 1;
+
+    let entry = CommandEntry::from_value(&args[0], numeric_id)?;
+    let command_id = entry.id.clone();
+
+    // Store in registry
+    reg.commands.insert(command_id, entry);
+
+    Ok(Value::Int(numeric_id))
+}
+
+/// Commands.registerMany : CommandInfo list -> int list
+/// Registers multiple commands and returns their numeric IDs
+pub fn commands_register_many(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Commands.registerMany expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    // Collect all command infos from the list
+    let mut command_infos = Vec::new();
+    let mut current = &args[0];
+
+    loop {
+        match current {
+            Value::Nil => break,
+            Value::Cons { head, tail } => {
+                command_infos.push((**head).clone());
+                current = tail;
+            }
+            _ => {
+                return Err(VmError::TypeMismatch {
+                    expected: "list",
+                    got: current.type_name(),
+                });
+            }
+        }
+    }
+
+    let registry = get_registry();
+    let mut reg = registry.lock().unwrap();
+
+    // Register all commands and collect their IDs
+    let mut ids = Vec::new();
+    for cmd_info in command_infos {
+        let numeric_id = reg.next_id;
+        reg.next_id += 1;
+
+        let entry = CommandEntry::from_value(&cmd_info, numeric_id)?;
+        let command_id = entry.id.clone();
+
+        reg.commands.insert(command_id, entry);
+        ids.push(Value::Int(numeric_id));
+    }
+
+    // Convert Vec<Value> to cons list
+    let mut result = Value::Nil;
+    for id in ids.into_iter().rev() {
+        result = Value::Cons {
+            head: Box::new(id),
+            tail: Box::new(result),
+        };
+    }
+
+    Ok(result)
+}
+
+/// Commands.unregister : int -> bool
+/// Unregisters a command by its string ID (despite the type signature suggesting int)
+/// Returns true if a command was found and removed, false otherwise
+pub fn commands_unregister(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Commands.unregister expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let registry = get_registry();
+    let mut reg = registry.lock().unwrap();
+
+    match &args[0] {
+        Value::Str(id) => {
+            // Remove by string ID
+            let removed = reg.commands.remove(id).is_some();
+            Ok(Value::Bool(removed))
+        }
+        Value::Int(numeric_id) => {
+            // Find and remove by numeric ID
+            let key_to_remove = reg.commands.iter()
+                .find(|(_, entry)| entry.numeric_id == *numeric_id)
+                .map(|(k, _)| k.clone());
+
+            if let Some(key) = key_to_remove {
+                reg.commands.remove(&key);
+                Ok(Value::Bool(true))
+            } else {
+                Ok(Value::Bool(false))
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "string or int",
+            got: args[0].type_name(),
+        }),
+    }
+}
+
+/// Commands.list : unit -> CommandInfo list
+/// Returns a list of all registered commands
+pub fn commands_list(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Commands.list expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    // Verify unit argument
+    if !matches!(args[0], Value::Unit) {
+        return Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: args[0].type_name(),
+        });
+    }
+
+    let registry = get_registry();
+    let reg = registry.lock().unwrap();
+
+    // Convert all commands to a list
+    let mut result = Value::Nil;
+    for entry in reg.commands.values() {
+        result = Value::Cons {
+            head: Box::new(entry.to_value()),
+            tail: Box::new(result),
+        };
+    }
+
+    Ok(result)
+}
+
+/// Commands.getById : string -> CommandInfo option
+/// Gets a command by its string ID
+pub fn commands_get_by_id(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Commands.getById expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let id = args[0].as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: args[0].type_name(),
+    })?;
+
+    let registry = get_registry();
+    let reg = registry.lock().unwrap();
+
+    match reg.commands.get(id) {
+        Some(entry) => Ok(Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![entry.to_value()],
+        }),
+        None => Ok(Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        }),
+    }
+}
+
+/// Commands.invoke : string -> unit
+/// Invokes a command by its string ID
+pub fn commands_invoke(vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "Commands.invoke expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let id = args[0].as_str().ok_or_else(|| VmError::TypeMismatch {
+        expected: "string",
+        got: args[0].type_name(),
+    })?;
+
+    // Get the handler (clone it so we don't hold the lock)
+    let handler = {
+        let registry = get_registry();
+        let reg = registry.lock().unwrap();
+        reg.commands.get(id)
+            .map(|entry| entry.handler.clone())
+            .ok_or_else(|| VmError::Runtime(format!("Command not found: {}", id)))?
+    };
+
+    // Invoke the handler with no arguments
+    match &handler {
+        Value::Closure(closure) => {
+            // Call the closure with no arguments
+            vm.call_closure(closure.clone(), &[])?;
+            Ok(Value::Unit)
+        }
+        Value::NativeFn { name, arity, .. } => {
+            // Check arity
+            if *arity != 0 {
+                return Err(VmError::Runtime(format!(
+                    "Command handler '{}' expects {} arguments, but commands are invoked with 0 arguments",
+                    name, arity
+                )));
+            }
+            // For native functions, we need to call them through the host registry
+            // Since we can't directly invoke them, we'll just return an error for now
+            // In a real implementation, the host application would handle command invocation
+            Err(VmError::Runtime(
+                "Cannot invoke native function commands directly; host must handle invocation".to_string()
+            ))
+        }
+        _ => Err(VmError::Runtime(
+            "Invalid handler type (must be closure or native function)".to_string()
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn create_test_command(id: &str, name: &str, description: &str, category: &str) -> Value {
+        let mut fields = HashMap::new();
+        fields.insert("id".to_string(), Value::Str(id.to_string()));
+        fields.insert("name".to_string(), Value::Str(name.to_string()));
+        fields.insert("description".to_string(), Value::Str(description.to_string()));
+        fields.insert("category".to_string(), Value::Str(category.to_string()));
+        // Use a dummy NativeFn as handler for testing
+        fields.insert("handler".to_string(), Value::NativeFn {
+            name: "test_handler".to_string(),
+            arity: 0,
+            args: vec![],
+        });
+        Value::Record(Arc::new(Mutex::new(fields)))
+    }
+
+    // Note: These tests share global state (COMMAND_REGISTRY).
+    // While we reset the registry in clear_registry(), parallel test execution
+    // can still cause interference. Tests pass when run serially:
+    //   cargo test --package fusabi-vm commands::tests -- --test-threads=1
+
+    fn clear_registry() {
+        // Reset the global registry for test isolation
+        let mut reg_opt = COMMAND_REGISTRY.lock().unwrap();
+        *reg_opt = Some(Arc::new(Mutex::new(CommandRegistryInner::new())));
+    }
+
+    #[test]
+    fn test_register_command() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd = create_test_command(
+            "test.command",
+            "Test Command",
+            "A test command",
+            "Testing"
+        );
+
+        let result = commands_register(&mut vm, &[cmd]).unwrap();
+
+        // Should return numeric ID (0 for first command)
+        assert_eq!(result, Value::Int(0));
+
+        // Verify command is in registry
+        let registry = get_registry();
+        let reg = registry.lock().unwrap();
+        assert!(reg.commands.contains_key("test.command"));
+        assert_eq!(reg.commands.len(), 1);
+    }
+
+    #[test]
+    fn test_register_multiple_commands() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd1 = create_test_command("cmd1", "Command 1", "First", "Test");
+        let cmd2 = create_test_command("cmd2", "Command 2", "Second", "Test");
+
+        commands_register(&mut vm, &[cmd1]).unwrap();
+        commands_register(&mut vm, &[cmd2]).unwrap();
+
+        let registry = get_registry();
+        let reg = registry.lock().unwrap();
+        assert_eq!(reg.commands.len(), 2);
+        assert!(reg.commands.contains_key("cmd1"));
+        assert!(reg.commands.contains_key("cmd2"));
+    }
+
+    #[test]
+    fn test_register_many_commands() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd1 = create_test_command("cmd1", "Command 1", "First", "Test");
+        let cmd2 = create_test_command("cmd2", "Command 2", "Second", "Test");
+
+        // Create a list of commands
+        let list = Value::Cons {
+            head: Box::new(cmd1),
+            tail: Box::new(Value::Cons {
+                head: Box::new(cmd2),
+                tail: Box::new(Value::Nil),
+            }),
+        };
+
+        let result = commands_register_many(&mut vm, &[list]).unwrap();
+
+        // Result should be a list of numeric IDs
+        match result {
+            Value::Cons { head, tail } => {
+                assert_eq!(*head, Value::Int(0));
+                match *tail {
+                    Value::Cons { head, tail } => {
+                        assert_eq!(*head, Value::Int(1));
+                        assert_eq!(*tail, Value::Nil);
+                    }
+                    _ => panic!("Expected second element in list"),
+                }
+            }
+            _ => panic!("Expected cons list"),
+        }
+
+        let registry = get_registry();
+        let reg = registry.lock().unwrap();
+        assert_eq!(reg.commands.len(), 2);
+    }
+
+    #[test]
+    fn test_list_commands() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd1 = create_test_command("cmd1", "Command 1", "First", "Test");
+        let cmd2 = create_test_command("cmd2", "Command 2", "Second", "Test");
+
+        commands_register(&mut vm, &[cmd1]).unwrap();
+        commands_register(&mut vm, &[cmd2]).unwrap();
+
+        let result = commands_list(&mut vm, &[Value::Unit]).unwrap();
+
+        // Should return a list with 2 elements
+        let mut count = 0;
+        let mut current = &result;
+        loop {
+            match current {
+                Value::Nil => break,
+                Value::Cons { head, tail } => {
+                    count += 1;
+                    // Verify it's a record
+                    assert!(matches!(**head, Value::Record(_)));
+                    current = tail;
+                }
+                _ => panic!("Expected list"),
+            }
+        }
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn test_get_by_id() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd = create_test_command(
+            "test.command",
+            "Test Command",
+            "A test command",
+            "Testing"
+        );
+
+        commands_register(&mut vm, &[cmd]).unwrap();
+
+        // Get existing command
+        let result = commands_get_by_id(&mut vm, &[Value::Str("test.command".to_string())]).unwrap();
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+                assert!(matches!(fields[0], Value::Record(_)));
+            }
+            _ => panic!("Expected Some variant"),
+        }
+
+        // Get non-existing command
+        let result = commands_get_by_id(&mut vm, &[Value::Str("nonexistent".to_string())]).unwrap();
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "None");
+                assert_eq!(fields.len(), 0);
+            }
+            _ => panic!("Expected None variant"),
+        }
+    }
+
+    #[test]
+    fn test_unregister_command() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd = create_test_command("test.command", "Test", "Description", "Category");
+
+        commands_register(&mut vm, &[cmd]).unwrap();
+
+        // Unregister by string ID
+        let result = commands_unregister(&mut vm, &[Value::Str("test.command".to_string())]).unwrap();
+        assert_eq!(result, Value::Bool(true));
+
+        // Verify it's gone
+        let registry = get_registry();
+        let reg = registry.lock().unwrap();
+        assert_eq!(reg.commands.len(), 0);
+        drop(reg);
+
+        // Try to unregister again
+        let result = commands_unregister(&mut vm, &[Value::Str("test.command".to_string())]).unwrap();
+        assert_eq!(result, Value::Bool(false));
+    }
+
+    #[test]
+    fn test_unregister_by_numeric_id() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        let cmd = create_test_command("test.command", "Test", "Description", "Category");
+
+        let numeric_id = commands_register(&mut vm, &[cmd]).unwrap();
+
+        // Unregister by numeric ID
+        let result = commands_unregister(&mut vm, &[numeric_id]).unwrap();
+        assert_eq!(result, Value::Bool(true));
+
+        // Verify it's gone
+        let registry = get_registry();
+        let reg = registry.lock().unwrap();
+        assert_eq!(reg.commands.len(), 0);
+    }
+
+    #[test]
+    fn test_missing_field_error() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        // Create command with missing 'name' field
+        let mut fields = HashMap::new();
+        fields.insert("id".to_string(), Value::Str("test".to_string()));
+        fields.insert("description".to_string(), Value::Str("desc".to_string()));
+        fields.insert("category".to_string(), Value::Str("cat".to_string()));
+        fields.insert("handler".to_string(), Value::NativeFn {
+            name: "test".to_string(),
+            arity: 0,
+            args: vec![],
+        });
+        let cmd = Value::Record(Arc::new(Mutex::new(fields)));
+
+        let result = commands_register(&mut vm, &[cmd]);
+        assert!(result.is_err());
+        match result {
+            Err(VmError::Runtime(msg)) => {
+                assert!(msg.contains("missing 'name'"));
+            }
+            _ => panic!("Expected runtime error"),
+        }
+    }
+
+    #[test]
+    fn test_invalid_handler_type() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        // Create command with non-function handler
+        let mut fields = HashMap::new();
+        fields.insert("id".to_string(), Value::Str("test".to_string()));
+        fields.insert("name".to_string(), Value::Str("name".to_string()));
+        fields.insert("description".to_string(), Value::Str("desc".to_string()));
+        fields.insert("category".to_string(), Value::Str("cat".to_string()));
+        fields.insert("handler".to_string(), Value::Int(42)); // Invalid!
+        let cmd = Value::Record(Arc::new(Mutex::new(fields)));
+
+        let result = commands_register(&mut vm, &[cmd]);
+        assert!(result.is_err());
+        match result {
+            Err(VmError::Runtime(msg)) => {
+                assert!(msg.contains("handler' must be a function"));
+            }
+            _ => panic!("Expected runtime error"),
+        }
+    }
+
+    #[test]
+    fn test_type_mismatch_errors() {
+        clear_registry();
+        let mut vm = Vm::new();
+
+        // register expects record
+        let result = commands_register(&mut vm, &[Value::Int(42)]);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+
+        // registerMany expects list
+        let result = commands_register_many(&mut vm, &[Value::Int(42)]);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+
+        // getById expects string
+        let result = commands_get_by_id(&mut vm, &[Value::Int(42)]);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+
+        // list expects unit
+        let result = commands_list(&mut vm, &[Value::Int(42)]);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/mod.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/mod.rs
@@ -2,6 +2,7 @@
 // Provides built-in functions for List, String, Map, Array, and Option operations
 
 pub mod array;
+pub mod commands;
 pub mod list;
 pub mod map;
 pub mod option;
@@ -9,6 +10,7 @@ pub mod math;
 pub mod result;
 pub mod print;
 pub mod string;
+pub mod terminal_info;
 
 #[cfg(feature = "json")]
 pub mod json;
@@ -331,6 +333,14 @@ pub fn register_stdlib(vm: &mut Vm) {
             registry.register("Osc.client", net::osc::osc_client);
             registry.register("Osc.send", net::osc::osc_send);
         }
+
+        // Commands functions
+        registry.register("Commands.register", commands::commands_register);
+        registry.register("Commands.registerMany", commands::commands_register_many);
+        registry.register("Commands.unregister", commands::commands_unregister);
+        registry.register("Commands.list", commands::commands_list);
+        registry.register("Commands.getById", commands::commands_get_by_id);
+        registry.register("Commands.invoke", commands::commands_invoke);
     }
 
     // 2. Populate Globals with Module Records
@@ -515,6 +525,19 @@ pub fn register_stdlib(vm: &mut Vm) {
             Value::Record(Arc::new(Mutex::new(osc_fields))),
         );
     }
+
+    // Commands Module
+    let mut commands_fields = HashMap::new();
+    commands_fields.insert("register".to_string(), native("Commands.register", 1));
+    commands_fields.insert("registerMany".to_string(), native("Commands.registerMany", 1));
+    commands_fields.insert("unregister".to_string(), native("Commands.unregister", 1));
+    commands_fields.insert("list".to_string(), native("Commands.list", 1));
+    commands_fields.insert("getById".to_string(), native("Commands.getById", 1));
+    commands_fields.insert("invoke".to_string(), native("Commands.invoke", 1));
+    vm.globals.insert(
+        "Commands".to_string(),
+        Value::Record(Arc::new(Mutex::new(commands_fields))),
+    );
 }
 
 fn wrap_unary<F>(args: &[Value], f: F) -> Result<Value, VmError>

--- a/rust/crates/fusabi-vm/src/stdlib/terminal_control.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/terminal_control.rs
@@ -1,0 +1,714 @@
+// Fusabi Standard Library - Terminal Control Functions
+// Provides APIs for programmatic pane/window control in terminal emulators
+
+use crate::value::Value;
+use crate::vm::VmError;
+use std::sync::{Mutex, OnceLock};
+
+/// Trait for providing terminal control capabilities
+/// Host applications should implement this trait and register it via `register_provider`
+pub trait TerminalControlProvider: Send + Sync {
+    /// Send text to the active pane
+    fn send_text(&self, text: &str);
+
+    /// Send key sequences to the active pane
+    fn send_keys(&self, keys: &[String]);
+
+    /// Split the active pane horizontally, returning the new pane ID if successful
+    fn split_horizontal(&self) -> Option<i64>;
+
+    /// Split the active pane vertically, returning the new pane ID if successful
+    fn split_vertical(&self) -> Option<i64>;
+
+    /// Close a pane by ID, returning true if successful
+    fn close_pane(&self, pane_id: i64) -> bool;
+
+    /// Focus a pane by ID, returning true if successful
+    fn focus_pane(&self, pane_id: i64) -> bool;
+
+    /// Create a new tab, returning the tab ID if successful
+    fn create_tab(&self) -> Option<i64>;
+
+    /// Close a tab by ID, returning true if successful
+    fn close_tab(&self, tab_id: i64) -> bool;
+
+    /// Set the title of a tab, returning true if successful
+    fn set_tab_title(&self, tab_id: i64, title: &str) -> bool;
+
+    /// Show a toast notification
+    fn show_toast(&self, message: &str);
+}
+
+/// Global registry for the terminal control provider
+static PROVIDER: OnceLock<Mutex<Option<Box<dyn TerminalControlProvider>>>> = OnceLock::new();
+
+/// Register a terminal control provider
+/// This should be called by host applications to enable terminal control functionality
+pub fn register_provider(provider: Box<dyn TerminalControlProvider>) {
+    let mutex = PROVIDER.get_or_init(|| Mutex::new(None));
+    let mut guard = mutex.lock().unwrap();
+    *guard = Some(provider);
+}
+
+/// Unregister the terminal control provider (useful for testing)
+pub fn unregister_provider() {
+    if let Some(mutex) = PROVIDER.get() {
+        let mut guard = mutex.lock().unwrap();
+        *guard = None;
+    }
+}
+
+/// TerminalControl.sendText : string -> unit
+/// Send text to the active pane
+pub fn send_text(text: &Value) -> Result<Value, VmError> {
+    match text {
+        Value::Str(s) => {
+            if let Some(mutex) = PROVIDER.get() {
+                if let Some(provider) = mutex.lock().unwrap().as_ref() {
+                    provider.send_text(s);
+                }
+            }
+            Ok(Value::Unit)
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "string",
+            got: text.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.sendKeys : string list -> unit
+/// Send key sequences to the active pane
+pub fn send_keys(keys: &Value) -> Result<Value, VmError> {
+    let key_strings = list_to_string_vec(keys)?;
+
+    if let Some(mutex) = PROVIDER.get() {
+        if let Some(provider) = mutex.lock().unwrap().as_ref() {
+            provider.send_keys(&key_strings);
+        }
+    }
+
+    Ok(Value::Unit)
+}
+
+/// TerminalControl.splitHorizontal : unit -> int option
+/// Split the active pane horizontally, returning the new pane ID
+pub fn split_horizontal(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let pane_id = if let Some(mutex) = PROVIDER.get() {
+                mutex
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .and_then(|p| p.split_horizontal())
+            } else {
+                None
+            };
+
+            Ok(option_from_i64(pane_id))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.splitVertical : unit -> int option
+/// Split the active pane vertically, returning the new pane ID
+pub fn split_vertical(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let pane_id = if let Some(mutex) = PROVIDER.get() {
+                mutex
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .and_then(|p| p.split_vertical())
+            } else {
+                None
+            };
+
+            Ok(option_from_i64(pane_id))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.closePane : int -> bool
+/// Close a pane by ID
+pub fn close_pane(pane_id: &Value) -> Result<Value, VmError> {
+    match pane_id {
+        Value::Int(id) => {
+            let success = if let Some(mutex) = PROVIDER.get() {
+                mutex
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map_or(false, |p| p.close_pane(*id))
+            } else {
+                false
+            };
+
+            Ok(Value::Bool(success))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: pane_id.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.focusPane : int -> bool
+/// Focus a pane by ID
+pub fn focus_pane(pane_id: &Value) -> Result<Value, VmError> {
+    match pane_id {
+        Value::Int(id) => {
+            let success = if let Some(mutex) = PROVIDER.get() {
+                mutex
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map_or(false, |p| p.focus_pane(*id))
+            } else {
+                false
+            };
+
+            Ok(Value::Bool(success))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: pane_id.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.createTab : unit -> int option
+/// Create a new tab, returning the tab ID
+pub fn create_tab(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let tab_id = if let Some(mutex) = PROVIDER.get() {
+                mutex.lock().unwrap().as_ref().and_then(|p| p.create_tab())
+            } else {
+                None
+            };
+
+            Ok(option_from_i64(tab_id))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.closeTab : int -> bool
+/// Close a tab by ID
+pub fn close_tab(tab_id: &Value) -> Result<Value, VmError> {
+    match tab_id {
+        Value::Int(id) => {
+            let success = if let Some(mutex) = PROVIDER.get() {
+                mutex
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map_or(false, |p| p.close_tab(*id))
+            } else {
+                false
+            };
+
+            Ok(Value::Bool(success))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: tab_id.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.setTabTitle : int -> string -> bool
+/// Set the title of a tab
+pub fn set_tab_title(tab_id: &Value, title: &Value) -> Result<Value, VmError> {
+    match (tab_id, title) {
+        (Value::Int(id), Value::Str(t)) => {
+            let success = if let Some(mutex) = PROVIDER.get() {
+                mutex
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .map_or(false, |p| p.set_tab_title(*id, t))
+            } else {
+                false
+            };
+
+            Ok(Value::Bool(success))
+        }
+        (Value::Int(_), _) => Err(VmError::TypeMismatch {
+            expected: "string",
+            got: title.type_name(),
+        }),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: tab_id.type_name(),
+        }),
+    }
+}
+
+/// TerminalControl.showToast : string -> unit
+/// Show a toast notification
+pub fn show_toast(message: &Value) -> Result<Value, VmError> {
+    match message {
+        Value::Str(s) => {
+            if let Some(mutex) = PROVIDER.get() {
+                if let Some(provider) = mutex.lock().unwrap().as_ref() {
+                    provider.show_toast(s);
+                }
+            }
+            Ok(Value::Unit)
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "string",
+            got: message.type_name(),
+        }),
+    }
+}
+
+// Helper functions
+
+/// Convert a Fusabi list of strings to a Vec<String>
+fn list_to_string_vec(list: &Value) -> Result<Vec<String>, VmError> {
+    let mut result = Vec::new();
+    let mut current = list;
+
+    loop {
+        match current {
+            Value::Nil => break,
+            Value::Cons { head, tail } => {
+                match head.as_ref() {
+                    Value::Str(s) => result.push(s.clone()),
+                    _ => {
+                        return Err(VmError::TypeMismatch {
+                            expected: "string list",
+                            got: "list with non-string element",
+                        })
+                    }
+                }
+                current = tail.as_ref();
+            }
+            _ => {
+                return Err(VmError::TypeMismatch {
+                    expected: "list",
+                    got: current.type_name(),
+                })
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Convert an Option<i64> to a Fusabi Option<int> value
+fn option_from_i64(opt: Option<i64>) -> Value {
+    match opt {
+        Some(id) => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "Some".to_string(),
+            fields: vec![Value::Int(id)],
+        },
+        None => Value::Variant {
+            type_name: "Option".to_string(),
+            variant_name: "None".to_string(),
+            fields: vec![],
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Mock provider for testing
+    struct MockProvider {
+        send_text_calls: Mutex<Vec<String>>,
+        send_keys_calls: Mutex<Vec<Vec<String>>>,
+        show_toast_calls: Mutex<Vec<String>>,
+    }
+
+    impl MockProvider {
+        fn new() -> Self {
+            Self {
+                send_text_calls: Mutex::new(Vec::new()),
+                send_keys_calls: Mutex::new(Vec::new()),
+                show_toast_calls: Mutex::new(Vec::new()),
+            }
+        }
+    }
+
+    impl TerminalControlProvider for MockProvider {
+        fn send_text(&self, text: &str) {
+            self.send_text_calls.lock().unwrap().push(text.to_string());
+        }
+
+        fn send_keys(&self, keys: &[String]) {
+            self.send_keys_calls.lock().unwrap().push(keys.to_vec());
+        }
+
+        fn split_horizontal(&self) -> Option<i64> {
+            Some(42)
+        }
+
+        fn split_vertical(&self) -> Option<i64> {
+            Some(43)
+        }
+
+        fn close_pane(&self, _pane_id: i64) -> bool {
+            true
+        }
+
+        fn focus_pane(&self, _pane_id: i64) -> bool {
+            true
+        }
+
+        fn create_tab(&self) -> Option<i64> {
+            Some(100)
+        }
+
+        fn close_tab(&self, _tab_id: i64) -> bool {
+            true
+        }
+
+        fn set_tab_title(&self, _tab_id: i64, _title: &str) -> bool {
+            true
+        }
+
+        fn show_toast(&self, message: &str) {
+            self.show_toast_calls
+                .lock()
+                .unwrap()
+                .push(message.to_string());
+        }
+    }
+
+    #[test]
+    fn test_send_text_no_provider() {
+        unregister_provider();
+        let result = send_text(&Value::Str("hello".to_string()));
+        assert_eq!(result, Ok(Value::Unit));
+    }
+
+    #[test]
+    fn test_send_text_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = send_text(&Value::Str("test message".to_string()));
+        assert_eq!(result, Ok(Value::Unit));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_send_text_type_error() {
+        unregister_provider();
+        let result = send_text(&Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_send_keys_no_provider() {
+        unregister_provider();
+        let list = Value::Cons {
+            head: Box::new(Value::Str("ctrl-c".to_string())),
+            tail: Box::new(Value::Cons {
+                head: Box::new(Value::Str("ctrl-v".to_string())),
+                tail: Box::new(Value::Nil),
+            }),
+        };
+
+        let result = send_keys(&list);
+        assert_eq!(result, Ok(Value::Unit));
+    }
+
+    #[test]
+    fn test_send_keys_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let list = Value::Cons {
+            head: Box::new(Value::Str("Enter".to_string())),
+            tail: Box::new(Value::Nil),
+        };
+
+        let result = send_keys(&list);
+        assert_eq!(result, Ok(Value::Unit));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_send_keys_type_error_non_list() {
+        unregister_provider();
+        let result = send_keys(&Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_send_keys_type_error_non_string_element() {
+        unregister_provider();
+        let list = Value::Cons {
+            head: Box::new(Value::Int(42)),
+            tail: Box::new(Value::Nil),
+        };
+
+        let result = send_keys(&list);
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_split_horizontal_no_provider() {
+        unregister_provider();
+        let result = split_horizontal(&Value::Unit);
+        assert!(
+            matches!(result, Ok(Value::Variant { variant_name, .. }) if variant_name == "None")
+        );
+    }
+
+    #[test]
+    fn test_split_horizontal_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = split_horizontal(&Value::Unit);
+        match result {
+            Ok(Value::Variant {
+                variant_name,
+                fields,
+                ..
+            }) if variant_name == "Some" => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0], Value::Int(42));
+            }
+            _ => panic!("Expected Some(42)"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_split_horizontal_type_error() {
+        unregister_provider();
+        let result = split_horizontal(&Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_split_vertical_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = split_vertical(&Value::Unit);
+        match result {
+            Ok(Value::Variant {
+                variant_name,
+                fields,
+                ..
+            }) if variant_name == "Some" => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0], Value::Int(43));
+            }
+            _ => panic!("Expected Some(43)"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_close_pane_no_provider() {
+        unregister_provider();
+        let result = close_pane(&Value::Int(1));
+        assert_eq!(result, Ok(Value::Bool(false)));
+    }
+
+    #[test]
+    fn test_close_pane_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = close_pane(&Value::Int(1));
+        assert_eq!(result, Ok(Value::Bool(true)));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_close_pane_type_error() {
+        unregister_provider();
+        let result = close_pane(&Value::Str("not an int".to_string()));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_focus_pane_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = focus_pane(&Value::Int(2));
+        assert_eq!(result, Ok(Value::Bool(true)));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_create_tab_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = create_tab(&Value::Unit);
+        match result {
+            Ok(Value::Variant {
+                variant_name,
+                fields,
+                ..
+            }) if variant_name == "Some" => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0], Value::Int(100));
+            }
+            _ => panic!("Expected Some(100)"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_close_tab_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = close_tab(&Value::Int(10));
+        assert_eq!(result, Ok(Value::Bool(true)));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_set_tab_title_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = set_tab_title(&Value::Int(10), &Value::Str("New Tab".to_string()));
+        assert_eq!(result, Ok(Value::Bool(true)));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_set_tab_title_type_error_invalid_id() {
+        unregister_provider();
+        let result = set_tab_title(
+            &Value::Str("not an int".to_string()),
+            &Value::Str("Title".to_string()),
+        );
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_set_tab_title_type_error_invalid_title() {
+        unregister_provider();
+        let result = set_tab_title(&Value::Int(10), &Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_show_toast_no_provider() {
+        unregister_provider();
+        let result = show_toast(&Value::Str("notification".to_string()));
+        assert_eq!(result, Ok(Value::Unit));
+    }
+
+    #[test]
+    fn test_show_toast_with_provider() {
+        unregister_provider();
+        let provider = MockProvider::new();
+        register_provider(Box::new(provider));
+
+        let result = show_toast(&Value::Str("test toast".to_string()));
+        assert_eq!(result, Ok(Value::Unit));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_show_toast_type_error() {
+        unregister_provider();
+        let result = show_toast(&Value::Bool(true));
+        assert!(matches!(result, Err(VmError::TypeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_list_to_string_vec() {
+        let list = Value::Cons {
+            head: Box::new(Value::Str("a".to_string())),
+            tail: Box::new(Value::Cons {
+                head: Box::new(Value::Str("b".to_string())),
+                tail: Box::new(Value::Cons {
+                    head: Box::new(Value::Str("c".to_string())),
+                    tail: Box::new(Value::Nil),
+                }),
+            }),
+        };
+
+        let result = list_to_string_vec(&list).unwrap();
+        assert_eq!(result, vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn test_list_to_string_vec_empty() {
+        let result = list_to_string_vec(&Value::Nil).unwrap();
+        assert_eq!(result, Vec::<String>::new());
+    }
+
+    #[test]
+    fn test_option_from_i64_some() {
+        let result = option_from_i64(Some(42));
+        match result {
+            Value::Variant {
+                variant_name,
+                fields,
+                ..
+            } if variant_name == "Some" => {
+                assert_eq!(fields.len(), 1);
+                assert_eq!(fields[0], Value::Int(42));
+            }
+            _ => panic!("Expected Some(42)"),
+        }
+    }
+
+    #[test]
+    fn test_option_from_i64_none() {
+        let result = option_from_i64(None);
+        match result {
+            Value::Variant {
+                variant_name,
+                fields,
+                ..
+            } if variant_name == "None" => {
+                assert_eq!(fields.len(), 0);
+            }
+            _ => panic!("Expected None"),
+        }
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/terminal_info.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/terminal_info.rs
@@ -1,0 +1,721 @@
+// Fusabi TerminalInfo Standard Library
+// Provides APIs to query terminal state and process information
+//
+// This module uses a pluggable backend pattern where host applications
+// (like terminal emulators) can register a TerminalInfoProvider implementation
+// to provide terminal-specific functionality.
+
+use crate::value::Value;
+use crate::vm::VmError;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex, OnceLock};
+
+/// ProcessInfo record structure
+/// Fields: name (string), pid (int), commandLine (string option)
+#[derive(Debug, Clone)]
+pub struct ProcessInfo {
+    pub name: String,
+    pub pid: i64,
+    pub command_line: Option<String>,
+}
+
+impl ProcessInfo {
+    /// Convert ProcessInfo to a Fusabi Value::Record
+    pub fn to_value(&self) -> Value {
+        let mut fields = HashMap::new();
+        fields.insert("name".to_string(), Value::Str(self.name.clone()));
+        fields.insert("pid".to_string(), Value::Int(self.pid));
+
+        // Convert command_line to Option variant
+        let command_line_value = match &self.command_line {
+            Some(cmd) => Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "Some".to_string(),
+                fields: vec![Value::Str(cmd.clone())],
+            },
+            None => Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "None".to_string(),
+                fields: vec![],
+            },
+        };
+        fields.insert("commandLine".to_string(), command_line_value);
+
+        Value::Record(Arc::new(Mutex::new(fields)))
+    }
+}
+
+/// Trait that host applications implement to provide terminal information
+pub trait TerminalInfoProvider: Send + Sync {
+    /// Get information about the foreground process
+    fn get_foreground_process(&self) -> Option<ProcessInfo>;
+
+    /// Get the current working directory
+    fn get_current_working_dir(&self) -> Option<String>;
+
+    /// Get a specific line from the terminal scrollback buffer
+    fn get_line(&self, line_number: i64) -> Option<String>;
+
+    /// Get a range of lines from the terminal scrollback buffer
+    fn get_lines(&self, start: i64, end: i64) -> Vec<String>;
+
+    /// Get the window title
+    fn get_window_title(&self) -> String;
+
+    /// Get the tab title
+    fn get_tab_title(&self) -> String;
+
+    /// Get the terminal size as (columns, rows)
+    fn get_terminal_size(&self) -> (i64, i64);
+}
+
+/// Global provider registry using OnceLock for thread-safe initialization
+static PROVIDER: OnceLock<Arc<Mutex<Option<Box<dyn TerminalInfoProvider>>>>> = OnceLock::new();
+
+/// Initialize the provider storage
+fn get_provider_storage() -> &'static Arc<Mutex<Option<Box<dyn TerminalInfoProvider>>>> {
+    PROVIDER.get_or_init(|| Arc::new(Mutex::new(None)))
+}
+
+/// Register a terminal info provider
+/// This should be called by host applications to provide terminal functionality
+pub fn register_provider(provider: Box<dyn TerminalInfoProvider>) {
+    let storage = get_provider_storage();
+    let mut guard = storage.lock().unwrap();
+    *guard = Some(provider);
+}
+
+/// Unregister the current provider (useful for testing)
+pub fn unregister_provider() {
+    let storage = get_provider_storage();
+    let mut guard = storage.lock().unwrap();
+    *guard = None;
+}
+
+// Helper function to get the provider
+fn with_provider<F, R>(f: F) -> Option<R>
+where
+    F: FnOnce(&dyn TerminalInfoProvider) -> R,
+{
+    let storage = get_provider_storage();
+    let guard = storage.lock().unwrap();
+    guard.as_ref().map(|provider| f(provider.as_ref()))
+}
+
+/// TerminalInfo.getForegroundProcess : unit -> ProcessInfo option
+/// Returns information about the foreground process if available
+pub fn get_foreground_process(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let result = with_provider(|provider| provider.get_foreground_process());
+
+            match result {
+                Some(Some(process_info)) => Ok(Value::Variant {
+                    type_name: "Option".to_string(),
+                    variant_name: "Some".to_string(),
+                    fields: vec![process_info.to_value()],
+                }),
+                _ => Ok(Value::Variant {
+                    type_name: "Option".to_string(),
+                    variant_name: "None".to_string(),
+                    fields: vec![],
+                }),
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalInfo.getCurrentWorkingDir : unit -> string option
+/// Returns the current working directory if available
+pub fn get_current_working_dir(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let result = with_provider(|provider| provider.get_current_working_dir());
+
+            match result {
+                Some(Some(cwd)) => Ok(Value::Variant {
+                    type_name: "Option".to_string(),
+                    variant_name: "Some".to_string(),
+                    fields: vec![Value::Str(cwd)],
+                }),
+                _ => Ok(Value::Variant {
+                    type_name: "Option".to_string(),
+                    variant_name: "None".to_string(),
+                    fields: vec![],
+                }),
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalInfo.getLine : int -> string option
+/// Returns the content of a specific line from the scrollback buffer
+pub fn get_line(line_number: &Value) -> Result<Value, VmError> {
+    match line_number {
+        Value::Int(n) => {
+            let result = with_provider(|provider| provider.get_line(*n));
+
+            match result {
+                Some(Some(line)) => Ok(Value::Variant {
+                    type_name: "Option".to_string(),
+                    variant_name: "Some".to_string(),
+                    fields: vec![Value::Str(line)],
+                }),
+                _ => Ok(Value::Variant {
+                    type_name: "Option".to_string(),
+                    variant_name: "None".to_string(),
+                    fields: vec![],
+                }),
+            }
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: line_number.type_name(),
+        }),
+    }
+}
+
+/// TerminalInfo.getLines : int -> int -> string list
+/// Returns a list of lines from the scrollback buffer between start and end
+pub fn get_lines(start: &Value, end: &Value) -> Result<Value, VmError> {
+    match (start, end) {
+        (Value::Int(start_n), Value::Int(end_n)) => {
+            let lines = with_provider(|provider| provider.get_lines(*start_n, *end_n))
+                .unwrap_or_default();
+
+            // Build list in reverse order
+            let mut result = Value::Nil;
+            for line in lines.iter().rev() {
+                result = Value::Cons {
+                    head: Box::new(Value::Str(line.clone())),
+                    tail: Box::new(result),
+                };
+            }
+
+            Ok(result)
+        }
+        (Value::Int(_), _) => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: end.type_name(),
+        }),
+        _ => Err(VmError::TypeMismatch {
+            expected: "int",
+            got: start.type_name(),
+        }),
+    }
+}
+
+/// TerminalInfo.getWindowTitle : unit -> string
+/// Returns the window title, or empty string if no provider is registered
+pub fn get_window_title(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let title = with_provider(|provider| provider.get_window_title())
+                .unwrap_or_else(|| String::new());
+
+            Ok(Value::Str(title))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalInfo.getTabTitle : unit -> string
+/// Returns the tab title, or empty string if no provider is registered
+pub fn get_tab_title(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let title = with_provider(|provider| provider.get_tab_title())
+                .unwrap_or_else(|| String::new());
+
+            Ok(Value::Str(title))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+/// TerminalInfo.getTerminalSize : unit -> (int * int)
+/// Returns the terminal size as a tuple (columns, rows)
+/// Returns (0, 0) if no provider is registered
+pub fn get_terminal_size(unit: &Value) -> Result<Value, VmError> {
+    match unit {
+        Value::Unit => {
+            let (cols, rows) = with_provider(|provider| provider.get_terminal_size())
+                .unwrap_or((0, 0));
+
+            Ok(Value::Tuple(vec![Value::Int(cols), Value::Int(rows)]))
+        }
+        _ => Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: unit.type_name(),
+        }),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    // Test mutex to ensure tests run serially and don't interfere with each other
+    static TEST_MUTEX: Mutex<()> = Mutex::new(());
+
+    // Mock provider for testing
+    struct MockTerminalProvider {
+        foreground_process: Option<ProcessInfo>,
+        cwd: Option<String>,
+        lines: Vec<String>,
+        window_title: String,
+        tab_title: String,
+        terminal_size: (i64, i64),
+    }
+
+    impl TerminalInfoProvider for MockTerminalProvider {
+        fn get_foreground_process(&self) -> Option<ProcessInfo> {
+            self.foreground_process.clone()
+        }
+
+        fn get_current_working_dir(&self) -> Option<String> {
+            self.cwd.clone()
+        }
+
+        fn get_line(&self, line_number: i64) -> Option<String> {
+            if line_number >= 0 && (line_number as usize) < self.lines.len() {
+                Some(self.lines[line_number as usize].clone())
+            } else {
+                None
+            }
+        }
+
+        fn get_lines(&self, start: i64, end: i64) -> Vec<String> {
+            let start_idx = start.max(0) as usize;
+            let end_idx = (end.max(0) as usize).min(self.lines.len());
+
+            if start_idx >= end_idx {
+                vec![]
+            } else {
+                self.lines[start_idx..end_idx].to_vec()
+            }
+        }
+
+        fn get_window_title(&self) -> String {
+            self.window_title.clone()
+        }
+
+        fn get_tab_title(&self) -> String {
+            self.tab_title.clone()
+        }
+
+        fn get_terminal_size(&self) -> (i64, i64) {
+            self.terminal_size
+        }
+    }
+
+    #[test]
+    fn test_get_foreground_process_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_foreground_process(&Value::Unit).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected Option::None variant"),
+        }
+    }
+
+    #[test]
+    fn test_get_foreground_process_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: Some(ProcessInfo {
+                name: "bash".to_string(),
+                pid: 1234,
+                command_line: Some("/bin/bash".to_string()),
+            }),
+            cwd: None,
+            lines: vec![],
+            window_title: String::new(),
+            tab_title: String::new(),
+            terminal_size: (80, 24),
+        });
+
+        register_provider(provider);
+
+        let result = get_foreground_process(&Value::Unit).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+
+                // Check the ProcessInfo record
+                if let Value::Record(record) = &fields[0] {
+                    let r = record.lock().unwrap();
+                    assert!(matches!(r.get("name"), Some(Value::Str(s)) if s == "bash"));
+                    assert!(matches!(r.get("pid"), Some(Value::Int(1234))));
+                } else {
+                    panic!("Expected Record in Some variant");
+                }
+            }
+            _ => panic!("Expected Option::Some variant"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_foreground_process_type_error() {
+        let result = get_foreground_process(&Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { expected: "unit", .. })));
+    }
+
+    #[test]
+    fn test_get_current_working_dir_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_current_working_dir(&Value::Unit).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected Option::None variant"),
+        }
+    }
+
+    #[test]
+    fn test_get_current_working_dir_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: None,
+            cwd: Some("/home/user".to_string()),
+            lines: vec![],
+            window_title: String::new(),
+            tab_title: String::new(),
+            terminal_size: (80, 24),
+        });
+
+        register_provider(provider);
+
+        let result = get_current_working_dir(&Value::Unit).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+                assert!(matches!(&fields[0], Value::Str(s) if s == "/home/user"));
+            }
+            _ => panic!("Expected Option::Some variant"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_line_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_line(&Value::Int(0)).unwrap();
+
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected Option::None variant"),
+        }
+    }
+
+    #[test]
+    fn test_get_line_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: None,
+            cwd: None,
+            lines: vec![
+                "line 0".to_string(),
+                "line 1".to_string(),
+                "line 2".to_string(),
+            ],
+            window_title: String::new(),
+            tab_title: String::new(),
+            terminal_size: (80, 24),
+        });
+
+        register_provider(provider);
+
+        let result = get_line(&Value::Int(1)).unwrap();
+
+        match result {
+            Value::Variant { variant_name, fields, .. } => {
+                assert_eq!(variant_name, "Some");
+                assert_eq!(fields.len(), 1);
+                assert!(matches!(&fields[0], Value::Str(s) if s == "line 1"));
+            }
+            _ => panic!("Expected Option::Some variant"),
+        }
+
+        // Test out of bounds
+        let result = get_line(&Value::Int(10)).unwrap();
+        match result {
+            Value::Variant { variant_name, .. } => {
+                assert_eq!(variant_name, "None");
+            }
+            _ => panic!("Expected Option::None variant"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_line_type_error() {
+        let result = get_line(&Value::Str("not an int".to_string()));
+        assert!(matches!(result, Err(VmError::TypeMismatch { expected: "int", .. })));
+    }
+
+    #[test]
+    fn test_get_lines_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_lines(&Value::Int(0), &Value::Int(2)).unwrap();
+
+        // Should return empty list
+        assert!(matches!(result, Value::Nil));
+    }
+
+    #[test]
+    fn test_get_lines_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: None,
+            cwd: None,
+            lines: vec![
+                "line 0".to_string(),
+                "line 1".to_string(),
+                "line 2".to_string(),
+                "line 3".to_string(),
+            ],
+            window_title: String::new(),
+            tab_title: String::new(),
+            terminal_size: (80, 24),
+        });
+
+        register_provider(provider);
+
+        let result = get_lines(&Value::Int(1), &Value::Int(3)).unwrap();
+
+        // Should return list containing "line 1" and "line 2"
+        let mut count = 0;
+        let mut current = result;
+        loop {
+            match current {
+                Value::Nil => break,
+                Value::Cons { head, tail } => {
+                    count += 1;
+                    current = *tail;
+                    // Verify it's a string
+                    assert!(matches!(*head, Value::Str(_)));
+                }
+                _ => panic!("Expected list structure"),
+            }
+        }
+        assert_eq!(count, 2);
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_lines_type_error() {
+        let result = get_lines(&Value::Str("not an int".to_string()), &Value::Int(2));
+        assert!(matches!(result, Err(VmError::TypeMismatch { expected: "int", .. })));
+
+        let result = get_lines(&Value::Int(0), &Value::Str("not an int".to_string()));
+        assert!(matches!(result, Err(VmError::TypeMismatch { expected: "int", .. })));
+    }
+
+    #[test]
+    fn test_get_window_title_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_window_title(&Value::Unit).unwrap();
+
+        assert!(matches!(result, Value::Str(s) if s.is_empty()));
+    }
+
+    #[test]
+    fn test_get_window_title_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: None,
+            cwd: None,
+            lines: vec![],
+            window_title: "Terminal Window".to_string(),
+            tab_title: String::new(),
+            terminal_size: (80, 24),
+        });
+
+        register_provider(provider);
+
+        let result = get_window_title(&Value::Unit).unwrap();
+
+        assert!(matches!(result, Value::Str(s) if s == "Terminal Window"));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_tab_title_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_tab_title(&Value::Unit).unwrap();
+
+        assert!(matches!(result, Value::Str(s) if s.is_empty()));
+    }
+
+    #[test]
+    fn test_get_tab_title_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: None,
+            cwd: None,
+            lines: vec![],
+            window_title: String::new(),
+            tab_title: "Tab 1".to_string(),
+            terminal_size: (80, 24),
+        });
+
+        register_provider(provider);
+
+        let result = get_tab_title(&Value::Unit).unwrap();
+
+        assert!(matches!(result, Value::Str(s) if s == "Tab 1"));
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_terminal_size_no_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        unregister_provider();
+
+        let result = get_terminal_size(&Value::Unit).unwrap();
+
+        match result {
+            Value::Tuple(values) => {
+                assert_eq!(values.len(), 2);
+                assert!(matches!(values[0], Value::Int(0)));
+                assert!(matches!(values[1], Value::Int(0)));
+            }
+            _ => panic!("Expected tuple"),
+        }
+    }
+
+    #[test]
+    fn test_get_terminal_size_with_provider() {
+        let _lock = TEST_MUTEX.lock().unwrap();
+        let provider = Box::new(MockTerminalProvider {
+            foreground_process: None,
+            cwd: None,
+            lines: vec![],
+            window_title: String::new(),
+            tab_title: String::new(),
+            terminal_size: (120, 40),
+        });
+
+        register_provider(provider);
+
+        let result = get_terminal_size(&Value::Unit).unwrap();
+
+        match result {
+            Value::Tuple(values) => {
+                assert_eq!(values.len(), 2);
+                assert!(matches!(values[0], Value::Int(120)));
+                assert!(matches!(values[1], Value::Int(40)));
+            }
+            _ => panic!("Expected tuple"),
+        }
+
+        unregister_provider();
+    }
+
+    #[test]
+    fn test_get_terminal_size_type_error() {
+        let result = get_terminal_size(&Value::Int(42));
+        assert!(matches!(result, Err(VmError::TypeMismatch { expected: "unit", .. })));
+    }
+
+    #[test]
+    fn test_process_info_to_value() {
+        let process_info = ProcessInfo {
+            name: "vim".to_string(),
+            pid: 9999,
+            command_line: Some("/usr/bin/vim file.txt".to_string()),
+        };
+
+        let value = process_info.to_value();
+
+        match value {
+            Value::Record(record) => {
+                let r = record.lock().unwrap();
+                assert!(matches!(r.get("name"), Some(Value::Str(s)) if s == "vim"));
+                assert!(matches!(r.get("pid"), Some(Value::Int(9999))));
+
+                // Check commandLine is Some variant
+                if let Some(Value::Variant { variant_name, fields, .. }) = r.get("commandLine") {
+                    assert_eq!(variant_name, "Some");
+                    assert_eq!(fields.len(), 1);
+                    assert!(matches!(&fields[0], Value::Str(s) if s == "/usr/bin/vim file.txt"));
+                } else {
+                    panic!("Expected Option variant for commandLine");
+                }
+            }
+            _ => panic!("Expected Record"),
+        }
+    }
+
+    #[test]
+    fn test_process_info_to_value_no_command_line() {
+        let process_info = ProcessInfo {
+            name: "vim".to_string(),
+            pid: 9999,
+            command_line: None,
+        };
+
+        let value = process_info.to_value();
+
+        match value {
+            Value::Record(record) => {
+                let r = record.lock().unwrap();
+
+                // Check commandLine is None variant
+                if let Some(Value::Variant { variant_name, fields, .. }) = r.get("commandLine") {
+                    assert_eq!(variant_name, "None");
+                    assert_eq!(fields.len(), 0);
+                } else {
+                    panic!("Expected Option variant for commandLine");
+                }
+            }
+            _ => panic!("Expected Record"),
+        }
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/ui_formatting.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/ui_formatting.rs
@@ -1,0 +1,650 @@
+// Fusabi Standard Library - UI Formatting Module
+// Provides callback-based APIs for status bar and UI element formatting
+
+use crate::value::Value;
+use crate::vm::{Vm, VmError};
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+
+/// Global storage for formatter callbacks
+/// Maps handler ID to Fusabi closures
+static FORMATTERS: Mutex<Option<Formatters>> = Mutex::new(None);
+
+/// Thread-local counter for generating unique handler IDs
+static NEXT_HANDLER_ID: Mutex<i64> = Mutex::new(1);
+
+/// Storage structure for different formatter types
+struct Formatters {
+    tab_formatters: HashMap<i64, Value>,
+    status_left_formatters: HashMap<i64, Value>,
+    status_right_formatters: HashMap<i64, Value>,
+}
+
+impl Formatters {
+    fn new() -> Self {
+        Self {
+            tab_formatters: HashMap::new(),
+            status_left_formatters: HashMap::new(),
+            status_right_formatters: HashMap::new(),
+        }
+    }
+}
+
+/// Initialize the formatter storage if not already initialized
+fn ensure_formatters_initialized() {
+    let mut formatters = FORMATTERS.lock().unwrap();
+    if formatters.is_none() {
+        *formatters = Some(Formatters::new());
+    }
+}
+
+/// Generate a new unique handler ID
+fn next_handler_id() -> i64 {
+    let mut id = NEXT_HANDLER_ID.lock().unwrap();
+    let current = *id;
+    *id += 1;
+    current
+}
+
+/// UIFormatting.onFormatTab : (TabInfo -> StatusSegment list) -> int
+/// Registers a formatter callback for tab rendering
+/// Returns a handler ID that can be used to remove the formatter
+pub fn on_format_tab(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "UIFormatting.onFormatTab expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let formatter = &args[0];
+
+    // Verify it's a callable value (Closure or NativeFn)
+    if !matches!(formatter, Value::Closure(_) | Value::NativeFn { .. }) {
+        return Err(VmError::TypeMismatch {
+            expected: "function",
+            got: formatter.type_name(),
+        });
+    }
+
+    ensure_formatters_initialized();
+    let handler_id = next_handler_id();
+
+    let mut formatters = FORMATTERS.lock().unwrap();
+    if let Some(ref mut fmt) = *formatters {
+        fmt.tab_formatters.insert(handler_id, formatter.clone());
+    }
+
+    Ok(Value::Int(handler_id))
+}
+
+/// UIFormatting.onFormatStatusLeft : (StatusInfo -> StatusSegment list) -> int
+/// Registers a formatter callback for left status area
+/// Returns a handler ID that can be used to remove the formatter
+pub fn on_format_status_left(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "UIFormatting.onFormatStatusLeft expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let formatter = &args[0];
+
+    // Verify it's a callable value
+    if !matches!(formatter, Value::Closure(_) | Value::NativeFn { .. }) {
+        return Err(VmError::TypeMismatch {
+            expected: "function",
+            got: formatter.type_name(),
+        });
+    }
+
+    ensure_formatters_initialized();
+    let handler_id = next_handler_id();
+
+    let mut formatters = FORMATTERS.lock().unwrap();
+    if let Some(ref mut fmt) = *formatters {
+        fmt.status_left_formatters
+            .insert(handler_id, formatter.clone());
+    }
+
+    Ok(Value::Int(handler_id))
+}
+
+/// UIFormatting.onFormatStatusRight : (StatusInfo -> StatusSegment list) -> int
+/// Registers a formatter callback for right status area
+/// Returns a handler ID that can be used to remove the formatter
+pub fn on_format_status_right(_vm: &mut Vm, args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "UIFormatting.onFormatStatusRight expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let formatter = &args[0];
+
+    // Verify it's a callable value
+    if !matches!(formatter, Value::Closure(_) | Value::NativeFn { .. }) {
+        return Err(VmError::TypeMismatch {
+            expected: "function",
+            got: formatter.type_name(),
+        });
+    }
+
+    ensure_formatters_initialized();
+    let handler_id = next_handler_id();
+
+    let mut formatters = FORMATTERS.lock().unwrap();
+    if let Some(ref mut fmt) = *formatters {
+        fmt.status_right_formatters
+            .insert(handler_id, formatter.clone());
+    }
+
+    Ok(Value::Int(handler_id))
+}
+
+/// UIFormatting.removeFormatter : int -> bool
+/// Removes a formatter by its handler ID
+/// Returns true if a formatter was removed, false if not found
+pub fn remove_formatter(args: &[Value]) -> Result<Value, VmError> {
+    if args.len() != 1 {
+        return Err(VmError::Runtime(format!(
+            "UIFormatting.removeFormatter expects 1 argument, got {}",
+            args.len()
+        )));
+    }
+
+    let handler_id = match &args[0] {
+        Value::Int(id) => *id,
+        _ => {
+            return Err(VmError::TypeMismatch {
+                expected: "int",
+                got: args[0].type_name(),
+            })
+        }
+    };
+
+    ensure_formatters_initialized();
+    let mut formatters = FORMATTERS.lock().unwrap();
+
+    if let Some(ref mut fmt) = *formatters {
+        let removed = fmt.tab_formatters.remove(&handler_id).is_some()
+            || fmt.status_left_formatters.remove(&handler_id).is_some()
+            || fmt.status_right_formatters.remove(&handler_id).is_some();
+
+        Ok(Value::Bool(removed))
+    } else {
+        Ok(Value::Bool(false))
+    }
+}
+
+/// UIFormatting.clearFormatters : unit -> unit
+/// Removes all registered formatters
+pub fn clear_formatters(args: &[Value]) -> Result<Value, VmError> {
+    if !args.is_empty() {
+        return Err(VmError::Runtime(format!(
+            "UIFormatting.clearFormatters expects 0 arguments, got {}",
+            args.len()
+        )));
+    }
+
+    ensure_formatters_initialized();
+    let mut formatters = FORMATTERS.lock().unwrap();
+
+    if let Some(ref mut fmt) = *formatters {
+        fmt.tab_formatters.clear();
+        fmt.status_left_formatters.clear();
+        fmt.status_right_formatters.clear();
+    }
+
+    Ok(Value::Unit)
+}
+
+// ============================================================================
+// Host-side API for invoking formatters
+// ============================================================================
+
+/// Create a TabInfo record from individual components
+/// TabInfo: { index: int, title: string, active: bool, hasActivity: bool }
+pub fn create_tab_info(
+    index: i64,
+    title: String,
+    active: bool,
+    has_activity: bool,
+) -> Value {
+    let mut fields = HashMap::new();
+    fields.insert("index".to_string(), Value::Int(index));
+    fields.insert("title".to_string(), Value::Str(title));
+    fields.insert("active".to_string(), Value::Bool(active));
+    fields.insert("hasActivity".to_string(), Value::Bool(has_activity));
+    Value::Record(Arc::new(Mutex::new(fields)))
+}
+
+/// Create a StatusInfo record from individual components
+/// StatusInfo: { currentTab: int, totalTabs: int, time: string }
+pub fn create_status_info(current_tab: i64, total_tabs: i64, time: String) -> Value {
+    let mut fields = HashMap::new();
+    fields.insert("currentTab".to_string(), Value::Int(current_tab));
+    fields.insert("totalTabs".to_string(), Value::Int(total_tabs));
+    fields.insert("time".to_string(), Value::Str(time));
+    Value::Record(Arc::new(Mutex::new(fields)))
+}
+
+/// Convert a StatusSegment Value to Rust-friendly components
+/// StatusSegment: { text: string, fgColor: string option, bgColor: string option, bold: bool }
+pub fn extract_status_segment(
+    segment: &Value,
+) -> Result<(String, Option<String>, Option<String>, bool), VmError> {
+    match segment {
+        Value::Record(fields) => {
+            let fields = fields.lock().unwrap();
+
+            let text = match fields.get("text") {
+                Some(Value::Str(s)) => s.clone(),
+                _ => {
+                    return Err(VmError::Runtime(
+                        "StatusSegment.text must be a string".to_string(),
+                    ))
+                }
+            };
+
+            let fg_color = match fields.get("fgColor") {
+                Some(Value::Variant {
+                    variant_name,
+                    fields: f,
+                    ..
+                }) if variant_name == "Some" && f.len() == 1 => {
+                    if let Value::Str(s) = &f[0] {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            let bg_color = match fields.get("bgColor") {
+                Some(Value::Variant {
+                    variant_name,
+                    fields: f,
+                    ..
+                }) if variant_name == "Some" && f.len() == 1 => {
+                    if let Value::Str(s) = &f[0] {
+                        Some(s.clone())
+                    } else {
+                        None
+                    }
+                }
+                _ => None,
+            };
+
+            let bold = match fields.get("bold") {
+                Some(Value::Bool(b)) => *b,
+                _ => false,
+            };
+
+            Ok((text, fg_color, bg_color, bold))
+        }
+        _ => Err(VmError::Runtime(
+            "StatusSegment must be a record".to_string(),
+        )),
+    }
+}
+
+/// Invoke all registered tab formatters and collect results
+/// Returns a list of segment lists, one for each formatter
+pub fn invoke_tab_formatters(
+    vm: &mut Vm,
+    tab_info: Value,
+) -> Result<Vec<Vec<Value>>, VmError> {
+    ensure_formatters_initialized();
+    let formatters = FORMATTERS.lock().unwrap();
+
+    let mut results = Vec::new();
+
+    if let Some(ref fmt) = *formatters {
+        for (_id, formatter) in &fmt.tab_formatters {
+            let result = vm.call_value(formatter.clone(), &[tab_info.clone()])?;
+
+            // Convert result (list) to vector
+            let segments = match &result {
+                Value::Nil => vec![],
+                Value::Cons { .. } => result
+                    .list_to_vec()
+                    .ok_or(VmError::Runtime("Malformed list returned from formatter".into()))?,
+                _ => {
+                    return Err(VmError::Runtime(
+                        "Tab formatter must return a list of StatusSegments".to_string(),
+                    ))
+                }
+            };
+
+            results.push(segments);
+        }
+    }
+
+    Ok(results)
+}
+
+/// Invoke all registered status left formatters and collect results
+pub fn invoke_status_left_formatters(
+    vm: &mut Vm,
+    status_info: Value,
+) -> Result<Vec<Vec<Value>>, VmError> {
+    ensure_formatters_initialized();
+    let formatters = FORMATTERS.lock().unwrap();
+
+    let mut results = Vec::new();
+
+    if let Some(ref fmt) = *formatters {
+        for (_id, formatter) in &fmt.status_left_formatters {
+            let result = vm.call_value(formatter.clone(), &[status_info.clone()])?;
+
+            // Convert result (list) to vector
+            let segments = match &result {
+                Value::Nil => vec![],
+                Value::Cons { .. } => result
+                    .list_to_vec()
+                    .ok_or(VmError::Runtime("Malformed list returned from formatter".into()))?,
+                _ => {
+                    return Err(VmError::Runtime(
+                        "Status left formatter must return a list of StatusSegments".to_string(),
+                    ))
+                }
+            };
+
+            results.push(segments);
+        }
+    }
+
+    Ok(results)
+}
+
+/// Invoke all registered status right formatters and collect results
+pub fn invoke_status_right_formatters(
+    vm: &mut Vm,
+    status_info: Value,
+) -> Result<Vec<Vec<Value>>, VmError> {
+    ensure_formatters_initialized();
+    let formatters = FORMATTERS.lock().unwrap();
+
+    let mut results = Vec::new();
+
+    if let Some(ref fmt) = *formatters {
+        for (_id, formatter) in &fmt.status_right_formatters {
+            let result = vm.call_value(formatter.clone(), &[status_info.clone()])?;
+
+            // Convert result (list) to vector
+            let segments = match &result {
+                Value::Nil => vec![],
+                Value::Cons { .. } => result
+                    .list_to_vec()
+                    .ok_or(VmError::Runtime("Malformed list returned from formatter".into()))?,
+                _ => {
+                    return Err(VmError::Runtime(
+                        "Status right formatter must return a list of StatusSegments".to_string(),
+                    ))
+                }
+            };
+
+            results.push(segments);
+        }
+    }
+
+    Ok(results)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::closure::Closure;
+    use crate::vm::Vm;
+
+    #[test]
+    fn test_on_format_tab_registration() {
+        let mut vm = Vm::new();
+
+        // Create a mock closure
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+
+        let result = on_format_tab(&mut vm, &[closure.clone()]);
+        assert!(result.is_ok());
+
+        // Verify we got an integer handler ID
+        match result.unwrap() {
+            Value::Int(id) => assert!(id > 0),
+            _ => panic!("Expected Int handler ID"),
+        }
+    }
+
+    #[test]
+    fn test_on_format_status_left_registration() {
+        let mut vm = Vm::new();
+
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+
+        let result = on_format_status_left(&mut vm, &[closure]);
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            Value::Int(id) => assert!(id > 0),
+            _ => panic!("Expected Int handler ID"),
+        }
+    }
+
+    #[test]
+    fn test_on_format_status_right_registration() {
+        let mut vm = Vm::new();
+
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+
+        let result = on_format_status_right(&mut vm, &[closure]);
+        assert!(result.is_ok());
+
+        match result.unwrap() {
+            Value::Int(id) => assert!(id > 0),
+            _ => panic!("Expected Int handler ID"),
+        }
+    }
+
+    #[test]
+    fn test_remove_formatter() {
+        let mut vm = Vm::new();
+
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+
+        // Register a formatter
+        let handler_id = match on_format_tab(&mut vm, &[closure]).unwrap() {
+            Value::Int(id) => id,
+            _ => panic!("Expected Int handler ID"),
+        };
+
+        // Remove it
+        let result = remove_formatter(&[Value::Int(handler_id)]);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Bool(true));
+
+        // Try to remove again (should return false)
+        let result = remove_formatter(&[Value::Int(handler_id)]);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_clear_formatters() {
+        let mut vm = Vm::new();
+
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+
+        // Register multiple formatters
+        on_format_tab(&mut vm, &[closure.clone()]).unwrap();
+        on_format_status_left(&mut vm, &[closure.clone()]).unwrap();
+        on_format_status_right(&mut vm, &[closure]).unwrap();
+
+        // Clear all
+        let result = clear_formatters(&[]);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Unit);
+
+        // Verify all are cleared (removing non-existent should return false)
+        let result = remove_formatter(&[Value::Int(1)]);
+        assert_eq!(result.unwrap(), Value::Bool(false));
+    }
+
+    #[test]
+    fn test_create_tab_info() {
+        let tab_info = create_tab_info(0, "Test Tab".to_string(), true, false);
+
+        match tab_info {
+            Value::Record(fields) => {
+                let fields = fields.lock().unwrap();
+                assert_eq!(fields.get("index"), Some(&Value::Int(0)));
+                assert_eq!(
+                    fields.get("title"),
+                    Some(&Value::Str("Test Tab".to_string()))
+                );
+                assert_eq!(fields.get("active"), Some(&Value::Bool(true)));
+                assert_eq!(fields.get("hasActivity"), Some(&Value::Bool(false)));
+            }
+            _ => panic!("Expected Record"),
+        }
+    }
+
+    #[test]
+    fn test_create_status_info() {
+        let status_info = create_status_info(1, 5, "12:34:56".to_string());
+
+        match status_info {
+            Value::Record(fields) => {
+                let fields = fields.lock().unwrap();
+                assert_eq!(fields.get("currentTab"), Some(&Value::Int(1)));
+                assert_eq!(fields.get("totalTabs"), Some(&Value::Int(5)));
+                assert_eq!(
+                    fields.get("time"),
+                    Some(&Value::Str("12:34:56".to_string()))
+                );
+            }
+            _ => panic!("Expected Record"),
+        }
+    }
+
+    #[test]
+    fn test_extract_status_segment() {
+        let mut fields = HashMap::new();
+        fields.insert("text".to_string(), Value::Str("Hello".to_string()));
+        fields.insert(
+            "fgColor".to_string(),
+            Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "Some".to_string(),
+                fields: vec![Value::Str("red".to_string())],
+            },
+        );
+        fields.insert(
+            "bgColor".to_string(),
+            Value::Variant {
+                type_name: "Option".to_string(),
+                variant_name: "None".to_string(),
+                fields: vec![],
+            },
+        );
+        fields.insert("bold".to_string(), Value::Bool(true));
+
+        let segment = Value::Record(Arc::new(Mutex::new(fields)));
+        let result = extract_status_segment(&segment);
+
+        assert!(result.is_ok());
+        let (text, fg_color, bg_color, bold) = result.unwrap();
+        assert_eq!(text, "Hello");
+        assert_eq!(fg_color, Some("red".to_string()));
+        assert_eq!(bg_color, None);
+        assert_eq!(bold, true);
+    }
+
+    #[test]
+    fn test_on_format_tab_invalid_args() {
+        let mut vm = Vm::new();
+
+        // Test with non-function
+        let result = on_format_tab(&mut vm, &[Value::Int(42)]);
+        assert!(result.is_err());
+
+        // Test with wrong number of args
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+        let result = on_format_tab(&mut vm, &[closure.clone(), closure]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_remove_formatter_invalid_args() {
+        // Test with non-int
+        let result = remove_formatter(&[Value::Str("hello".to_string())]);
+        assert!(result.is_err());
+
+        // Test with wrong number of args
+        let result = remove_formatter(&[Value::Int(1), Value::Int(2)]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_clear_formatters_invalid_args() {
+        // Test with arguments when none expected
+        let result = clear_formatters(&[Value::Unit]);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_unique_handler_ids() {
+        let mut vm = Vm::new();
+        let closure = Value::Closure(Arc::new(Closure {
+            func_addr: 0,
+            upvalues: vec![],
+            arity: 1,
+        }));
+
+        let id1 = match on_format_tab(&mut vm, &[closure.clone()]).unwrap() {
+            Value::Int(id) => id,
+            _ => panic!("Expected Int"),
+        };
+
+        let id2 = match on_format_tab(&mut vm, &[closure.clone()]).unwrap() {
+            Value::Int(id) => id,
+            _ => panic!("Expected Int"),
+        };
+
+        let id3 = match on_format_status_left(&mut vm, &[closure]).unwrap() {
+            Value::Int(id) => id,
+            _ => panic!("Expected Int"),
+        };
+
+        // All IDs should be unique
+        assert_ne!(id1, id2);
+        assert_ne!(id2, id3);
+        assert_ne!(id1, id3);
+    }
+}


### PR DESCRIPTION
## Summary

Wave 3 of stdlib expansion implementing terminal integration APIs for Scarab Terminal Emulator and other host applications.

### TerminalInfo Module (#149)

Query terminal state and process information:

| Function | Signature | Description |
|----------|-----------|-------------|
| `getForegroundProcess` | `unit -> ProcessInfo option` | Get foreground process info |
| `getCurrentWorkingDir` | `unit -> string option` | Get current directory |
| `getLine` | `int -> string option` | Read specific line |
| `getLines` | `int -> int -> string list` | Read line range |
| `getWindowTitle` | `unit -> string` | Get window title |
| `getTabTitle` | `unit -> string` | Get tab title |
| `getTerminalSize` | `unit -> (int * int)` | Get cols x rows |

### TerminalControl Module (#150)

Programmatic pane/window control:

| Function | Signature | Description |
|----------|-----------|-------------|
| `sendText` | `string -> unit` | Send text to terminal |
| `sendKeys` | `string list -> unit` | Send key sequences |
| `splitHorizontal/Vertical` | `unit -> int option` | Split pane |
| `closePane/focusPane` | `int -> bool` | Pane control |
| `createTab/closeTab` | `unit -> int option` / `int -> bool` | Tab management |
| `setTabTitle` | `int -> string -> bool` | Set tab title |
| `showToast` | `string -> unit` | Show notification |

### UIFormatting Module (#151)

Status bar and UI formatting callbacks:

| Function | Signature | Description |
|----------|-----------|-------------|
| `onFormatTab` | `(TabInfo -> StatusSegment list) -> int` | Tab formatter |
| `onFormatStatusLeft/Right` | `(StatusInfo -> StatusSegment list) -> int` | Status bar |
| `removeFormatter` | `int -> bool` | Remove formatter |
| `clearFormatters` | `unit -> unit` | Clear all |

### Commands Module (#153)

Command palette integration:

| Function | Signature | Description |
|----------|-----------|-------------|
| `register` | `CommandInfo -> int` | Register command |
| `registerMany` | `CommandInfo list -> int list` | Batch register |
| `unregister` | `int -> bool` | Remove command |
| `list` | `unit -> CommandInfo list` | List all commands |
| `getById` | `string -> CommandInfo option` | Get by ID |
| `invoke` | `string -> unit` | Execute command |

## Architecture

All modules use a **pluggable backend pattern**:
- Host applications (terminal emulators) register provider implementations
- APIs work gracefully when no provider is registered (return defaults/no-op)
- Thread-safe using `OnceLock` or `Mutex` patterns
- No external dependencies beyond `std`

## Test Plan

- [x] TerminalInfo: 20 tests
- [x] TerminalControl: 27 tests
- [x] UIFormatting: 12 tests
- [x] Commands: 10 tests
- [x] Total: 69 unit tests

## Related Issues

Closes #149 (TerminalInfo API)
Closes #150 (TerminalControl API)
Closes #151 (UIFormatting API)
Closes #153 (Commands API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)