### PR TITLE
ci: Add documentation freshness check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,29 @@ jobs:
         env:
           RUSTDOCFLAGS: -D warnings
 
+  # Documentation freshness check
+  docs-freshness:
+    name: Documentation Freshness
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Nushell
+        uses: hustcer/setup-nu@v3
+        with:
+          version: '*'
+
+      - name: Generate documentation
+        run: nu scripts/gen-docs.nu
+
+      - name: Check docs are up to date
+        run: |
+          if ! git diff --exit-code docs/STDLIB_REFERENCE.md; then
+            echo "::error::Documentation is stale! Run 'nu scripts/gen-docs.nu' and commit the changes."
+            exit 1
+          fi
+
   # Benchmark - ensure benchmarks compile (don't run them in CI)
   benchmark-check:
     name: Benchmark Check
@@ -248,7 +271,7 @@ jobs:
   # All checks passed
   ci-success:
     name: CI Success
-    needs: [check, test, build-release, coverage, security-audit, docs]
+    needs: [check, test, build-release, coverage, security-audit, docs, docs-freshness]
     runs-on: ubuntu-latest
     steps:
       - name: Mark CI as successful


### PR DESCRIPTION
## Summary
- Add new `docs-freshness` job to CI pipeline that verifies STDLIB_REFERENCE.md is up-to-date
- Installs Nushell and runs `gen-docs.nu` to regenerate documentation
- Fails CI if documentation differs from committed version
- Integrated into `ci-success` gate to prevent stale docs from being merged

## Benefits
- Ensures documentation stays synchronized with code changes
- Prevents accidental merges of stale documentation
- Provides clear error message with remediation steps
- Runs independently in parallel with other CI jobs

## Test plan
- [ ] Verify CI workflow syntax is valid
- [ ] Confirm docs-freshness job runs successfully when docs are fresh
- [ ] Verify job fails appropriately when docs are stale
- [ ] Check that error message is clear and actionable
- [ ] Ensure ci-success gate includes docs-freshness job

Generated with [Claude Code](https://claude.com/claude-code)