### PR TITLE
feat: Add fusabi-pm package manager scaffolding

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -4,5 +4,6 @@ members = [
   "crates/fusabi-vm",
   "crates/fusabi",
   "crates/fusabi-bench-compare",
+  "crates/fusabi-pm",
 ]
 resolver = "2"

--- a/rust/crates/fusabi-pm/Cargo.toml
+++ b/rust/crates/fusabi-pm/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "fusabi-pm"
+version = "0.1.0"
+edition = "2021"
+description = "Fusabi Package Manager"
+license = "MIT"
+
+[dependencies]
+serde = { version = "1.0", features = ["derive"] }
+toml = "0.8"
+thiserror = "1.0"
+clap = { version = "4.0", features = ["derive"] }
+
+[dev-dependencies]
+tempfile = "3.0"
+
+[lib]
+name = "fusabi_pm"
+path = "src/lib.rs"
+
+[[bin]]
+name = "fpm"
+path = "src/cli.rs"

--- a/rust/crates/fusabi-pm/src/cli.rs
+++ b/rust/crates/fusabi-pm/src/cli.rs
@@ -1,0 +1,217 @@
+//! Command-line interface for the Fusabi Package Manager (fpm).
+
+use clap::{Parser, Subcommand};
+use fusabi_pm::{Dependency, Manifest, Package};
+use std::fs;
+
+#[derive(Parser)]
+#[command(name = "fpm")]
+#[command(about = "Fusabi Package Manager", long_about = None)]
+#[command(version)]
+struct Cli {
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Initialize a new Fusabi package
+    Init {
+        /// Package name (defaults to current directory name)
+        #[arg(long)]
+        name: Option<String>,
+    },
+    /// Build the current package
+    Build,
+    /// Run the current package
+    Run,
+    /// Add a dependency to the current package
+    Add {
+        /// Package name to add
+        package: String,
+
+        /// Version requirement
+        #[arg(long)]
+        version: Option<String>,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+
+    match cli.command {
+        Commands::Init { name } => {
+            if let Err(e) = init_package(name) {
+                eprintln!("Error initializing package: {}", e);
+                std::process::exit(1);
+            }
+        }
+        Commands::Build => {
+            println!("Build functionality not yet implemented");
+            std::process::exit(1);
+        }
+        Commands::Run => {
+            println!("Run functionality not yet implemented");
+            std::process::exit(1);
+        }
+        Commands::Add { package, version } => {
+            if let Err(e) = add_package(package, version) {
+                eprintln!("Error adding package: {}", e);
+                std::process::exit(1);
+            }
+        }
+    }
+}
+
+/// Initializes a new Fusabi package in the current directory.
+fn init_package(name: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let current_dir = std::env::current_dir()?;
+    let manifest_path = current_dir.join("fusabi.toml");
+    let src_dir = current_dir.join("src");
+    let main_file = src_dir.join("main.fsx");
+
+    // Check if fusabi.toml already exists
+    if manifest_path.exists() {
+        return Err("fusabi.toml already exists in this directory".into());
+    }
+
+    // Determine package name
+    let package_name = name.unwrap_or_else(|| {
+        current_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("fusabi-package")
+            .to_string()
+    });
+
+    // Create package metadata
+    let package = Package {
+        name: package_name.clone(),
+        version: "0.1.0".to_string(),
+        authors: vec![],
+        description: None,
+        license: Some("MIT".to_string()),
+        repository: None,
+    };
+
+    // Create manifest
+    let manifest = Manifest::new(package);
+    let toml_content = manifest.to_toml()?;
+
+    // Write fusabi.toml
+    fs::write(&manifest_path, toml_content)?;
+    println!("Created fusabi.toml");
+
+    // Create src directory if it doesn't exist
+    if !src_dir.exists() {
+        fs::create_dir(&src_dir)?;
+        println!("Created src/ directory");
+    }
+
+    // Create main.fsx if it doesn't exist
+    if !main_file.exists() {
+        let main_content = r#"// Main entry point for the Fusabi package
+
+fn main() {
+    println("Hello, Fusabi!")
+}
+"#;
+        fs::write(&main_file, main_content)?;
+        println!("Created src/main.fsx");
+    }
+
+    println!("\nPackage '{}' initialized successfully!", package_name);
+    println!("\nNext steps:");
+    println!("  - Edit fusabi.toml to configure your package");
+    println!("  - Add your code to src/main.fsx");
+    println!("  - Run 'fpm build' to build your package (coming soon)");
+
+    Ok(())
+}
+
+/// Adds a dependency to the current package.
+fn add_package(
+    package: String,
+    version: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let current_dir = std::env::current_dir()?;
+    let manifest_path = current_dir.join("fusabi.toml");
+
+    // Check if fusabi.toml exists
+    if !manifest_path.exists() {
+        return Err("fusabi.toml not found. Run 'fpm init' first.".into());
+    }
+
+    // Load existing manifest
+    let mut manifest = Manifest::load(&manifest_path)?;
+
+    // Create dependency
+    let dependency = match version {
+        Some(v) => Dependency::Simple(v),
+        None => Dependency::Simple("*".to_string()),
+    };
+
+    // Add dependency
+    manifest.add_dependency(package.clone(), dependency);
+
+    // Write updated manifest
+    let toml_content = manifest.to_toml()?;
+    fs::write(&manifest_path, toml_content)?;
+
+    println!("Added dependency: {}", package);
+    println!("Updated fusabi.toml");
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_init_package_creates_files() {
+        let temp_dir = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+
+        // Change to temp directory
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+
+        // Initialize package
+        let result = init_package(Some("test-package".to_string()));
+        assert!(result.is_ok());
+
+        // Check that files were created
+        assert!(temp_dir.path().join("fusabi.toml").exists());
+        assert!(temp_dir.path().join("src").exists());
+        assert!(temp_dir.path().join("src/main.fsx").exists());
+
+        // Verify manifest content
+        let manifest = Manifest::load(temp_dir.path().join("fusabi.toml")).unwrap();
+        assert_eq!(manifest.package.name, "test-package");
+        assert_eq!(manifest.package.version, "0.1.0");
+
+        // Restore original directory
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+
+    #[test]
+    fn test_init_package_fails_if_manifest_exists() {
+        let temp_dir = TempDir::new().unwrap();
+        let original_dir = std::env::current_dir().unwrap();
+
+        // Change to temp directory
+        std::env::set_current_dir(temp_dir.path()).unwrap();
+
+        // Create existing fusabi.toml
+        fs::write(temp_dir.path().join("fusabi.toml"), "").unwrap();
+
+        // Try to initialize package
+        let result = init_package(None);
+        assert!(result.is_err());
+
+        // Restore original directory
+        std::env::set_current_dir(original_dir).unwrap();
+    }
+}

--- a/rust/crates/fusabi-pm/src/lib.rs
+++ b/rust/crates/fusabi-pm/src/lib.rs
@@ -1,0 +1,7 @@
+//! Fusabi Package Manager (fpm)
+//!
+//! A package manager for the Fusabi language.
+
+pub mod manifest;
+
+pub use manifest::{Dependencies, Dependency, Manifest, Package};

--- a/rust/crates/fusabi-pm/src/manifest.rs
+++ b/rust/crates/fusabi-pm/src/manifest.rs
@@ -1,0 +1,350 @@
+//! Manifest file handling for Fusabi packages.
+//!
+//! This module provides types and functions for working with fusabi.toml manifest files.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::fs;
+use std::path::Path;
+use thiserror::Error;
+
+/// Type alias for package dependencies.
+pub type Dependencies = HashMap<String, Dependency>;
+
+/// Errors that can occur when working with manifests.
+#[derive(Debug, Error)]
+pub enum ManifestError {
+    #[error("Failed to read manifest file: {0}")]
+    IoError(#[from] std::io::Error),
+
+    #[error("Failed to parse manifest: {0}")]
+    ParseError(#[from] toml::de::Error),
+
+    #[error("Failed to serialize manifest: {0}")]
+    SerializeError(#[from] toml::ser::Error),
+
+    #[error("Invalid manifest: {0}")]
+    InvalidManifest(String),
+}
+
+/// Represents a fusabi.toml manifest file.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Manifest {
+    /// Package metadata.
+    pub package: Package,
+
+    /// Package dependencies.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dependencies: Dependencies,
+
+    /// Development dependencies.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub dev_dependencies: Dependencies,
+}
+
+impl Manifest {
+    /// Creates a new manifest with the given package information.
+    pub fn new(package: Package) -> Self {
+        Self {
+            package,
+            dependencies: HashMap::new(),
+            dev_dependencies: HashMap::new(),
+        }
+    }
+
+    /// Loads a manifest from a file path.
+    pub fn load<P: AsRef<Path>>(path: P) -> Result<Self, ManifestError> {
+        let contents = fs::read_to_string(path)?;
+        Self::parse(&contents)
+    }
+
+    /// Parses a manifest from a TOML string.
+    pub fn parse(toml_str: &str) -> Result<Self, ManifestError> {
+        let manifest: Manifest = toml::from_str(toml_str)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    /// Serializes the manifest to a TOML string.
+    pub fn to_toml(&self) -> Result<String, ManifestError> {
+        Ok(toml::to_string_pretty(self)?)
+    }
+
+    /// Validates the manifest structure.
+    fn validate(&self) -> Result<(), ManifestError> {
+        if self.package.name.is_empty() {
+            return Err(ManifestError::InvalidManifest(
+                "Package name cannot be empty".to_string(),
+            ));
+        }
+
+        if self.package.version.is_empty() {
+            return Err(ManifestError::InvalidManifest(
+                "Package version cannot be empty".to_string(),
+            ));
+        }
+
+        Ok(())
+    }
+
+    /// Adds a dependency to the manifest.
+    pub fn add_dependency(&mut self, name: String, dependency: Dependency) {
+        self.dependencies.insert(name, dependency);
+    }
+
+    /// Adds a development dependency to the manifest.
+    pub fn add_dev_dependency(&mut self, name: String, dependency: Dependency) {
+        self.dev_dependencies.insert(name, dependency);
+    }
+}
+
+/// Package metadata from the manifest.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Package {
+    /// The package name.
+    pub name: String,
+
+    /// The package version.
+    pub version: String,
+
+    /// Package authors.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub authors: Vec<String>,
+
+    /// Package description.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+
+    /// Package license.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub license: Option<String>,
+
+    /// Package repository URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub repository: Option<String>,
+}
+
+impl Package {
+    /// Creates a new package with the given name and version.
+    pub fn new(name: String, version: String) -> Self {
+        Self {
+            name,
+            version,
+            authors: Vec::new(),
+            description: None,
+            license: None,
+            repository: None,
+        }
+    }
+}
+
+/// Represents a dependency specification.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(untagged)]
+pub enum Dependency {
+    /// Simple version string (e.g., "1.0.0" or "^1.0").
+    Simple(String),
+
+    /// Detailed dependency specification.
+    Detailed(DetailedDependency),
+}
+
+/// Detailed dependency specification with multiple options.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct DetailedDependency {
+    /// Version requirement.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub version: Option<String>,
+
+    /// Local file path.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub path: Option<String>,
+
+    /// Git repository URL.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub git: Option<String>,
+
+    /// Git revision (commit, branch, or tag).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rev: Option<String>,
+
+    /// Whether this dependency is optional.
+    #[serde(default, skip_serializing_if = "is_false")]
+    pub optional: bool,
+}
+
+/// Helper function for serde to skip serializing false values.
+fn is_false(b: &bool) -> bool {
+    !b
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_simple_manifest() {
+        let toml = r#"
+[package]
+name = "test-package"
+version = "0.1.0"
+authors = ["Test Author <test@example.com>"]
+description = "A test package"
+license = "MIT"
+repository = "https://github.com/test/test"
+"#;
+
+        let manifest = Manifest::parse(toml).unwrap();
+        assert_eq!(manifest.package.name, "test-package");
+        assert_eq!(manifest.package.version, "0.1.0");
+        assert_eq!(manifest.package.authors.len(), 1);
+        assert_eq!(
+            manifest.package.description,
+            Some("A test package".to_string())
+        );
+        assert_eq!(manifest.package.license, Some("MIT".to_string()));
+        assert_eq!(
+            manifest.package.repository,
+            Some("https://github.com/test/test".to_string())
+        );
+    }
+
+    #[test]
+    fn test_parse_manifest_with_dependencies() {
+        let toml = r#"
+[package]
+name = "test-package"
+version = "0.1.0"
+
+[dependencies]
+simple-dep = "1.0.0"
+
+[dependencies.detailed-dep]
+version = "2.0.0"
+optional = true
+"#;
+
+        let manifest = Manifest::parse(toml).unwrap();
+        assert_eq!(manifest.dependencies.len(), 2);
+
+        let simple_dep = manifest.dependencies.get("simple-dep").unwrap();
+        assert!(matches!(simple_dep, Dependency::Simple(v) if v == "1.0.0"));
+
+        let detailed_dep = manifest.dependencies.get("detailed-dep").unwrap();
+        match detailed_dep {
+            Dependency::Detailed(d) => {
+                assert_eq!(d.version, Some("2.0.0".to_string()));
+                assert_eq!(d.optional, true);
+            }
+            _ => panic!("Expected detailed dependency"),
+        }
+    }
+
+    #[test]
+    fn test_parse_manifest_with_git_dependency() {
+        let toml = r#"
+[package]
+name = "test-package"
+version = "0.1.0"
+
+[dependencies.git-dep]
+git = "https://github.com/example/repo"
+rev = "abc123"
+"#;
+
+        let manifest = Manifest::parse(toml).unwrap();
+        let git_dep = manifest.dependencies.get("git-dep").unwrap();
+        match git_dep {
+            Dependency::Detailed(d) => {
+                assert_eq!(d.git, Some("https://github.com/example/repo".to_string()));
+                assert_eq!(d.rev, Some("abc123".to_string()));
+            }
+            _ => panic!("Expected detailed dependency"),
+        }
+    }
+
+    #[test]
+    fn test_parse_manifest_with_path_dependency() {
+        let toml = r#"
+[package]
+name = "test-package"
+version = "0.1.0"
+
+[dependencies.local-dep]
+path = "../local-package"
+"#;
+
+        let manifest = Manifest::parse(toml).unwrap();
+        let local_dep = manifest.dependencies.get("local-dep").unwrap();
+        match local_dep {
+            Dependency::Detailed(d) => {
+                assert_eq!(d.path, Some("../local-package".to_string()));
+            }
+            _ => panic!("Expected detailed dependency"),
+        }
+    }
+
+    #[test]
+    fn test_manifest_validation_empty_name() {
+        let toml = r#"
+[package]
+name = ""
+version = "0.1.0"
+"#;
+
+        let result = Manifest::parse(toml);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ManifestError::InvalidManifest(_)));
+    }
+
+    #[test]
+    fn test_manifest_validation_empty_version() {
+        let toml = r#"
+[package]
+name = "test"
+version = ""
+"#;
+
+        let result = Manifest::parse(toml);
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), ManifestError::InvalidManifest(_)));
+    }
+
+    #[test]
+    fn test_manifest_to_toml() {
+        let package = Package::new("test-package".to_string(), "0.1.0".to_string());
+        let mut manifest = Manifest::new(package);
+        manifest.add_dependency("dep1".to_string(), Dependency::Simple("1.0.0".to_string()));
+
+        let toml_str = manifest.to_toml().unwrap();
+        assert!(toml_str.contains("name = \"test-package\""));
+        assert!(toml_str.contains("version = \"0.1.0\""));
+        assert!(toml_str.contains("dep1"));
+    }
+
+    #[test]
+    fn test_add_dependency() {
+        let package = Package::new("test".to_string(), "0.1.0".to_string());
+        let mut manifest = Manifest::new(package);
+
+        manifest.add_dependency("dep1".to_string(), Dependency::Simple("1.0.0".to_string()));
+        assert_eq!(manifest.dependencies.len(), 1);
+
+        manifest.add_dev_dependency(
+            "dev-dep1".to_string(),
+            Dependency::Simple("2.0.0".to_string()),
+        );
+        assert_eq!(manifest.dev_dependencies.len(), 1);
+    }
+
+    #[test]
+    fn test_new_package() {
+        let package = Package::new("my-package".to_string(), "1.0.0".to_string());
+        assert_eq!(package.name, "my-package");
+        assert_eq!(package.version, "1.0.0");
+        assert!(package.authors.is_empty());
+        assert!(package.description.is_none());
+        assert!(package.license.is_none());
+        assert!(package.repository.is_none());
+    }
+}


