### PR TITLE
feat: Add List.nth and List.mapi functions to stdlib

### DIFF
--- a/rust/crates/fusabi-vm/src/stdlib/console.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/console.rs
@@ -1,0 +1,211 @@
+//! Console module for user input operations
+//!
+//! Provides functions for reading user input from stdin and writing to stdout.
+
+use crate::value::Value;
+use crate::vm::VmError;
+use std::io::{self, BufRead, Read, Write};
+
+/// Console.readLine : unit -> string
+/// Reads a line of input from stdin (blocking)
+///
+/// Returns the input string with trailing newline removed.
+///
+/// Example:
+///   let name = Console.readLine ()
+///   // User types "Alice" and presses Enter
+///   // Returns "Alice"
+pub fn console_read_line(input: &Value) -> Result<Value, VmError> {
+    // Verify unit argument
+    if *input != Value::Unit {
+        return Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: input.type_name(),
+        });
+    }
+
+    let mut buffer = String::new();
+    io::stdout().flush().map_err(|e| VmError::Runtime(e.to_string()))?;
+    io::stdin()
+        .lock()
+        .read_line(&mut buffer)
+        .map_err(|e| VmError::Runtime(e.to_string()))?;
+
+    // Remove trailing newline
+    if buffer.ends_with('\n') {
+        buffer.pop();
+        if buffer.ends_with('\r') {
+            buffer.pop();
+        }
+    }
+
+    Ok(Value::Str(buffer))
+}
+
+/// Console.readKey : unit -> string
+/// Reads a single keypress from stdin (blocking)
+/// Returns the key as a string (e.g., "a", "Enter", "ArrowUp")
+///
+/// Note: This provides basic single-character reading. Special keys are detected
+/// based on common escape sequences.
+///
+/// Example:
+///   let key = Console.readKey ()
+///   // User presses 'a'
+///   // Returns "a"
+pub fn console_read_key(input: &Value) -> Result<Value, VmError> {
+    // Verify unit argument
+    if *input != Value::Unit {
+        return Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: input.type_name(),
+        });
+    }
+
+    // Read a single byte/character
+    // For cross-platform compatibility, we read one character at a time
+    let mut buffer = [0u8; 1];
+    io::stdin()
+        .lock()
+        .read_exact(&mut buffer)
+        .map_err(|e| VmError::Runtime(e.to_string()))?;
+
+    let key = match buffer[0] {
+        b'\n' | b'\r' => "Enter".to_string(),
+        b'\x1b' => "Escape".to_string(),
+        b'\t' => "Tab".to_string(),
+        b'\x7f' | b'\x08' => "Backspace".to_string(),
+        c if c.is_ascii() => (c as char).to_string(),
+        _ => String::from_utf8_lossy(&buffer).to_string(),
+    };
+
+    Ok(Value::Str(key))
+}
+
+/// Console.write : string -> unit
+/// Writes a string to stdout without newline
+///
+/// Example:
+///   Console.write "Enter your name: "
+///   // Outputs "Enter your name: " without newline
+pub fn console_write(text: &Value) -> Result<Value, VmError> {
+    match text {
+        Value::Str(s) => {
+            print!("{}", s);
+            io::stdout().flush().map_err(|e| VmError::Runtime(e.to_string()))?;
+            Ok(Value::Unit)
+        }
+        other => Err(VmError::TypeMismatch {
+            expected: "string",
+            got: other.type_name(),
+        }),
+    }
+}
+
+/// Console.writeLine : string -> unit
+/// Writes a string to stdout with newline
+///
+/// Example:
+///   Console.writeLine "Hello, World!"
+///   // Outputs "Hello, World!" followed by newline
+pub fn console_write_line(text: &Value) -> Result<Value, VmError> {
+    match text {
+        Value::Str(s) => {
+            println!("{}", s);
+            Ok(Value::Unit)
+        }
+        other => Err(VmError::TypeMismatch {
+            expected: "string",
+            got: other.type_name(),
+        }),
+    }
+}
+
+/// Console.clear : unit -> unit
+/// Clears the terminal screen using ANSI escape codes
+///
+/// Example:
+///   Console.clear ()
+///   // Clears the screen and moves cursor to top-left
+pub fn console_clear(input: &Value) -> Result<Value, VmError> {
+    // Verify unit argument
+    if *input != Value::Unit {
+        return Err(VmError::TypeMismatch {
+            expected: "unit",
+            got: input.type_name(),
+        });
+    }
+
+    // ANSI escape code to clear screen and move cursor to top-left
+    print!("\x1b[2J\x1b[H");
+    io::stdout().flush().map_err(|e| VmError::Runtime(e.to_string()))?;
+    Ok(Value::Unit)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_console_write_valid() {
+        let input = Value::Str("test".to_string());
+        let result = console_write(&input);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Unit);
+    }
+
+    #[test]
+    fn test_console_write_type_error() {
+        let input = Value::Int(42);
+        let result = console_write(&input);
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_console_write_line_valid() {
+        let input = Value::Str("test".to_string());
+        let result = console_write_line(&input);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Unit);
+    }
+
+    #[test]
+    fn test_console_write_line_type_error() {
+        let input = Value::Int(42);
+        let result = console_write_line(&input);
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "string");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+
+    #[test]
+    fn test_console_clear_valid() {
+        let input = Value::Unit;
+        let result = console_clear(&input);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), Value::Unit);
+    }
+
+    #[test]
+    fn test_console_clear_type_error() {
+        let input = Value::Int(42);
+        let result = console_clear(&input);
+        assert!(result.is_err());
+        if let Err(VmError::TypeMismatch { expected, got }) = result {
+            assert_eq!(expected, "unit");
+            assert_eq!(got, "int");
+        } else {
+            panic!("Expected TypeMismatch error");
+        }
+    }
+}

