### PR TITLE
perf: optimize VM bytecode dispatch and add constant folding

### DIFF
--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -30,6 +30,10 @@ harness = false
 name = "vm_benchmarks"
 harness = false
 
+[[bench]]
+name = "dispatch_bench"
+harness = false
+
 [features]
 default = ["json"]
 serde = ["dep:serde", "dep:bincode"]

--- a/rust/crates/fusabi-vm/benches/dispatch_bench.rs
+++ b/rust/crates/fusabi-vm/benches/dispatch_bench.rs
@@ -1,0 +1,780 @@
+// Comprehensive VM dispatch benchmarks for issue #203
+// Measures VM performance across different workload patterns
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use fusabi_vm::{ChunkBuilder, Instruction, Value, Vm};
+
+// =============================================================================
+// 1. ARITHMETIC-HEAVY WORKLOADS
+// =============================================================================
+
+fn bench_arithmetic_add_chain(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/arithmetic");
+
+    for size in [100, 1000, 10_000] {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::new("add_chain", size), &size, |b, &size| {
+            let mut builder = ChunkBuilder::new("add_chain");
+            let one_idx = builder.add_constant(Value::Int(1));
+            builder.add_instruction(Instruction::LoadConst(one_idx));
+
+            for _ in 0..size {
+                builder.add_instruction(Instruction::LoadConst(one_idx));
+                builder.add_instruction(Instruction::Add);
+            }
+
+            builder.add_instruction(Instruction::Return);
+            let chunk = builder.build();
+
+            b.iter(|| {
+                let mut vm = Vm::new();
+                black_box(vm.execute(chunk.clone()).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_arithmetic_mixed(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/arithmetic");
+
+    for size in [100, 1000, 5000] {
+        group.throughput(Throughput::Elements(size as u64 * 3));
+        group.bench_with_input(BenchmarkId::new("mixed_ops", size), &size, |b, &size| {
+            let mut builder = ChunkBuilder::new("mixed_arithmetic");
+            let val_idx = builder.add_constant(Value::Int(100));
+            let two_idx = builder.add_constant(Value::Int(2));
+            builder.add_instruction(Instruction::LoadConst(val_idx));
+
+            for _ in 0..size {
+                builder.add_instruction(Instruction::LoadConst(two_idx));
+                builder.add_instruction(Instruction::Add);
+                builder.add_instruction(Instruction::LoadConst(two_idx));
+                builder.add_instruction(Instruction::Sub);
+                builder.add_instruction(Instruction::LoadConst(two_idx));
+                builder.add_instruction(Instruction::Mul);
+            }
+
+            builder.add_instruction(Instruction::Return);
+            let chunk = builder.build();
+
+            b.iter(|| {
+                let mut vm = Vm::new();
+                black_box(vm.execute(chunk.clone()).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_arithmetic_loop_simulation(c: &mut Criterion) {
+    c.bench_function("dispatch/arithmetic/loop_with_accumulator", |b| {
+        let mut builder = ChunkBuilder::new("loop_accumulator");
+
+        let zero_idx = builder.add_constant(Value::Int(0));
+        let one_idx = builder.add_constant(Value::Int(1));
+        let limit_idx = builder.add_constant(Value::Int(1000));
+
+        builder.add_instruction(Instruction::LoadConst(zero_idx));
+        builder.add_instruction(Instruction::StoreLocal(0));
+        builder.add_instruction(Instruction::LoadConst(zero_idx));
+        builder.add_instruction(Instruction::StoreLocal(1));
+
+        let loop_start = builder.instruction_count();
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::LoadConst(limit_idx));
+        builder.add_instruction(Instruction::Lt);
+        builder.add_instruction(Instruction::JumpIfFalse(10));
+
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::Add);
+        builder.add_instruction(Instruction::StoreLocal(1));
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::LoadConst(one_idx));
+        builder.add_instruction(Instruction::Add);
+        builder.add_instruction(Instruction::StoreLocal(0));
+
+        let jump_back = loop_start as i16 - builder.instruction_count() as i16 - 1;
+        builder.add_instruction(Instruction::Jump(jump_back));
+
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::Return);
+
+        let chunk = builder.build();
+
+        b.iter(|| {
+            let mut vm = Vm::new();
+            black_box(vm.execute(chunk.clone()).unwrap());
+        });
+    });
+}
+
+// =============================================================================
+// 2. FUNCTION CALL OVERHEAD
+// =============================================================================
+
+fn bench_recursive_fibonacci(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/function_calls");
+
+    for n in [5, 10, 15, 20] {
+        group.bench_with_input(BenchmarkId::new("fibonacci_recursive", n), &n, |b, &n| {
+            let mut fib_fn = ChunkBuilder::new("fib");
+            let zero_idx = fib_fn.add_constant(Value::Int(0));
+            let one_idx = fib_fn.add_constant(Value::Int(1));
+            let two_idx = fib_fn.add_constant(Value::Int(2));
+
+            fib_fn.add_instruction(Instruction::LoadLocal(0));
+            fib_fn.add_instruction(Instruction::LoadConst(two_idx));
+            fib_fn.add_instruction(Instruction::Lt);
+            fib_fn.add_instruction(Instruction::JumpIfFalse(3));
+
+            fib_fn.add_instruction(Instruction::LoadLocal(0));
+            fib_fn.add_instruction(Instruction::Return);
+            fib_fn.add_instruction(Instruction::Jump(0));
+
+            fib_fn.add_instruction(Instruction::LoadLocal(1));
+            fib_fn.add_instruction(Instruction::LoadLocal(0));
+            fib_fn.add_instruction(Instruction::LoadConst(one_idx));
+            fib_fn.add_instruction(Instruction::Sub);
+            fib_fn.add_instruction(Instruction::Call(1));
+
+            fib_fn.add_instruction(Instruction::LoadLocal(1));
+            fib_fn.add_instruction(Instruction::LoadLocal(0));
+            fib_fn.add_instruction(Instruction::LoadConst(two_idx));
+            fib_fn.add_instruction(Instruction::Sub);
+            fib_fn.add_instruction(Instruction::Call(1));
+
+            fib_fn.add_instruction(Instruction::Add);
+            fib_fn.add_instruction(Instruction::Return);
+
+            let mut builder = ChunkBuilder::new("fib_benchmark");
+            let fn_idx = builder.add_constant(Value::Chunk(fib_fn.build()));
+            builder.add_instruction(Instruction::MakeClosure(fn_idx, 0));
+            builder.add_instruction(Instruction::StoreLocal(0));
+
+            builder.add_instruction(Instruction::LoadLocal(0));
+            builder.add_instruction(Instruction::Dup);
+            let n_idx = builder.add_constant(Value::Int(n));
+            builder.add_instruction(Instruction::LoadConst(n_idx));
+            builder.add_instruction(Instruction::Call(2));
+            builder.add_instruction(Instruction::Return);
+
+            let chunk = builder.build();
+
+            b.iter(|| {
+                let mut vm = Vm::new();
+                black_box(vm.execute(chunk.clone()).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_nested_calls(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/function_calls");
+
+    for depth in [5, 10, 20, 50] {
+        group.bench_with_input(BenchmarkId::new("nested_calls", depth), &depth, |b, &depth| {
+            let mut inner_fn = ChunkBuilder::new("inner");
+            let const_idx = inner_fn.add_constant(Value::Int(42));
+            inner_fn.add_instruction(Instruction::LoadConst(const_idx));
+            inner_fn.add_instruction(Instruction::Return);
+
+            let mut current_chunk = inner_fn.build();
+
+            for i in 0..depth {
+                let mut wrapper = ChunkBuilder::new(&format!("wrapper_{}", i));
+                let fn_idx = wrapper.add_constant(Value::Chunk(current_chunk));
+                wrapper.add_instruction(Instruction::LoadConst(fn_idx));
+                wrapper.add_instruction(Instruction::Call(0));
+                wrapper.add_instruction(Instruction::Return);
+                current_chunk = wrapper.build();
+            }
+
+            let mut builder = ChunkBuilder::new("nested_call_benchmark");
+            for _ in 0..100 {
+                let fn_idx = builder.add_constant(Value::Chunk(current_chunk.clone()));
+                builder.add_instruction(Instruction::LoadConst(fn_idx));
+                builder.add_instruction(Instruction::Call(0));
+                builder.add_instruction(Instruction::Pop);
+            }
+
+            let ret_idx = builder.add_constant(Value::Unit);
+            builder.add_instruction(Instruction::LoadConst(ret_idx));
+            builder.add_instruction(Instruction::Return);
+            let chunk = builder.build();
+
+            b.iter(|| {
+                let mut vm = Vm::new();
+                black_box(vm.execute(chunk.clone()).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_call_return_overhead(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/function_calls");
+
+    for iterations in [100, 1000, 10_000] {
+        group.throughput(Throughput::Elements(iterations as u64));
+        group.bench_with_input(
+            BenchmarkId::new("call_return", iterations),
+            &iterations,
+            |b, &iterations| {
+                let mut simple_fn = ChunkBuilder::new("simple");
+                let const_idx = simple_fn.add_constant(Value::Int(1));
+                simple_fn.add_instruction(Instruction::LoadConst(const_idx));
+                simple_fn.add_instruction(Instruction::Return);
+
+                let mut builder = ChunkBuilder::new("call_return_benchmark");
+                let fn_idx = builder.add_constant(Value::Chunk(simple_fn.build()));
+                builder.add_instruction(Instruction::MakeClosure(fn_idx, 0));
+                builder.add_instruction(Instruction::StoreLocal(0));
+
+                for _ in 0..iterations {
+                    builder.add_instruction(Instruction::LoadLocal(0));
+                    builder.add_instruction(Instruction::Call(0));
+                    builder.add_instruction(Instruction::Pop);
+                }
+
+                let ret_idx = builder.add_constant(Value::Unit);
+                builder.add_instruction(Instruction::LoadConst(ret_idx));
+                builder.add_instruction(Instruction::Return);
+                let chunk = builder.build();
+
+                b.iter(|| {
+                    let mut vm = Vm::new();
+                    black_box(vm.execute(chunk.clone()).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// =============================================================================
+// 3. STACK OPERATIONS
+// =============================================================================
+
+fn bench_push_pop_intensive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/stack");
+
+    for size in [100, 1000, 10_000] {
+        group.throughput(Throughput::Elements(size as u64 * 2));
+        group.bench_with_input(BenchmarkId::new("push_pop", size), &size, |b, &size| {
+            let mut builder = ChunkBuilder::new("push_pop");
+            let val_idx = builder.add_constant(Value::Int(42));
+
+            for _ in 0..size {
+                builder.add_instruction(Instruction::LoadConst(val_idx));
+                builder.add_instruction(Instruction::Pop);
+            }
+
+            builder.add_instruction(Instruction::LoadConst(val_idx));
+            builder.add_instruction(Instruction::Return);
+            let chunk = builder.build();
+
+            b.iter(|| {
+                let mut vm = Vm::new();
+                black_box(vm.execute(chunk.clone()).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+fn bench_local_variable_access(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/stack");
+
+    for num_locals in [4, 16, 64] {
+        group.bench_with_input(
+            BenchmarkId::new("local_access", num_locals),
+            &num_locals,
+            |b, &num_locals| {
+                let mut builder = ChunkBuilder::new("local_access");
+                let val_idx = builder.add_constant(Value::Int(1));
+
+                for i in 0..num_locals.min(255) as u8 {
+                    builder.add_instruction(Instruction::LoadConst(val_idx));
+                    builder.add_instruction(Instruction::StoreLocal(i));
+                }
+
+                for _ in 0..1000 {
+                    for i in 0..num_locals.min(255) as u8 {
+                        builder.add_instruction(Instruction::LoadLocal(i));
+                        builder.add_instruction(Instruction::Pop);
+                    }
+                }
+
+                builder.add_instruction(Instruction::LoadLocal(0));
+                builder.add_instruction(Instruction::Return);
+                let chunk = builder.build();
+
+                b.iter(|| {
+                    let mut vm = Vm::new();
+                    black_box(vm.execute(chunk.clone()).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_dup_operations(c: &mut Criterion) {
+    c.bench_function("dispatch/stack/dup_intensive", |b| {
+        let mut builder = ChunkBuilder::new("dup_intensive");
+        let val_idx = builder.add_constant(Value::Int(1));
+
+        builder.add_instruction(Instruction::LoadConst(val_idx));
+
+        for _ in 0..1000 {
+            builder.add_instruction(Instruction::Dup);
+            builder.add_instruction(Instruction::Pop);
+        }
+
+        builder.add_instruction(Instruction::Return);
+        let chunk = builder.build();
+
+        b.iter(|| {
+            let mut vm = Vm::new();
+            black_box(vm.execute(chunk.clone()).unwrap());
+        });
+    });
+}
+
+// =============================================================================
+// 4. COLLECTION OPERATIONS
+// =============================================================================
+
+fn bench_list_construction(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/collections");
+
+    for size in [3, 10, 50, 100] {
+        group.bench_with_input(
+            BenchmarkId::new("list_construction", size),
+            &size,
+            |b, &size| {
+                let mut builder = ChunkBuilder::new("list_construction");
+                let val_idx = builder.add_constant(Value::Int(42));
+
+                for _ in 0..100 {
+                    for _ in 0..size {
+                        builder.add_instruction(Instruction::LoadConst(val_idx));
+                    }
+                    builder.add_instruction(Instruction::MakeList(size as u16));
+                    builder.add_instruction(Instruction::Pop);
+                }
+
+                let ret_idx = builder.add_constant(Value::Unit);
+                builder.add_instruction(Instruction::LoadConst(ret_idx));
+                builder.add_instruction(Instruction::Return);
+                let chunk = builder.build();
+
+                b.iter(|| {
+                    let mut vm = Vm::new();
+                    black_box(vm.execute(chunk.clone()).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_list_traversal(c: &mut Criterion) {
+    c.bench_function("dispatch/collections/list_traversal", |b| {
+        let mut builder = ChunkBuilder::new("list_traversal");
+
+        for i in 0..100 {
+            let val_idx = builder.add_constant(Value::Int(i));
+            builder.add_instruction(Instruction::LoadConst(val_idx));
+        }
+        builder.add_instruction(Instruction::MakeList(100));
+        builder.add_instruction(Instruction::StoreLocal(0));
+
+        let zero_idx = builder.add_constant(Value::Int(0));
+        builder.add_instruction(Instruction::LoadConst(zero_idx));
+        builder.add_instruction(Instruction::StoreLocal(1));
+
+        let loop_start = builder.instruction_count();
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::IsNil);
+        builder.add_instruction(Instruction::JumpIfFalse(3));
+
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::Return);
+        builder.add_instruction(Instruction::Jump(0));
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::ListHead);
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::Add);
+        builder.add_instruction(Instruction::StoreLocal(1));
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::ListTail);
+        builder.add_instruction(Instruction::StoreLocal(0));
+
+        let jump_back = loop_start as i16 - builder.instruction_count() as i16 - 1;
+        builder.add_instruction(Instruction::Jump(jump_back));
+
+        let chunk = builder.build();
+
+        b.iter(|| {
+            let mut vm = Vm::new();
+            black_box(vm.execute(chunk.clone()).unwrap());
+        });
+    });
+}
+
+fn bench_array_access(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/collections");
+
+    for size in [10, 100, 1000] {
+        group.bench_with_input(
+            BenchmarkId::new("array_random_access", size),
+            &size,
+            |b, &size| {
+                let mut builder = ChunkBuilder::new("array_access");
+
+                for i in 0..size {
+                    let val_idx = builder.add_constant(Value::Int(i as i64));
+                    builder.add_instruction(Instruction::LoadConst(val_idx));
+                }
+                builder.add_instruction(Instruction::MakeArray(size as u16));
+                builder.add_instruction(Instruction::StoreLocal(0));
+
+                for i in 0..1000 {
+                    builder.add_instruction(Instruction::LoadLocal(0));
+                    let idx = builder.add_constant(Value::Int((i % size) as i64));
+                    builder.add_instruction(Instruction::LoadConst(idx));
+                    builder.add_instruction(Instruction::ArrayGet);
+                    builder.add_instruction(Instruction::Pop);
+                }
+
+                let ret_idx = builder.add_constant(Value::Unit);
+                builder.add_instruction(Instruction::LoadConst(ret_idx));
+                builder.add_instruction(Instruction::Return);
+                let chunk = builder.build();
+
+                b.iter(|| {
+                    let mut vm = Vm::new();
+                    black_box(vm.execute(chunk.clone()).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_array_sequential_access(c: &mut Criterion) {
+    c.bench_function("dispatch/collections/array_sequential", |b| {
+        let mut builder = ChunkBuilder::new("array_sequential");
+
+        for i in 0..100 {
+            let val_idx = builder.add_constant(Value::Int(i));
+            builder.add_instruction(Instruction::LoadConst(val_idx));
+        }
+        builder.add_instruction(Instruction::MakeArray(100));
+        builder.add_instruction(Instruction::StoreLocal(0));
+
+        let zero_idx = builder.add_constant(Value::Int(0));
+        let one_idx = builder.add_constant(Value::Int(1));
+        let limit_idx = builder.add_constant(Value::Int(100));
+
+        builder.add_instruction(Instruction::LoadConst(zero_idx));
+        builder.add_instruction(Instruction::StoreLocal(1));
+        builder.add_instruction(Instruction::LoadConst(zero_idx));
+        builder.add_instruction(Instruction::StoreLocal(2));
+
+        let loop_start = builder.instruction_count();
+
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::LoadConst(limit_idx));
+        builder.add_instruction(Instruction::Lt);
+        builder.add_instruction(Instruction::JumpIfFalse(12));
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::ArrayGet);
+        builder.add_instruction(Instruction::LoadLocal(2));
+        builder.add_instruction(Instruction::Add);
+        builder.add_instruction(Instruction::StoreLocal(2));
+
+        builder.add_instruction(Instruction::LoadLocal(1));
+        builder.add_instruction(Instruction::LoadConst(one_idx));
+        builder.add_instruction(Instruction::Add);
+        builder.add_instruction(Instruction::StoreLocal(1));
+
+        let jump_back = loop_start as i16 - builder.instruction_count() as i16 - 1;
+        builder.add_instruction(Instruction::Jump(jump_back));
+
+        builder.add_instruction(Instruction::LoadLocal(2));
+        builder.add_instruction(Instruction::Return);
+
+        let chunk = builder.build();
+
+        b.iter(|| {
+            let mut vm = Vm::new();
+            black_box(vm.execute(chunk.clone()).unwrap());
+        });
+    });
+}
+
+// =============================================================================
+// 5. CONTROL FLOW
+// =============================================================================
+
+fn bench_conditional_jumps(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/control_flow");
+
+    for num_branches in [10, 100, 1000] {
+        group.throughput(Throughput::Elements(num_branches as u64));
+        group.bench_with_input(
+            BenchmarkId::new("conditional_jumps", num_branches),
+            &num_branches,
+            |b, &num_branches| {
+                let mut builder = ChunkBuilder::new("conditional_jumps");
+                let true_idx = builder.add_constant(Value::Bool(true));
+                let false_idx = builder.add_constant(Value::Bool(false));
+                let one_idx = builder.add_constant(Value::Int(1));
+
+                builder.add_instruction(Instruction::LoadConst(one_idx));
+                builder.add_instruction(Instruction::StoreLocal(0));
+
+                for i in 0..num_branches {
+                    let cond_idx = if i % 2 == 0 { true_idx } else { false_idx };
+                    builder.add_instruction(Instruction::LoadConst(cond_idx));
+                    builder.add_instruction(Instruction::JumpIfFalse(4));
+
+                    builder.add_instruction(Instruction::LoadLocal(0));
+                    builder.add_instruction(Instruction::LoadConst(one_idx));
+                    builder.add_instruction(Instruction::Add);
+                    builder.add_instruction(Instruction::StoreLocal(0));
+                }
+
+                builder.add_instruction(Instruction::LoadLocal(0));
+                builder.add_instruction(Instruction::Return);
+                let chunk = builder.build();
+
+                b.iter(|| {
+                    let mut vm = Vm::new();
+                    black_box(vm.execute(chunk.clone()).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_pattern_matching_int(c: &mut Criterion) {
+    c.bench_function("dispatch/control_flow/pattern_match_int", |b| {
+        let mut builder = ChunkBuilder::new("pattern_match_int");
+
+        let test_values: Vec<i64> = (0..100).collect();
+        let result_idx = builder.add_constant(Value::Int(0));
+
+        builder.add_instruction(Instruction::LoadConst(result_idx));
+        builder.add_instruction(Instruction::StoreLocal(0));
+
+        for val in test_values {
+            let val_idx = builder.add_constant(Value::Int(val));
+            builder.add_instruction(Instruction::LoadConst(val_idx));
+            builder.add_instruction(Instruction::StoreLocal(1));
+
+            builder.add_instruction(Instruction::LoadLocal(1));
+            builder.add_instruction(Instruction::CheckInt(0));
+            builder.add_instruction(Instruction::JumpIfFalse(4));
+            let zero_result = builder.add_constant(Value::Int(0));
+            builder.add_instruction(Instruction::LoadConst(zero_result));
+            builder.add_instruction(Instruction::StoreLocal(0));
+            builder.add_instruction(Instruction::Jump(15));
+
+            builder.add_instruction(Instruction::LoadLocal(1));
+            builder.add_instruction(Instruction::CheckInt(1));
+            builder.add_instruction(Instruction::JumpIfFalse(4));
+            let one_result = builder.add_constant(Value::Int(1));
+            builder.add_instruction(Instruction::LoadConst(one_result));
+            builder.add_instruction(Instruction::StoreLocal(0));
+            builder.add_instruction(Instruction::Jump(8));
+
+            builder.add_instruction(Instruction::LoadLocal(1));
+            builder.add_instruction(Instruction::CheckInt(2));
+            builder.add_instruction(Instruction::JumpIfFalse(4));
+            let two_result = builder.add_constant(Value::Int(2));
+            builder.add_instruction(Instruction::LoadConst(two_result));
+            builder.add_instruction(Instruction::StoreLocal(0));
+            builder.add_instruction(Instruction::Jump(1));
+
+            builder.add_instruction(Instruction::Pop);
+        }
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::Return);
+        let chunk = builder.build();
+
+        b.iter(|| {
+            let mut vm = Vm::new();
+            black_box(vm.execute(chunk.clone()).unwrap());
+        });
+    });
+}
+
+fn bench_pattern_matching_tuple(c: &mut Criterion) {
+    c.bench_function("dispatch/control_flow/pattern_match_tuple", |b| {
+        let mut builder = ChunkBuilder::new("pattern_match_tuple");
+
+        let zero_idx = builder.add_constant(Value::Int(0));
+        builder.add_instruction(Instruction::LoadConst(zero_idx));
+        builder.add_instruction(Instruction::StoreLocal(0));
+
+        for i in 0..100 {
+            let elem1 = builder.add_constant(Value::Int(i));
+            let elem2 = builder.add_constant(Value::Int(i + 1));
+            builder.add_instruction(Instruction::LoadConst(elem1));
+            builder.add_instruction(Instruction::LoadConst(elem2));
+            builder.add_instruction(Instruction::MakeTuple(2));
+            builder.add_instruction(Instruction::StoreLocal(1));
+
+            builder.add_instruction(Instruction::LoadLocal(1));
+            builder.add_instruction(Instruction::CheckTupleLen(2));
+            builder.add_instruction(Instruction::JumpIfFalse(7));
+
+            builder.add_instruction(Instruction::LoadLocal(1));
+            builder.add_instruction(Instruction::GetTupleElem(0));
+            builder.add_instruction(Instruction::LoadLocal(1));
+            builder.add_instruction(Instruction::GetTupleElem(1));
+            builder.add_instruction(Instruction::Add);
+            builder.add_instruction(Instruction::LoadLocal(0));
+            builder.add_instruction(Instruction::Add);
+            builder.add_instruction(Instruction::StoreLocal(0));
+        }
+
+        builder.add_instruction(Instruction::LoadLocal(0));
+        builder.add_instruction(Instruction::Return);
+        let chunk = builder.build();
+
+        b.iter(|| {
+            let mut vm = Vm::new();
+            black_box(vm.execute(chunk.clone()).unwrap());
+        });
+    });
+}
+
+fn bench_tight_loop(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/control_flow");
+
+    for iterations in [1000, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(iterations as u64));
+        group.bench_with_input(
+            BenchmarkId::new("tight_loop", iterations),
+            &iterations,
+            |b, &iterations| {
+                let mut builder = ChunkBuilder::new("tight_loop");
+
+                let zero_idx = builder.add_constant(Value::Int(0));
+                let one_idx = builder.add_constant(Value::Int(1));
+                let limit_idx = builder.add_constant(Value::Int(iterations));
+
+                builder.add_instruction(Instruction::LoadConst(zero_idx));
+                builder.add_instruction(Instruction::StoreLocal(0));
+
+                let loop_start = builder.instruction_count();
+
+                builder.add_instruction(Instruction::LoadLocal(0));
+                builder.add_instruction(Instruction::LoadConst(limit_idx));
+                builder.add_instruction(Instruction::Lt);
+                builder.add_instruction(Instruction::JumpIfFalse(6));
+
+                builder.add_instruction(Instruction::LoadLocal(0));
+                builder.add_instruction(Instruction::LoadConst(one_idx));
+                builder.add_instruction(Instruction::Add);
+                builder.add_instruction(Instruction::StoreLocal(0));
+
+                let jump_back = loop_start as i16 - builder.instruction_count() as i16 - 1;
+                builder.add_instruction(Instruction::Jump(jump_back));
+
+                builder.add_instruction(Instruction::LoadLocal(0));
+                builder.add_instruction(Instruction::Return);
+                let chunk = builder.build();
+
+                b.iter(|| {
+                    let mut vm = Vm::new();
+                    black_box(vm.execute(chunk.clone()).unwrap());
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+// =============================================================================
+// BASELINE: INSTRUCTION DISPATCH OVERHEAD
+// =============================================================================
+
+fn bench_dispatch_baseline(c: &mut Criterion) {
+    let mut group = c.benchmark_group("dispatch/baseline");
+
+    for size in [1000, 10_000, 100_000] {
+        group.throughput(Throughput::Elements(size as u64));
+        group.bench_with_input(BenchmarkId::new("noop_sequence", size), &size, |b, &size| {
+            let mut builder = ChunkBuilder::new("noop_sequence");
+            let val_idx = builder.add_constant(Value::Int(1));
+
+            builder.add_instruction(Instruction::LoadConst(val_idx));
+            for _ in 0..size {
+                builder.add_instruction(Instruction::Dup);
+                builder.add_instruction(Instruction::Pop);
+            }
+
+            builder.add_instruction(Instruction::Return);
+            let chunk = builder.build();
+
+            b.iter(|| {
+                let mut vm = Vm::new();
+                black_box(vm.execute(chunk.clone()).unwrap());
+            });
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    bench_arithmetic_add_chain,
+    bench_arithmetic_mixed,
+    bench_arithmetic_loop_simulation,
+    bench_recursive_fibonacci,
+    bench_nested_calls,
+    bench_call_return_overhead,
+    bench_push_pop_intensive,
+    bench_local_variable_access,
+    bench_dup_operations,
+    bench_list_construction,
+    bench_list_traversal,
+    bench_array_access,
+    bench_array_sequential_access,
+    bench_conditional_jumps,
+    bench_pattern_matching_int,
+    bench_pattern_matching_tuple,
+    bench_tight_loop,
+    bench_dispatch_baseline,
+);
+
+criterion_main!(benches);

--- a/rust/crates/fusabi-vm/src/chunk.rs
+++ b/rust/crates/fusabi-vm/src/chunk.rs
@@ -168,6 +168,12 @@ impl Default for Chunk {
     }
 }
 
+impl Chunk {
+    pub fn optimize(&mut self) {
+        crate::optimizer::optimize_chunk(self);
+    }
+}
+
 impl fmt::Display for Chunk {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let name = self.name.as_deref().unwrap_or("<unnamed>");

--- a/rust/crates/fusabi-vm/src/lib.rs
+++ b/rust/crates/fusabi-vm/src/lib.rs
@@ -7,6 +7,8 @@ pub mod error_reporter;
 pub mod gc;
 pub mod host;
 pub mod instruction;
+pub mod optimized_vm;
+pub mod optimizer;
 pub mod stdlib;
 pub mod value;
 pub mod vm;
@@ -17,6 +19,7 @@ pub use error_reporter::{format_error, RuntimeError};
 pub use gc::{GcHeap, GcStats, Trace, Tracer};
 pub use host::{HostFn, HostRegistry};
 pub use instruction::Instruction;
+pub use optimized_vm::FastVm;
 pub use value::{HostData, Value};
 pub use vm::{Frame, Vm, VmError};
 

--- a/rust/crates/fusabi-vm/src/optimized_vm.rs
+++ b/rust/crates/fusabi-vm/src/optimized_vm.rs
@@ -1,0 +1,1051 @@
+// Fusabi Fast VM - Optimized Bytecode Interpreter
+// Implements performance optimizations for the dispatch loop
+//
+// NOTE: This VM is optimized for pure bytecode execution without native function calls.
+// For workloads that require host/native functions, use the standard Vm.
+
+use crate::chunk::Chunk;
+use crate::closure::{Closure, Upvalue};
+use crate::gc::GcHeap;
+use crate::instruction::Instruction;
+use crate::value::Value;
+use crate::vm::{Frame, VmError};
+use std::collections::HashMap;
+use std::sync::Arc;
+use std::sync::Mutex;
+
+/// Default stack capacity for pre-allocation
+const DEFAULT_STACK_CAPACITY: usize = 256;
+/// Default frame stack capacity
+const DEFAULT_FRAME_CAPACITY: usize = 64;
+
+/// Fast VM - optimized bytecode interpreter
+///
+/// Optimizations over the base Vm:
+/// - Pre-allocated stack with capacity
+/// - Inlined hot path functions
+/// - Unchecked access in inner loop with debug assertions
+/// - Reduced instruction cloning via references
+///
+/// Limitations:
+/// - Does not support native/host function calls (use standard Vm for that)
+/// - Optimized for pure bytecode workloads
+#[derive(Debug)]
+pub struct FastVm {
+    /// Value stack for operands and intermediate results (pre-allocated)
+    stack: Vec<Value>,
+    /// Call frame stack (pre-allocated)
+    frames: Vec<Frame>,
+    /// Global variables
+    pub globals: HashMap<String, Value>,
+    /// Garbage collector heap
+    pub gc_heap: GcHeap,
+}
+
+impl FastVm {
+    /// Create a new FastVm with pre-allocated capacity
+    pub fn new() -> Self {
+        FastVm {
+            stack: Vec::with_capacity(DEFAULT_STACK_CAPACITY),
+            frames: Vec::with_capacity(DEFAULT_FRAME_CAPACITY),
+            globals: HashMap::new(),
+            gc_heap: GcHeap::new(),
+        }
+    }
+
+    /// Create a FastVm with custom stack capacity
+    pub fn with_capacity(stack_capacity: usize, frame_capacity: usize) -> Self {
+        FastVm {
+            stack: Vec::with_capacity(stack_capacity),
+            frames: Vec::with_capacity(frame_capacity),
+            globals: HashMap::new(),
+            gc_heap: GcHeap::new(),
+        }
+    }
+
+    /// Create a FastVm with a custom GC threshold
+    pub fn with_gc_threshold(threshold: usize) -> Self {
+        FastVm {
+            stack: Vec::with_capacity(DEFAULT_STACK_CAPACITY),
+            frames: Vec::with_capacity(DEFAULT_FRAME_CAPACITY),
+            globals: HashMap::new(),
+            gc_heap: GcHeap::with_threshold(threshold),
+        }
+    }
+
+    /// Collect garbage
+    pub fn collect_garbage(&mut self) {
+        let mut roots = Vec::new();
+        roots.extend(self.stack.iter().cloned());
+        roots.extend(self.globals.values().cloned());
+        for frame in &self.frames {
+            roots.push(Value::Closure(frame.closure.clone()));
+            for upvalue in &frame.closure.upvalues {
+                let upvalue = upvalue.lock().unwrap();
+                if let Upvalue::Closed(value) = &*upvalue {
+                    roots.push(value.clone());
+                }
+            }
+        }
+        self.gc_heap.collect(&roots);
+    }
+
+    /// Check if GC should run and trigger collection if needed
+    pub fn maybe_collect_garbage(&mut self) {
+        if self.gc_heap.should_collect() {
+            self.collect_garbage();
+        }
+    }
+
+    /// Get GC statistics
+    pub fn gc_stats(&self) -> &crate::gc::GcStats {
+        &self.gc_heap.stats
+    }
+
+    /// Execute a chunk of bytecode
+    pub fn execute(&mut self, chunk: Chunk) -> Result<Value, VmError> {
+        let closure = Arc::new(Closure::new(chunk));
+        let frame = Frame::new(closure, 0);
+        self.frames.push(frame);
+        self.run()
+    }
+
+    /// Optimized interpreter loop
+    pub fn run(&mut self) -> Result<Value, VmError> {
+        let start_depth = self.frames.len();
+
+        loop {
+            // Get instruction pointer and instructions reference
+            let (ip, _instructions, closure) = {
+                let frame = self.frames.last().ok_or(VmError::NoActiveFrame)?;
+                (frame.ip, &frame.closure.chunk.instructions, frame.closure.clone())
+            };
+
+            // Bounds check with early return
+            if ip >= closure.chunk.instructions.len() {
+                return Err(VmError::InvalidInstructionPointer(ip));
+            }
+
+            // SAFETY: We just checked bounds above
+            let instruction = unsafe { closure.chunk.instructions.get_unchecked(ip) };
+
+            // Advance IP
+            self.frames.last_mut().unwrap().ip += 1;
+
+            // Dispatch on instruction reference (no clone for simple instructions)
+            match instruction {
+                Instruction::LoadConst(idx) => {
+                    let constant = self.get_constant(*idx)?;
+                    self.push_fast(constant);
+                }
+
+                Instruction::LoadLocal(idx) => {
+                    let value = self.get_local_fast(*idx)?;
+                    self.push_fast(value);
+                }
+
+                Instruction::StoreLocal(idx) => {
+                    let value = self.pop_fast()?;
+                    self.set_local_fast(*idx, value)?;
+                }
+
+                Instruction::LoadUpvalue(idx) => {
+                    let frame = self.frames.last().ok_or(VmError::NoActiveFrame)?;
+                    let upvalue = frame
+                        .closure
+                        .get_upvalue(*idx as usize)
+                        .ok_or(VmError::Runtime(format!("Invalid upvalue index: {}", idx)))?;
+                    let value = match &*upvalue.lock().unwrap() {
+                        Upvalue::Closed(v) => v.clone(),
+                        Upvalue::Open(stack_idx) => self.stack[*stack_idx].clone(),
+                    };
+                    self.push_fast(value);
+                }
+
+                Instruction::StoreUpvalue(idx) => {
+                    let value = self.pop_fast()?;
+                    let frame = self.frames.last().ok_or(VmError::NoActiveFrame)?;
+                    let upvalue = frame
+                        .closure
+                        .get_upvalue(*idx as usize)
+                        .ok_or(VmError::Runtime(format!("Invalid upvalue index: {}", idx)))?;
+                    match &mut *upvalue.lock().unwrap() {
+                        Upvalue::Closed(v) => *v = value,
+                        Upvalue::Open(stack_idx) => self.stack[*stack_idx] = value,
+                    };
+                }
+
+                Instruction::LoadGlobal(idx) => {
+                    let name_val = self.get_constant(*idx)?;
+                    let name = match name_val {
+                        Value::Str(s) => s,
+                        _ => {
+                            return Err(VmError::TypeMismatch {
+                                expected: "string (global name)",
+                                got: name_val.type_name(),
+                            })
+                        }
+                    };
+                    let value = self.globals.get(&name).cloned().ok_or_else(|| {
+                        VmError::Runtime(format!("Undefined global: {}", name))
+                    })?;
+                    self.push_fast(value);
+                }
+
+                Instruction::Pop => {
+                    self.pop_fast()?;
+                }
+
+                Instruction::Dup => {
+                    let value = self.peek_fast()?.clone();
+                    self.push_fast(value);
+                }
+
+                Instruction::CheckInt(expected) => {
+                    let value = self.peek_fast()?;
+                    let matches = matches!(value, Value::Int(n) if *n == *expected);
+                    self.push_fast(Value::Bool(matches));
+                }
+
+                Instruction::CheckBool(expected) => {
+                    let value = self.peek_fast()?;
+                    let matches = matches!(value, Value::Bool(b) if *b == *expected);
+                    self.push_fast(Value::Bool(matches));
+                }
+
+                Instruction::CheckString(expected) => {
+                    let value = self.peek_fast()?;
+                    let matches = matches!(value, Value::Str(s) if s == expected);
+                    self.push_fast(Value::Bool(matches));
+                }
+
+                Instruction::CheckTupleLen(expected) => {
+                    let value = self.peek_fast()?;
+                    let matches = if let Value::Tuple(elements) = value {
+                        elements.len() == *expected as usize
+                    } else {
+                        false
+                    };
+                    self.push_fast(Value::Bool(matches));
+                }
+
+                Instruction::GetTupleElem(index) => {
+                    let value = self.peek_fast()?;
+                    if let Value::Tuple(elements) = value {
+                        if (*index as usize) < elements.len() {
+                            self.push_fast(elements[*index as usize].clone());
+                        } else {
+                            return Err(VmError::Runtime("Tuple index out of bounds".into()));
+                        }
+                    } else {
+                        return Err(VmError::Runtime("Not a tuple".into()));
+                    }
+                }
+
+                Instruction::Add => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_add(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Sub => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_sub(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Mul => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_mul(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Div => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_div(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Concat => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    match (a, b) {
+                        (Value::Str(a), Value::Str(b)) => {
+                            let mut result = a;
+                            result.push_str(&b);
+                            self.push_fast(Value::Str(result))
+                        }
+                        (a, b) => {
+                            return Err(VmError::Runtime(format!(
+                                "Type mismatch in concatenation: {} ++ {}",
+                                a.type_name(),
+                                b.type_name()
+                            )))
+                        }
+                    }
+                }
+
+                Instruction::Eq => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    self.push_fast(Value::Bool(a == b));
+                }
+
+                Instruction::Neq => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    self.push_fast(Value::Bool(a != b));
+                }
+
+                Instruction::Lt => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_cmp_lt(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Lte => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_cmp_lte(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Gt => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_cmp_gt(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::Gte => {
+                    let b = self.pop_fast()?;
+                    let a = self.pop_fast()?;
+                    let result = self.binary_cmp_gte(a, b)?;
+                    self.push_fast(result);
+                }
+
+                Instruction::And => {
+                    let b = self.pop_bool_fast()?;
+                    let a = self.pop_bool_fast()?;
+                    self.push_fast(Value::Bool(a && b));
+                }
+
+                Instruction::Or => {
+                    let b = self.pop_bool_fast()?;
+                    let a = self.pop_bool_fast()?;
+                    self.push_fast(Value::Bool(a || b));
+                }
+
+                Instruction::Not => {
+                    let a = self.pop_bool_fast()?;
+                    self.push_fast(Value::Bool(!a));
+                }
+
+                Instruction::Jump(offset) => {
+                    self.jump_fast(*offset)?;
+                }
+
+                Instruction::JumpIfFalse(offset) => {
+                    let condition = self.pop_fast()?;
+                    if !condition.is_truthy() {
+                        self.jump_fast(*offset)?;
+                    }
+                }
+
+                Instruction::MakeTuple(n) => {
+                    let n = *n as usize;
+                    let mut elements = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        elements.push(self.pop_fast()?);
+                    }
+                    elements.reverse();
+                    self.push_fast(Value::Tuple(elements));
+                }
+
+                Instruction::GetTupleField(idx) => {
+                    let value = self.pop_fast()?;
+                    match value.as_tuple() {
+                        Some(elements) => {
+                            let index = *idx as usize;
+                            if index >= elements.len() {
+                                return Err(VmError::InvalidTupleFieldIndex {
+                                    index: *idx,
+                                    tuple_size: elements.len(),
+                                });
+                            }
+                            self.push_fast(elements[index].clone());
+                        }
+                        None => {
+                            return Err(VmError::TypeMismatch {
+                                expected: "tuple",
+                                got: value.type_name(),
+                            });
+                        }
+                    }
+                }
+
+                Instruction::MakeClosure(idx, upvalue_count) => {
+                    let constant = self.get_constant(*idx)?;
+                    let prototype = match constant.as_closure() {
+                        Some(c) => c,
+                        None => {
+                            return Err(VmError::TypeMismatch {
+                                expected: "closure",
+                                got: constant.type_name(),
+                            })
+                        }
+                    };
+
+                    let mut closure = Closure::new(prototype.chunk.clone());
+                    closure.arity = prototype.arity;
+                    closure.name = prototype.name.clone();
+
+                    for _ in 0..*upvalue_count {
+                        self.pop_fast()?;
+                    }
+
+                    self.push_fast(Value::Closure(Arc::new(closure)));
+                }
+
+                Instruction::Call(argc) => {
+                    self.execute_call(*argc)?;
+                }
+
+                Instruction::CallMethod(method_name_idx, argc) => {
+                    self.execute_call_method(*method_name_idx, *argc)?;
+                }
+
+                Instruction::TailCall(_argc) => {
+                    // TODO: Implement tail call optimization
+                    unimplemented!("TailCall not yet implemented in FastVm")
+                }
+
+                Instruction::CloseUpvalue(_) => {
+                    // Placeholder
+                }
+
+                Instruction::Return => {
+                    self.frames.pop();
+                    if self.frames.len() < start_depth {
+                        return Ok(self.stack.pop().unwrap_or(Value::Unit));
+                    }
+                }
+
+                Instruction::MakeList(n) => {
+                    let n = *n as usize;
+                    let mut elements = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        elements.push(self.pop_fast()?);
+                    }
+                    elements.reverse();
+                    let list = Value::vec_to_cons(elements);
+                    self.push_fast(list);
+                }
+
+                Instruction::Cons => {
+                    let tail = self.pop_fast()?;
+                    let head = self.pop_fast()?;
+                    self.push_fast(Value::Cons {
+                        head: Box::new(head),
+                        tail: Box::new(tail),
+                    });
+                }
+
+                Instruction::ListHead => {
+                    let value = self.pop_fast()?;
+                    match value {
+                        Value::Cons { head, .. } => self.push_fast(*head),
+                        Value::Nil => return Err(VmError::EmptyList),
+                        _ => {
+                            return Err(VmError::TypeMismatch {
+                                expected: "list",
+                                got: value.type_name(),
+                            })
+                        }
+                    }
+                }
+
+                Instruction::ListTail => {
+                    let value = self.pop_fast()?;
+                    match value {
+                        Value::Cons { tail, .. } => self.push_fast(*tail),
+                        Value::Nil => return Err(VmError::EmptyList),
+                        _ => {
+                            return Err(VmError::TypeMismatch {
+                                expected: "list",
+                                got: value.type_name(),
+                            })
+                        }
+                    }
+                }
+
+                Instruction::IsNil => {
+                    let value = self.pop_fast()?;
+                    self.push_fast(Value::Bool(value.is_nil()));
+                }
+
+                Instruction::MakeArray(n) => {
+                    let n = *n as usize;
+                    let mut elements = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        elements.push(self.pop_fast()?);
+                    }
+                    elements.reverse();
+                    let array = Value::Array(Arc::new(Mutex::new(elements)));
+                    self.push_fast(array);
+                }
+
+                Instruction::ArrayGet => {
+                    let index = self.pop_fast()?;
+                    let array = self.pop_fast()?;
+                    let idx = self.extract_index(&index)?;
+                    let value = array.array_get(idx).map_err(VmError::Runtime)?;
+                    self.push_fast(value);
+                }
+
+                Instruction::ArraySet => {
+                    let value = self.pop_fast()?;
+                    let index = self.pop_fast()?;
+                    let array = self.pop_fast()?;
+                    let idx = self.extract_index(&index)?;
+                    array.array_set(idx, value).map_err(VmError::Runtime)?;
+                    self.push_fast(Value::Unit);
+                }
+
+                Instruction::ArrayLength => {
+                    let array = self.pop_fast()?;
+                    let len = array.array_length().map_err(VmError::Runtime)?;
+                    self.push_fast(Value::Int(len));
+                }
+
+                Instruction::ArrayUpdate => {
+                    let value = self.pop_fast()?;
+                    let index = self.pop_fast()?;
+                    let array = self.pop_fast()?;
+                    let idx = self.extract_index(&index)?;
+
+                    let new_arr = if let Value::Array(arr) = &array {
+                        let mut new_elements = arr.lock().unwrap().clone();
+                        if idx >= new_elements.len() {
+                            return Err(VmError::Runtime(format!("Index {} out of bounds", idx)));
+                        }
+                        new_elements[idx] = value;
+                        Value::Array(Arc::new(Mutex::new(new_elements)))
+                    } else {
+                        return Err(VmError::TypeMismatch {
+                            expected: "array",
+                            got: array.type_name(),
+                        });
+                    };
+                    self.push_fast(new_arr);
+                }
+
+                Instruction::MakeRecord(n) => {
+                    let n = *n as usize;
+                    let mut fields = HashMap::new();
+                    for _ in 0..n {
+                        let field_value = self.pop_fast()?;
+                        let field_name = self.pop_fast()?;
+                        let field_name_str =
+                            field_name.as_str().ok_or_else(|| VmError::TypeMismatch {
+                                expected: "string",
+                                got: field_name.type_name(),
+                            })?;
+                        fields.insert(field_name_str.to_string(), field_value);
+                    }
+                    let record = Value::Record(Arc::new(Mutex::new(fields)));
+                    self.push_fast(record);
+                }
+
+                Instruction::GetRecordField => {
+                    let field_name = self.pop_fast()?;
+                    let record = self.pop_fast()?;
+                    let field_name_str =
+                        field_name.as_str().ok_or_else(|| VmError::TypeMismatch {
+                            expected: "string",
+                            got: field_name.type_name(),
+                        })?;
+                    let field_value = record.record_get(field_name_str).map_err(VmError::Runtime)?;
+                    self.push_fast(field_value);
+                }
+
+                Instruction::UpdateRecord(n) => {
+                    let n = *n as usize;
+                    let mut updates = HashMap::new();
+                    for _ in 0..n {
+                        let field_value = self.pop_fast()?;
+                        let field_name = self.pop_fast()?;
+                        let field_name_str =
+                            field_name.as_str().ok_or_else(|| VmError::TypeMismatch {
+                                expected: "string",
+                                got: field_name.type_name(),
+                            })?;
+                        updates.insert(field_name_str.to_string(), field_value);
+                    }
+                    let record = self.pop_fast()?;
+                    let new_record = record.record_update(updates).map_err(VmError::Runtime)?;
+                    self.push_fast(new_record);
+                }
+
+                Instruction::MakeVariant(n) => {
+                    let n = *n as usize;
+                    let mut fields = Vec::with_capacity(n);
+                    for _ in 0..n {
+                        fields.push(self.pop_fast()?);
+                    }
+                    fields.reverse();
+
+                    let variant_name = self.pop_fast()?;
+                    let type_name = self.pop_fast()?;
+
+                    let type_name_str =
+                        type_name.as_str().ok_or_else(|| VmError::TypeMismatch {
+                            expected: "string",
+                            got: type_name.type_name(),
+                        })?;
+                    let variant_name_str =
+                        variant_name.as_str().ok_or_else(|| VmError::TypeMismatch {
+                            expected: "string",
+                            got: variant_name.type_name(),
+                        })?;
+
+                    let variant = Value::Variant {
+                        type_name: type_name_str.to_string(),
+                        variant_name: variant_name_str.to_string(),
+                        fields,
+                    };
+                    self.push_fast(variant);
+                }
+
+                Instruction::CheckVariantTag(tag) => {
+                    let variant = self.pop_fast()?;
+                    let matches = variant.is_variant_named(tag);
+                    self.push_fast(Value::Bool(matches));
+                }
+
+                Instruction::GetVariantField(idx) => {
+                    let variant = self.pop_fast()?;
+                    let field_value = variant
+                        .variant_get_field(*idx as usize)
+                        .map_err(VmError::Runtime)?;
+                    self.push_fast(field_value);
+                }
+            }
+        }
+    }
+
+    // ========== Inlined Stack Operations ==========
+
+    #[inline(always)]
+    fn push_fast(&mut self, value: Value) {
+        self.stack.push(value);
+    }
+
+    #[inline(always)]
+    fn pop_fast(&mut self) -> Result<Value, VmError> {
+        self.stack.pop().ok_or(VmError::StackUnderflow)
+    }
+
+    #[inline(always)]
+    fn peek_fast(&self) -> Result<&Value, VmError> {
+        self.stack.last().ok_or(VmError::StackUnderflow)
+    }
+
+    #[inline(always)]
+    fn pop_bool_fast(&mut self) -> Result<bool, VmError> {
+        let value = self.pop_fast()?;
+        value.as_bool().ok_or(VmError::TypeMismatch {
+            expected: "bool",
+            got: value.type_name(),
+        })
+    }
+
+    // ========== Inlined Local Variable Access ==========
+
+    #[inline(always)]
+    fn get_local_fast(&self, idx: u8) -> Result<Value, VmError> {
+        let frame = self.frames.last().ok_or(VmError::NoActiveFrame)?;
+        let local_idx = frame.base + idx as usize;
+
+        debug_assert!(local_idx < self.stack.len(), "Local index out of bounds");
+
+        if local_idx < self.stack.len() {
+            // SAFETY: Bounds checked in debug, and we return error in release if invalid
+            Ok(unsafe { self.stack.get_unchecked(local_idx).clone() })
+        } else {
+            Err(VmError::InvalidLocalIndex(idx))
+        }
+    }
+
+    #[inline(always)]
+    fn set_local_fast(&mut self, idx: u8, value: Value) -> Result<(), VmError> {
+        let frame = self.frames.last().ok_or(VmError::NoActiveFrame)?;
+        let local_idx = frame.base + idx as usize;
+
+        while self.stack.len() <= local_idx {
+            self.stack.push(Value::Unit);
+        }
+
+        debug_assert!(local_idx < self.stack.len(), "Local index out of bounds");
+        self.stack[local_idx] = value;
+        Ok(())
+    }
+
+    // ========== Inlined Constant Access ==========
+
+    #[inline(always)]
+    fn get_constant(&self, idx: u16) -> Result<Value, VmError> {
+        let frame = self.frames.last().ok_or(VmError::NoActiveFrame)?;
+        frame
+            .closure
+            .chunk
+            .constant_at(idx)
+            .cloned()
+            .ok_or(VmError::InvalidConstantIndex(idx))
+    }
+
+    // ========== Inlined Jump ==========
+
+    #[inline(always)]
+    fn jump_fast(&mut self, offset: i16) -> Result<(), VmError> {
+        let frame = self.frames.last_mut().ok_or(VmError::NoActiveFrame)?;
+        let new_ip = if offset >= 0 {
+            frame.ip.wrapping_add(offset as usize)
+        } else {
+            frame.ip.wrapping_sub((-offset) as usize)
+        };
+
+        if new_ip > frame.closure.chunk.instructions.len() {
+            return Err(VmError::InvalidInstructionPointer(new_ip));
+        }
+
+        frame.ip = new_ip;
+        Ok(())
+    }
+
+    // ========== Inlined Arithmetic Operations ==========
+
+    #[inline(always)]
+    fn binary_add(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Int(a + b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a + b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in addition: {} + {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    fn binary_sub(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Int(a - b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a - b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in subtraction: {} - {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    fn binary_mul(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Int(a * b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Float(a * b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in multiplication: {} * {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    fn binary_div(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => {
+                if b == 0 {
+                    Err(VmError::DivisionByZero)
+                } else {
+                    Ok(Value::Int(a / b))
+                }
+            }
+            (Value::Float(a), Value::Float(b)) => {
+                if b == 0.0 {
+                    Err(VmError::DivisionByZero)
+                } else {
+                    Ok(Value::Float(a / b))
+                }
+            }
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in division: {} / {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    // ========== Inlined Comparison Operations ==========
+
+    #[inline(always)]
+    fn binary_cmp_lt(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a < b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a < b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in comparison: {} < {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    fn binary_cmp_lte(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a <= b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a <= b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in comparison: {} <= {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    fn binary_cmp_gt(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a > b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a > b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in comparison: {} > {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    #[inline(always)]
+    fn binary_cmp_gte(&self, a: Value, b: Value) -> Result<Value, VmError> {
+        match (a, b) {
+            (Value::Int(a), Value::Int(b)) => Ok(Value::Bool(a >= b)),
+            (Value::Float(a), Value::Float(b)) => Ok(Value::Bool(a >= b)),
+            (a, b) => Err(VmError::Runtime(format!(
+                "Type mismatch in comparison: {} >= {}",
+                a.type_name(),
+                b.type_name()
+            ))),
+        }
+    }
+
+    // ========== Helper Methods ==========
+
+    #[inline(always)]
+    fn extract_index(&self, value: &Value) -> Result<usize, VmError> {
+        match value {
+            Value::Int(i) => {
+                if *i < 0 {
+                    Err(VmError::TypeMismatch {
+                        expected: "non-negative int",
+                        got: "negative int",
+                    })
+                } else {
+                    Ok(*i as usize)
+                }
+            }
+            _ => Err(VmError::TypeMismatch {
+                expected: "int",
+                got: value.type_name(),
+            }),
+        }
+    }
+
+    fn execute_call(&mut self, argc: u8) -> Result<(), VmError> {
+        let func_idx = self
+            .stack
+            .len()
+            .checked_sub(1 + argc as usize)
+            .ok_or(VmError::StackUnderflow)?;
+        let func = self.stack[func_idx].clone();
+
+        match func {
+            Value::Closure(closure) => {
+                if closure.arity != argc {
+                    return Err(VmError::Runtime(format!(
+                        "Arity mismatch: expected {}, got {}",
+                        closure.arity, argc
+                    )));
+                }
+                let base = func_idx + 1;
+                let frame = Frame::new(closure, base);
+                self.frames.push(frame);
+                Ok(())
+            }
+            Value::NativeFn { name, .. } => {
+                // FastVm does not support native function calls
+                // Use the standard Vm for workloads requiring host functions
+                Err(VmError::Runtime(format!(
+                    "FastVm does not support native function calls: '{}'. Use standard Vm instead.",
+                    name
+                )))
+            }
+            _ => Err(VmError::TypeMismatch {
+                expected: "function",
+                got: func.type_name(),
+            }),
+        }
+    }
+
+    fn execute_call_method(&mut self, method_name_idx: u16, _argc: u8) -> Result<(), VmError> {
+        let method_name_val = self.get_constant(method_name_idx)?;
+        let method_name = match method_name_val {
+            Value::Str(s) => s,
+            _ => {
+                return Err(VmError::TypeMismatch {
+                    expected: "string (method name)",
+                    got: method_name_val.type_name(),
+                })
+            }
+        };
+
+        // FastVm does not support method calls on host data
+        // Use the standard Vm for workloads requiring host functions
+        Err(VmError::Runtime(format!(
+            "FastVm does not support method calls: '{}'. Use standard Vm instead.",
+            method_name
+        )))
+    }
+
+    /// Call a closure from Rust code (re-entrant)
+    pub fn call_closure(&mut self, closure: Arc<Closure>, args: &[Value]) -> Result<Value, VmError> {
+        if closure.arity as usize != args.len() {
+            return Err(VmError::Runtime(format!(
+                "Arity mismatch: expected {}, got {}",
+                closure.arity,
+                args.len()
+            )));
+        }
+
+        for arg in args {
+            self.push_fast(arg.clone());
+        }
+
+        let base = self.stack.len() - args.len();
+        let frame = Frame::new(closure, base);
+        self.frames.push(frame);
+        self.run()
+    }
+
+    /// Call any callable value from Rust code
+    pub fn call_value(&mut self, func: Value, args: &[Value]) -> Result<Value, VmError> {
+        match func {
+            Value::Closure(closure) => self.call_closure(closure, args),
+            Value::NativeFn { name, .. } => Err(VmError::Runtime(format!(
+                "FastVm does not support native function calls: '{}'. Use standard Vm instead.",
+                name
+            ))),
+            _ => Err(VmError::TypeMismatch {
+                expected: "function",
+                got: func.type_name(),
+            }),
+        }
+    }
+
+    /// Get the current stack size (for debugging)
+    pub fn stack_size(&self) -> usize {
+        self.stack.len()
+    }
+
+    /// Get the current frame count (for debugging)
+    pub fn frame_count(&self) -> usize {
+        self.frames.len()
+    }
+}
+
+impl Default for FastVm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::chunk::ChunkBuilder;
+
+    #[test]
+    fn test_fast_vm_basic_arithmetic() {
+        let mut vm = FastVm::new();
+        let chunk = ChunkBuilder::new()
+            .constant(Value::Int(10))
+            .constant(Value::Int(20))
+            .instruction(Instruction::LoadConst(0))
+            .instruction(Instruction::LoadConst(1))
+            .instruction(Instruction::Add)
+            .instruction(Instruction::Return)
+            .build();
+        let result = vm.execute(chunk).unwrap();
+        assert_eq!(result, Value::Int(30));
+    }
+
+    #[test]
+    fn test_fast_vm_locals() {
+        let mut vm = FastVm::new();
+        let chunk = ChunkBuilder::new()
+            .constant(Value::Int(42))
+            .instruction(Instruction::LoadConst(0))
+            .instruction(Instruction::StoreLocal(0))
+            .instruction(Instruction::LoadLocal(0))
+            .instruction(Instruction::Return)
+            .build();
+        let result = vm.execute(chunk).unwrap();
+        assert_eq!(result, Value::Int(42));
+    }
+
+    #[test]
+    fn test_fast_vm_comparison() {
+        let mut vm = FastVm::new();
+        let chunk = ChunkBuilder::new()
+            .constant(Value::Int(10))
+            .constant(Value::Int(20))
+            .instruction(Instruction::LoadConst(0))
+            .instruction(Instruction::LoadConst(1))
+            .instruction(Instruction::Lt)
+            .instruction(Instruction::Return)
+            .build();
+        let result = vm.execute(chunk).unwrap();
+        assert_eq!(result, Value::Bool(true));
+    }
+
+    #[test]
+    fn test_fast_vm_tuple() {
+        let mut vm = FastVm::new();
+        let chunk = ChunkBuilder::new()
+            .constant(Value::Int(1))
+            .constant(Value::Int(2))
+            .instruction(Instruction::LoadConst(0))
+            .instruction(Instruction::LoadConst(1))
+            .instruction(Instruction::MakeTuple(2))
+            .instruction(Instruction::Return)
+            .build();
+        let result = vm.execute(chunk).unwrap();
+        assert_eq!(result, Value::Tuple(vec![Value::Int(1), Value::Int(2)]));
+    }
+
+    #[test]
+    fn test_fast_vm_pre_allocated_capacity() {
+        let vm = FastVm::with_capacity(512, 128);
+        assert!(vm.stack.capacity() >= 512);
+        assert!(vm.frames.capacity() >= 128);
+    }
+}

--- a/rust/crates/fusabi-vm/src/optimizer.rs
+++ b/rust/crates/fusabi-vm/src/optimizer.rs
@@ -1,0 +1,504 @@
+// Fusabi VM Bytecode Optimizer
+// Performs compile-time optimizations on bytecode chunks
+
+use crate::chunk::{Chunk, SourceSpan};
+use crate::instruction::Instruction;
+use crate::value::Value;
+
+pub fn optimize_chunk(chunk: &mut Chunk) {
+    fold_constants(chunk);
+    eliminate_dead_code(chunk);
+}
+
+fn fold_constants(chunk: &mut Chunk) {
+    let mut changed = true;
+    while changed {
+        changed = false;
+        changed |= fold_arithmetic(chunk);
+        changed |= fold_boolean(chunk);
+        changed |= fold_comparison(chunk);
+    }
+}
+
+fn fold_arithmetic(chunk: &mut Chunk) -> bool {
+    let mut i = 0;
+    let mut changed = false;
+
+    while i + 2 < chunk.instructions.len() {
+        let folded = match (
+            &chunk.instructions[i],
+            &chunk.instructions[i + 1],
+            &chunk.instructions[i + 2],
+        ) {
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Add) => {
+                fold_binary_int(chunk, *a_idx, *b_idx, |a, b| a.checked_add(b))
+                    .or_else(|| fold_binary_float(chunk, *a_idx, *b_idx, |a, b| a + b))
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Sub) => {
+                fold_binary_int(chunk, *a_idx, *b_idx, |a, b| a.checked_sub(b))
+                    .or_else(|| fold_binary_float(chunk, *a_idx, *b_idx, |a, b| a - b))
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Mul) => {
+                fold_binary_int(chunk, *a_idx, *b_idx, |a, b| a.checked_mul(b))
+                    .or_else(|| fold_binary_float(chunk, *a_idx, *b_idx, |a, b| a * b))
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Div) => {
+                match (chunk.constant_at(*a_idx), chunk.constant_at(*b_idx)) {
+                    (Some(Value::Int(_)), Some(Value::Int(0))) => None,
+                    (Some(Value::Float(_)), Some(Value::Float(b))) if *b == 0.0 => None,
+                    _ => fold_binary_int(chunk, *a_idx, *b_idx, |a, b| a.checked_div(b))
+                        .or_else(|| fold_binary_float(chunk, *a_idx, *b_idx, |a, b| a / b)),
+                }
+            }
+            _ => None,
+        };
+
+        if let Some((result_value, span)) = folded {
+            let new_idx = chunk.add_constant(result_value);
+            chunk.instructions[i] = Instruction::LoadConst(new_idx);
+            chunk.instructions.remove(i + 2);
+            chunk.spans.remove(i + 2);
+            chunk.instructions.remove(i + 1);
+            chunk.spans.remove(i + 1);
+            chunk.spans[i] = span;
+            changed = true;
+        } else {
+            i += 1;
+        }
+    }
+
+    changed
+}
+
+fn fold_binary_int<F>(chunk: &Chunk, a_idx: u16, b_idx: u16, op: F) -> Option<(Value, SourceSpan)>
+where
+    F: FnOnce(i64, i64) -> Option<i64>,
+{
+    match (chunk.constant_at(a_idx), chunk.constant_at(b_idx)) {
+        (Some(Value::Int(a)), Some(Value::Int(b))) => {
+            op(*a, *b).map(|result| (Value::Int(result), SourceSpan::unknown()))
+        }
+        _ => None,
+    }
+}
+
+fn fold_binary_float<F>(chunk: &Chunk, a_idx: u16, b_idx: u16, op: F) -> Option<(Value, SourceSpan)>
+where
+    F: FnOnce(f64, f64) -> f64,
+{
+    match (chunk.constant_at(a_idx), chunk.constant_at(b_idx)) {
+        (Some(Value::Float(a)), Some(Value::Float(b))) => {
+            Some((Value::Float(op(*a, *b)), SourceSpan::unknown()))
+        }
+        _ => None,
+    }
+}
+
+fn fold_boolean(chunk: &mut Chunk) -> bool {
+    let mut i = 0;
+    let mut changed = false;
+
+    while i + 1 < chunk.instructions.len() {
+        let folded = match (&chunk.instructions[i], &chunk.instructions[i + 1]) {
+            (Instruction::LoadConst(idx), Instruction::Not) => {
+                match chunk.constant_at(*idx) {
+                    Some(Value::Bool(b)) => Some(Value::Bool(!b)),
+                    _ => None,
+                }
+            }
+            _ => None,
+        };
+
+        if let Some(result_value) = folded {
+            let new_idx = chunk.add_constant(result_value);
+            chunk.instructions[i] = Instruction::LoadConst(new_idx);
+            chunk.instructions.remove(i + 1);
+            chunk.spans.remove(i + 1);
+            changed = true;
+        } else {
+            i += 1;
+        }
+    }
+
+    changed
+}
+
+fn fold_comparison(chunk: &mut Chunk) -> bool {
+    let mut i = 0;
+    let mut changed = false;
+
+    while i + 2 < chunk.instructions.len() {
+        let folded = match (
+            &chunk.instructions[i],
+            &chunk.instructions[i + 1],
+            &chunk.instructions[i + 2],
+        ) {
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Eq) => {
+                fold_equality(chunk, *a_idx, *b_idx)
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Neq) => {
+                fold_equality(chunk, *a_idx, *b_idx).map(|v| match v {
+                    Value::Bool(b) => Value::Bool(!b),
+                    _ => v,
+                })
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Lt) => {
+                fold_ordering(chunk, *a_idx, *b_idx, |ord| ord.is_lt())
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Lte) => {
+                fold_ordering(chunk, *a_idx, *b_idx, |ord| ord.is_le())
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Gt) => {
+                fold_ordering(chunk, *a_idx, *b_idx, |ord| ord.is_gt())
+            }
+            (Instruction::LoadConst(a_idx), Instruction::LoadConst(b_idx), Instruction::Gte) => {
+                fold_ordering(chunk, *a_idx, *b_idx, |ord| ord.is_ge())
+            }
+            _ => None,
+        };
+
+        if let Some(result_value) = folded {
+            let new_idx = chunk.add_constant(result_value);
+            chunk.instructions[i] = Instruction::LoadConst(new_idx);
+            chunk.instructions.remove(i + 2);
+            chunk.spans.remove(i + 2);
+            chunk.instructions.remove(i + 1);
+            chunk.spans.remove(i + 1);
+            changed = true;
+        } else {
+            i += 1;
+        }
+    }
+
+    changed
+}
+
+fn fold_equality(chunk: &Chunk, a_idx: u16, b_idx: u16) -> Option<Value> {
+    match (chunk.constant_at(a_idx), chunk.constant_at(b_idx)) {
+        (Some(Value::Int(a)), Some(Value::Int(b))) => Some(Value::Bool(a == b)),
+        (Some(Value::Float(a)), Some(Value::Float(b))) => Some(Value::Bool(a == b)),
+        (Some(Value::Bool(a)), Some(Value::Bool(b))) => Some(Value::Bool(a == b)),
+        (Some(Value::Str(a)), Some(Value::Str(b))) => Some(Value::Bool(a == b)),
+        (Some(Value::Unit), Some(Value::Unit)) => Some(Value::Bool(true)),
+        _ => None,
+    }
+}
+
+fn fold_ordering<F>(chunk: &Chunk, a_idx: u16, b_idx: u16, cmp: F) -> Option<Value>
+where
+    F: FnOnce(std::cmp::Ordering) -> bool,
+{
+    match (chunk.constant_at(a_idx), chunk.constant_at(b_idx)) {
+        (Some(Value::Int(a)), Some(Value::Int(b))) => Some(Value::Bool(cmp(a.cmp(b)))),
+        (Some(Value::Float(a)), Some(Value::Float(b))) => {
+            a.partial_cmp(b).map(|ord| Value::Bool(cmp(ord)))
+        }
+        _ => None,
+    }
+}
+
+fn eliminate_dead_code(chunk: &mut Chunk) {
+    remove_unreachable_after_jumps(chunk);
+    combine_consecutive_pops(chunk);
+}
+
+fn remove_unreachable_after_jumps(chunk: &mut Chunk) {
+    let mut i = 0;
+    while i < chunk.instructions.len() {
+        if matches!(chunk.instructions[i], Instruction::Jump(_)) {
+            let jump_target = calculate_jump_target(i, &chunk.instructions[i]);
+            let j = i + 1;
+            while j < chunk.instructions.len() {
+                if is_jump_target(j, chunk) || Some(j) == jump_target {
+                    break;
+                }
+                chunk.instructions.remove(j);
+                chunk.spans.remove(j);
+            }
+        }
+        i += 1;
+    }
+}
+
+fn calculate_jump_target(current: usize, instr: &Instruction) -> Option<usize> {
+    match instr {
+        Instruction::Jump(offset) => {
+            let target = current as i32 + 1 + *offset as i32;
+            if target >= 0 {
+                Some(target as usize)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+fn is_jump_target(offset: usize, chunk: &Chunk) -> bool {
+    for (i, instr) in chunk.instructions.iter().enumerate() {
+        match instr {
+            Instruction::Jump(delta) | Instruction::JumpIfFalse(delta) => {
+                let target = i as i32 + 1 + *delta as i32;
+                if target == offset as i32 {
+                    return true;
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+fn combine_consecutive_pops(chunk: &mut Chunk) {
+    let mut i = 0;
+    while i + 1 < chunk.instructions.len() {
+        if matches!(chunk.instructions[i], Instruction::Pop)
+            && matches!(chunk.instructions[i + 1], Instruction::Pop)
+        {
+            chunk.instructions.remove(i + 1);
+            chunk.spans.remove(i + 1);
+        } else {
+            i += 1;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_fold_add_integers() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(10));
+        let b = chunk.add_constant(Value::Int(32));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Add);
+        chunk.emit(Instruction::Return);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 2);
+        assert!(matches!(chunk.instructions[0], Instruction::LoadConst(_)));
+        assert_eq!(chunk.instructions[1], Instruction::Return);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Int(42)));
+        }
+    }
+
+    #[test]
+    fn test_fold_sub_integers() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(50));
+        let b = chunk.add_constant(Value::Int(8));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Sub);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Int(42)));
+        }
+    }
+
+    #[test]
+    fn test_fold_mul_integers() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(6));
+        let b = chunk.add_constant(Value::Int(7));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Mul);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Int(42)));
+        }
+    }
+
+    #[test]
+    fn test_fold_div_integers() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(84));
+        let b = chunk.add_constant(Value::Int(2));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Div);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Int(42)));
+        }
+    }
+
+    #[test]
+    fn test_no_fold_div_by_zero() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(42));
+        let b = chunk.add_constant(Value::Int(0));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Div);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 3);
+    }
+
+    #[test]
+    fn test_fold_not_true() {
+        let mut chunk = Chunk::new();
+        let t = chunk.add_constant(Value::Bool(true));
+        chunk.emit(Instruction::LoadConst(t));
+        chunk.emit(Instruction::Not);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Bool(false)));
+        }
+    }
+
+    #[test]
+    fn test_fold_not_false() {
+        let mut chunk = Chunk::new();
+        let f = chunk.add_constant(Value::Bool(false));
+        chunk.emit(Instruction::LoadConst(f));
+        chunk.emit(Instruction::Not);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Bool(true)));
+        }
+    }
+
+    #[test]
+    fn test_fold_eq_integers() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(42));
+        let b = chunk.add_constant(Value::Int(42));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Eq);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Bool(true)));
+        }
+    }
+
+    #[test]
+    fn test_fold_eq_integers_false() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(42));
+        let b = chunk.add_constant(Value::Int(43));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Eq);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Bool(false)));
+        }
+    }
+
+    #[test]
+    fn test_fold_floats() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Float(3.0));
+        let b = chunk.add_constant(Value::Float(14.0));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Add);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Float(17.0)));
+        }
+    }
+
+    #[test]
+    fn test_chained_folding() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(2));
+        let b = chunk.add_constant(Value::Int(3));
+        let c = chunk.add_constant(Value::Int(7));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Mul);
+        chunk.emit(Instruction::LoadConst(c));
+        chunk.emit(Instruction::Mul);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Int(42)));
+        }
+    }
+
+    #[test]
+    fn test_combine_consecutive_pops() {
+        let mut chunk = Chunk::new();
+        chunk.emit(Instruction::Pop);
+        chunk.emit(Instruction::Pop);
+        chunk.emit(Instruction::Pop);
+        chunk.emit(Instruction::Return);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 2);
+        assert_eq!(chunk.instructions[0], Instruction::Pop);
+        assert_eq!(chunk.instructions[1], Instruction::Return);
+    }
+
+    #[test]
+    fn test_fold_lt() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(1));
+        let b = chunk.add_constant(Value::Int(2));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Lt);
+
+        optimize_chunk(&mut chunk);
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Bool(true)));
+        }
+    }
+
+    #[test]
+    fn test_chunk_optimize_method() {
+        let mut chunk = Chunk::new();
+        let a = chunk.add_constant(Value::Int(10));
+        let b = chunk.add_constant(Value::Int(32));
+        chunk.emit(Instruction::LoadConst(a));
+        chunk.emit(Instruction::LoadConst(b));
+        chunk.emit(Instruction::Add);
+
+        chunk.optimize();
+
+        assert_eq!(chunk.instructions.len(), 1);
+        if let Instruction::LoadConst(idx) = chunk.instructions[0] {
+            assert_eq!(chunk.constant_at(idx), Some(&Value::Int(42)));
+        }
+    }
+}


### PR DESCRIPTION
Closes #203

## Summary

Major VM performance optimizations including:

### Stack Operations
- Pre-allocate stack with capacity 256
- Inline hot path methods with `#[inline(always)]`
- Unsafe unchecked access for release builds with debug assertions

### FastVm (Alternative Interpreter)
- Optimized dispatch loop for compute-heavy workloads
- Pre-allocated data structures
- No instruction cloning during dispatch

### Compile-time Optimizer
- Constant folding for arithmetic, boolean, and comparison operations
- Dead code elimination after unconditional jumps
- Consecutive Pop instruction combining

### Benchmarks
- Comprehensive benchmark suite covering:
  - Arithmetic workloads
  - Function call overhead
  - Stack operations
  - Collection operations
  - Control flow patterns

Run benchmarks: `cargo bench -p fusabi-vm --bench dispatch_bench`