### PR DESCRIPTION
## Summary
- Implement initial scaffolding for the Fusabi Package Manager (fpm)
- Add fusabi-pm crate with library and binary targets
- Implement manifest handling for fusabi.toml files
- Add CLI commands: init, add, build (placeholder), run (placeholder)
- All tests passing (11 total)

## Details

### New Crate Structure
Created `fusabi-pm` crate in `rust/crates/fusabi-pm/` with:
- Library target (`fusabi_pm`) for core functionality
- Binary target (`fpm`) for command-line interface

### Manifest Module (`manifest.rs`)
Implemented comprehensive manifest file handling:
- **Manifest struct**: Represents fusabi.toml with package metadata and dependencies
- **Package struct**: Contains name, version, authors, description, license, repository
- **Dependency enum**: 
  - Simple: version string (e.g., "1.0.0")
  - Detailed: supports version, path, git, rev, and optional fields
- **ManifestError**: Type-safe error handling with thiserror
- **Core methods**:
  - `Manifest::load()` - Load from file path
  - `Manifest::parse()` - Parse from TOML string
  - `Manifest::to_toml()` - Serialize to TOML
  - `Manifest::new()` - Create new manifest
  - `add_dependency()` / `add_dev_dependency()` - Manage dependencies
- **9 comprehensive tests** covering parsing, validation, and serialization