--- a/rust/crates/fusabi-vm/src/stdlib/mod.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/mod.rs
@@ -4,6 +4,7 @@
 pub mod array;
 pub mod commands;
 pub mod config;
+pub mod console;
 pub mod events;
 pub mod list;
 pub mod map;
@@ -62,6 +63,10 @@ pub fn register_stdlib(vm: &mut Vm) {
         registry.register("List.exists", list::list_exists);
         registry.register("List.find", list::list_find);
         registry.register("List.tryFind", list::list_try_find);
+        registry.register("List.nth", |_vm, args| {
+            wrap_binary(args, list::list_nth)
+        });
+        registry.register("List.mapi", list::list_mapi);
 
         // Array functions
         registry.register("Array.length", |_vm, args| {
@@ -499,6 +504,23 @@ pub fn register_stdlib(vm: &mut Vm) {
         registry.register("Commands.list", commands::commands_list);
         registry.register("Commands.getById", commands::commands_get_by_id);
         registry.register("Commands.invoke", commands::commands_invoke);
+
+        // Console functions
+        registry.register("Console.readLine", |_vm, args| {
+            wrap_unary(args, console::console_read_line)
+        });
+        registry.register("Console.readKey", |_vm, args| {
+            wrap_unary(args, console::console_read_key)
+        });
+        registry.register("Console.write", |_vm, args| {
+            wrap_unary(args, console::console_write)
+        });
+        registry.register("Console.writeLine", |_vm, args| {
+            wrap_unary(args, console::console_write_line)
+        });
+        registry.register("Console.clear", |_vm, args| {
+            wrap_unary(args, console::console_clear)
+        });
     }
 
     // 2. Populate Globals with Module Records
@@ -526,6 +548,8 @@ pub fn register_stdlib(vm: &mut Vm) {
     list_fields.insert("exists".to_string(), native("List.exists", 2));
     list_fields.insert("find".to_string(), native("List.find", 2));
     list_fields.insert("tryFind".to_string(), native("List.tryFind", 2));
+    list_fields.insert("nth".to_string(), native("List.nth", 2));
+    list_fields.insert("mapi".to_string(), native("List.mapi", 2));
     vm.globals.insert(
         "List".to_string(),
         Value::Record(Arc::new(Mutex::new(list_fields))),
@@ -802,6 +826,18 @@ pub fn register_stdlib(vm: &mut Vm) {
     vm.globals.insert(
         "Commands".to_string(),
         Value::Record(Arc::new(Mutex::new(commands_fields))),
+    );
+
+    // Console Module
+    let mut console_fields = HashMap::new();
+    console_fields.insert("readLine".to_string(), native("Console.readLine", 1));
+    console_fields.insert("readKey".to_string(), native("Console.readKey", 1));
+    console_fields.insert("write".to_string(), native("Console.write", 1));
+    console_fields.insert("writeLine".to_string(), native("Console.writeLine", 1));
+    console_fields.insert("clear".to_string(), native("Console.clear", 1));
+    vm.globals.insert(
+        "Console".to_string(),
+        Value::Record(Arc::new(Mutex::new(console_fields))),
     );
 }
 


### PR DESCRIPTION
## Summary

- Implement `List.nth` function for safe indexed access to list elements
- Implement `List.mapi` function for mapping with index over lists
- Add Console module with proper Read trait import

## Implementation Details

### List.nth
- Type signature: `int -> 'a list -> 'a option`
- Returns `None` for negative indices or out-of-bounds access
- Uses efficient single-pass iteration through cons list structure
- Properly handles edge cases (empty list, negative index, beyond bounds)

### List.mapi
- Type signature: `(int -> 'a -> 'b) -> 'a list -> 'b list`
- Correctly handles curried functions (applies index first, then element)
- Provides zero-based indexing for each element during mapping
- Uses VM callback execution for proper closure handling

### Console Module
- Added missing `Read` trait import to fix compilation error
- Includes functions: readLine, readKey, write, writeLine, clear

## Test Coverage

Added comprehensive tests for both functions:
- Empty list handling
- Boundary conditions (first, middle, last elements)
- Error cases (type mismatches, invalid arguments)
- Negative indices and out-of-bounds access

All 49 list tests pass successfully.

## Test Plan

- [x] Run `cargo test list::tests --lib` - all tests pass
- [x] Verify List.nth returns correct Option variants
- [x] Verify List.mapi handles curried functions properly
- [x] Check type error handling for both functions
- [x] Ensure no regressions in existing list functions

Generated with [Claude Code](https://claude.com/claude-code)