### PR TITLE
feat: Implement fpm build and run commands

### DIFF
--- a/rust/crates/fusabi-pm/Cargo.toml
+++ b/rust/crates/fusabi-pm/Cargo.toml
@@ -10,6 +10,8 @@ serde = { version = "1.0", features = ["derive"] }
 toml = "0.8"
 thiserror = "1.0"
 clap = { version = "4.0", features = ["derive"] }
+fusabi = { path = "../fusabi" }
+fusabi-vm = { path = "../fusabi-vm" }
 
 [dev-dependencies]
 tempfile = "3.0"


### PR DESCRIPTION
## Summary

This PR implements the `fpm build` and `fpm run` commands for the Fusabi package manager (fpm), enabling users to compile and execute Fusabi projects.

- `fpm build` - Compiles src/main.fsx to bytecode and saves to target/<package-name>.fzb
- `fpm run` - Executes src/main.fsx and prints the result

## Changes

### `/rust/crates/fusabi-pm/Cargo.toml`
- Added dependencies on `fusabi` and `fusabi-vm` crates to enable compilation and execution

### `/rust/crates/fusabi-pm/src/cli.rs`
- Implemented `build_package()` function that:
  - Loads the fusabi.toml manifest
  - Finds and reads src/main.fsx
  - Compiles source to bytecode using `fusabi::compile_to_bytecode`
  - Creates target/ directory if needed
  - Writes output to target/<package-name>.fzb
- Implemented `run_package()` function that:
  - Loads the fusabi.toml manifest
  - Finds and reads src/main.fsx
  - Executes source using `fusabi::run_source`
  - Prints non-unit results to stdout
- Both commands provide clear error messages and user feedback

## Implementation Details

The implementation follows the Fusabi compilation pipeline:
1. Load and validate fusabi.toml manifest
2. Read source from src/main.fsx
3. For build: compile to bytecode and save to target/
4. For run: execute directly and display results

Error handling covers:
- Missing fusabi.toml (prompts user to run `fpm init`)
- Missing src/main.fsx
- Compilation errors
- Runtime errors

## Test Plan

- [x] Run `cargo check -p fusabi-pm` (passes)
- [ ] Test `fpm init` to create a new project
- [ ] Test `fpm build` on the created project
- [ ] Verify target/<package-name>.fzb is created
- [ ] Test `fpm run` on the created project
- [ ] Verify output is correct
- [ ] Test error cases (missing files, invalid syntax)

🤖 Generated with [Claude Code](https://claude.com/claude-code)