### CLI Module (`cli.rs`)
Implemented clap-based command-line interface:
- **fpm init [--name NAME]**: Initialize new Fusabi package
  - Creates fusabi.toml with package metadata
  - Creates src/ directory and src/main.fsx template
  - Uses current directory name if --name not provided
- **fpm add PACKAGE [--version VERSION]**: Add dependency to manifest
  - Updates fusabi.toml with new dependency
  - Defaults to "*" version if not specified
- **fpm build**: Placeholder for future build functionality
- **fpm run**: Placeholder for future run functionality
- **2 integration tests** for init command

### Dependencies
- **serde**: Serialization/deserialization with derive macros
- **toml**: TOML parsing and generation
- **thiserror**: Ergonomic error handling
- **clap**: Command-line argument parsing with derive macros
- **tempfile** (dev): Temporary directories for testing

### Test Results
```
running 11 tests
✓ manifest::tests::test_new_package
✓ manifest::tests::test_add_dependency
✓ manifest::tests::test_manifest_validation_empty_name
✓ manifest::tests::test_manifest_validation_empty_version
✓ manifest::tests::test_manifest_to_toml
✓ manifest::tests::test_parse_manifest_with_git_dependency
✓ manifest::tests::test_parse_manifest_with_path_dependency
✓ manifest::tests::test_parse_manifest_with_dependencies
✓ manifest::tests::test_parse_simple_manifest
✓ tests::test_init_package_fails_if_manifest_exists
✓ tests::test_init_package_creates_files
```

## Test plan
- [x] Verify cargo check -p fusabi-pm passes
- [x] Verify all tests pass (11/11)
- [x] Add fusabi-pm to workspace members
- [x] Ensure no compilation warnings

## Next Steps
Future PRs will add:
- Dependency resolution and downloading
- Build system integration
- Run command implementation
- Package publishing
- Version management
- Lock file support

🤖 Generated with [Claude Code](https://claude.com/claude-code)