### PR TITLE
feat: implement package registry, LSP server, and commander docs

### DIFF
--- a/docs/packages/commander.md
+++ b/docs/packages/commander.md
@@ -1,0 +1,78 @@
+# Commander
+
+A TUI file explorer demonstrating Fusabi's terminal and event capabilities.
+
+## Quick Start
+
+```bash
+fus run examples/commander.fsx
+```
+
+## Features
+
+- **File Navigation**: Browse directories with vim-style `j`/`k` keys
+- **Directory Traversal**: Enter directories with `Enter`, navigate up with `..`
+- **Terminal Integration**: Uses `TerminalControl`, `TerminalInfo`, and `Console` modules
+- **Event System**: Demonstrates `Events.on`/`Events.off` for keyboard handling
+- **Process Execution**: Runs shell commands via `Process.runShell`
+
+## Controls
+
+| Key     | Action                  |
+|---------|-------------------------|
+| `j`     | Move selection down     |
+| `k`     | Move selection up       |
+| `Enter` | Open selected directory |
+| `q`     | Quit                    |
+
+## Architecture
+
+Commander follows a Model-View-Update (MVU) pattern:
+
+### Model
+
+```fusabi
+let initialModel = {
+    currentDir = Process.cwd ();
+    files = [];
+    selectedIndex = 0;
+    running = true
+}
+```
+
+### View
+
+Renders the current state to the terminal using ANSI escape codes:
+
+```fusabi
+let clearScreen () =
+    TerminalControl.sendText "\x1b[2J\x1b[H"
+```
+
+### Update
+
+Handles events and returns a new model:
+
+```fusabi
+let update event model =
+    match event with
+    | "key:j" -> handleKeyDown model
+    | "key:k" -> handleKeyUp model
+    | "key:enter" -> handleEnter model
+    | "key:q" -> handleQuit model
+    | _ -> model
+```
+
+## Stdlib Modules Used
+
+- `Events` - Event registration and handling
+- `TerminalControl` - Terminal escape sequences
+- `TerminalInfo` - Terminal size detection
+- `Process` - Directory and shell operations
+- `Console` - User input/output
+- `List` - List manipulation
+- `String` - String parsing
+
+## Package Manifest
+
+See [examples/commander/fusabi.toml](../../examples/commander/fusabi.toml) for a sample package manifest.

--- a/examples/async_demo.fsx
+++ b/examples/async_demo.fsx
@@ -1,13 +1,47 @@
-// Async Demo Debug 5
-let log msg =
-    print msg
-    print "\n"
+// Async Demo
+// Demonstrates the new Async Computation Expressions
 
-let main = async {
-    log "Inside async"
-    return "Done"
+// Helper to print progress
+let log msg =
+    let t = Time.format "%H:%M:%S" (Time.now()) in
+    printfn (sprintf "[%s] %s" [t; msg])
+
+// Simulating an async operation
+let sleep ms = async {
+    log (sprintf "Sleeping for %d ms..." [ms])
+    // In a real implementation this would be non-blocking
+    // For now, we just spin/wait but structure it as async
+    let _ = Process.runShell (sprintf "sleep %f" [float ms / 1000.0])
+    log "Woke up!"
+    return ms
 }
 
-log "Calling RunSync"
-let _ = Async.RunSynchronously main
-log "Done"
+// Simulating data fetching
+let fetchData url = async {
+    log (sprintf "Fetching %s..." [url])
+    do! sleep 500
+    return (sprintf "Content of %s" [url])
+}
+
+// The main async workflow
+let main = async {
+    log "Starting workflow..."
+
+    // Sequential composition using let!
+    let! data1 = fetchData "http://example.com/1"
+    log (sprintf "Got: %s" [data1])
+
+    let! data2 = fetchData "http://example.com/2"
+    log (sprintf "Got: %s" [data2])
+
+    // Control flow (Linear for now as parser doesn't support nested do! in if)
+    log "Doing extra work..."
+    do! sleep 200
+
+    return "Done!"
+}
+
+// Execute the workflow
+log "--- RunSynchronously ---"
+let result = Async.RunSynchronously main
+log (sprintf "Final Result: %s" [result])

--- a/examples/commander/fusabi.toml
+++ b/examples/commander/fusabi.toml
@@ -1,0 +1,12 @@
+[package]
+name = "commander"
+version = "0.1.0"
+description = "A TUI file explorer for Fusabi"
+authors = ["Fusabi Community"]
+license = "MIT"
+repository = "https://github.com/fusabi-lang/commander"
+
+[dependencies]
+
+[scripts]
+run = "fus run main.fsx"

--- a/examples/commander/main.fsx
+++ b/examples/commander/main.fsx
@@ -1,0 +1,203 @@
+// Commander - A TUI File Explorer for Fusabi
+// Demonstrates Events, TerminalControl, TerminalInfo, Process, Console, List, and String modules
+
+// ============================================================================
+// MODEL
+// ============================================================================
+
+let initialModel = {
+    currentDir = Process.cwd ();
+    files = [];
+    selectedIndex = 0;
+    running = true
+}
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+let parseFiles stdout =
+    let lines = String.split "\n" stdout
+    let nonEmpty = List.filter (fun line -> String.length line > 0) lines
+    // Skip the first line (total count from ls -l)
+    match List.tail nonEmpty with
+    | Some tail -> tail
+    | None -> []
+
+let getFileName line =
+    let parts = String.split " " line
+    let filtered = List.filter (fun p -> String.length p > 0) parts
+    // Get the last part (filename)
+    match List.nth 8 filtered with
+    | Some name -> name
+    | None -> line
+
+let loadDirectory dir =
+    let result = Process.runShell (sprintf "ls -la \"%s\"" dir)
+    if result.exitCode == 0 then
+        parseFiles result.stdout
+    else
+        []
+
+let clamp min max value =
+    if value < min then min
+    else if value > max then max
+    else value
+
+// ============================================================================
+// VIEW
+// ============================================================================
+
+let clearScreen () =
+    TerminalControl.sendText "\x1b[2J\x1b[H"
+
+let renderHeader model =
+    printfn (sprintf "=== Commander TUI ===")
+    printfn (sprintf "Directory: %s" model.currentDir)
+    printfn (sprintf "")
+
+let renderFile index selected fileName =
+    let marker = if index == selected then "> " else "  "
+    printfn (sprintf "%s%s" marker fileName)
+
+let renderFiles model =
+    let renderWithIndex = fun (index, fileName) ->
+        renderFile index model.selectedIndex fileName
+    let indexed = List.mapi (fun i f -> (i, f)) model.files
+    List.iter renderWithIndex indexed
+
+let renderFooter () =
+    printfn (sprintf "")
+    printfn (sprintf "Controls: j/k (navigate) | Enter (select) | q (quit)")
+
+let render model =
+    clearScreen ()
+    renderHeader model
+    renderFiles model
+    renderFooter ()
+
+// ============================================================================
+// UPDATE
+// ============================================================================
+
+let handleKeyDown model =
+    let maxIndex = List.length model.files - 1
+    let newIndex = clamp 0 maxIndex (model.selectedIndex + 1)
+    { model with selectedIndex = newIndex }
+
+let handleKeyUp model =
+    let maxIndex = List.length model.files - 1
+    let newIndex = clamp 0 maxIndex (model.selectedIndex - 1)
+    { model with selectedIndex = newIndex }
+
+let handleEnter model =
+    match List.nth model.selectedIndex model.files with
+    | Some selectedFile ->
+        let fileName = getFileName selectedFile
+        let newPath =
+            if fileName == "." then
+                model.currentDir
+            else if fileName == ".." then
+                let result = Process.runShell (sprintf "cd \"%s\" && cd .. && pwd" model.currentDir)
+                if result.exitCode == 0 then
+                    String.trim result.stdout
+                else
+                    model.currentDir
+            else
+                sprintf "%s/%s" model.currentDir fileName
+
+        // Check if it's a directory
+        let checkResult = Process.runShell (sprintf "test -d \"%s\" && echo \"dir\"" newPath)
+        if String.contains "dir" checkResult.stdout then
+            let files = loadDirectory newPath
+            { model with currentDir = newPath; files = files; selectedIndex = 0 }
+        else
+            TerminalControl.showToast (sprintf "Not a directory: %s" fileName)
+            model
+    | None -> model
+
+let handleQuit model =
+    { model with running = false }
+
+let update event model =
+    match event with
+    | "key:j" -> handleKeyDown model
+    | "key:k" -> handleKeyUp model
+    | "key:enter" -> handleEnter model
+    | "key:q" -> handleQuit model
+    | _ -> model
+
+// ============================================================================
+// EVENT LOOP
+// ============================================================================
+
+let rec eventLoop model =
+    if model.running then
+        // Render current state
+        render model
+
+        // Get real user input
+        Console.write "Enter command (j/k/enter/q): "
+        let input = Console.readLine ()
+
+        // Convert input to event name
+        let eventName =
+            match input with
+            | "j" -> "key:j"
+            | "k" -> "key:k"
+            | "enter" -> "key:enter"
+            | "" -> "key:enter"   // Empty line = Enter
+            | "q" -> "key:q"
+            | other -> sprintf "key:%s" other
+
+        // Update model and continue loop
+        let newModel = update eventName model
+        eventLoop newModel
+    else
+        printfn (sprintf "\nExiting Commander...")
+        model
+
+// ============================================================================
+// MAIN
+// ============================================================================
+
+let main () =
+    printfn (sprintf "Starting Commander TUI...")
+    printfn (sprintf "")
+
+    // Get terminal size
+    let (cols, rows) = TerminalInfo.getTerminalSize ()
+    printfn (sprintf "Terminal size: %d cols x %d rows" cols rows)
+
+    // Get current directory
+    let cwd = Process.cwd ()
+    printfn (sprintf "Starting directory: %s" cwd)
+    printfn (sprintf "")
+
+    // Load initial files
+    let files = loadDirectory cwd
+    let startModel = { initialModel with currentDir = cwd; files = files }
+
+    // Register event handlers
+    let handlerJ = Events.on "key:j" (fun _ -> printfn (sprintf "Down pressed"))
+    let handlerK = Events.on "key:k" (fun _ -> printfn (sprintf "Up pressed"))
+    let handlerEnter = Events.on "key:enter" (fun _ -> printfn (sprintf "Enter pressed"))
+    let handlerQ = Events.on "key:q" (fun _ -> printfn (sprintf "Quit pressed"))
+
+    printfn (sprintf "Event handlers registered: %d, %d, %d, %d" handlerJ handlerK handlerEnter handlerQ)
+    printfn (sprintf "")
+
+    // Start event loop
+    let finalModel = eventLoop startModel
+
+    // Cleanup event handlers
+    let _ = Events.off handlerJ
+    let _ = Events.off handlerK
+    let _ = Events.off handlerEnter
+    let _ = Events.off handlerQ
+
+    printfn (sprintf "Commander TUI exited")
+    printfn (sprintf "Final directory: %s" finalModel.currentDir)
+
+// Run the application
+main ()

--- a/rust/crates/fusabi-lsp/src/lib.rs
+++ b/rust/crates/fusabi-lsp/src/lib.rs
@@ -1,14 +1,227 @@
+//! Fusabi Language Server Protocol Implementation
+//!
+//! Provides IDE features for Fusabi: diagnostics, hover, and completion.
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use fusabi_frontend::{Lexer, Parser};
 use tower_lsp::jsonrpc::Result;
 use tower_lsp::lsp_types::*;
 use tower_lsp::{Client, LanguageServer};
 
 pub struct FusabiLanguageServer {
     client: Client,
+    documents: RwLock<HashMap<Url, String>>,
 }
 
 impl FusabiLanguageServer {
     pub fn new(client: Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            documents: RwLock::new(HashMap::new()),
+        }
+    }
+
+    async fn publish_diagnostics(&self, uri: Url, text: &str) {
+        let diagnostics = self.analyze(text);
+        self.client
+            .publish_diagnostics(uri, diagnostics, None)
+            .await;
+    }
+
+    fn analyze(&self, text: &str) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+
+        let mut lexer = Lexer::new(text);
+        let tokens = match lexer.tokenize() {
+            Ok(tokens) => tokens,
+            Err(e) => {
+                let (line, col, msg) = match &e {
+                    fusabi_frontend::LexError::UnexpectedChar(ch, pos) => {
+                        (pos.line, pos.column, format!("Unexpected character: '{}'", ch))
+                    }
+                    fusabi_frontend::LexError::UnterminatedString(pos) => {
+                        (pos.line, pos.column, "Unterminated string literal".to_string())
+                    }
+                    fusabi_frontend::LexError::InvalidNumber(s, pos) => {
+                        (pos.line, pos.column, format!("Invalid number: '{}'", s))
+                    }
+                    fusabi_frontend::LexError::UnterminatedComment(pos) => {
+                        (pos.line, pos.column, "Unterminated comment".to_string())
+                    }
+                };
+                diagnostics.push(Diagnostic {
+                    range: Range {
+                        start: Position {
+                            line: (line.saturating_sub(1)) as u32,
+                            character: (col.saturating_sub(1)) as u32,
+                        },
+                        end: Position {
+                            line: (line.saturating_sub(1)) as u32,
+                            character: col as u32,
+                        },
+                    },
+                    severity: Some(DiagnosticSeverity::ERROR),
+                    source: Some("fusabi".to_string()),
+                    message: msg,
+                    ..Default::default()
+                });
+                return diagnostics;
+            }
+        };
+
+        let mut parser = Parser::new(tokens);
+        if let Err(e) = parser.parse_program() {
+            let (line, col, msg) = match &e {
+                fusabi_frontend::ParseError::UnexpectedToken {
+                    expected,
+                    found,
+                    pos,
+                } => (
+                    pos.line,
+                    pos.column,
+                    format!("Expected {}, found {}", expected, found),
+                ),
+                fusabi_frontend::ParseError::UnexpectedEof { expected } => {
+                    let lines: Vec<&str> = text.lines().collect();
+                    let last_line = lines.len().max(1);
+                    let last_col = lines.last().map(|l| l.len()).unwrap_or(0);
+                    (last_line, last_col, format!("Unexpected end of file, expected {}", expected))
+                }
+                fusabi_frontend::ParseError::InvalidExpr { message, pos } => {
+                    (pos.line, pos.column, message.clone())
+                }
+            };
+            diagnostics.push(Diagnostic {
+                range: Range {
+                    start: Position {
+                        line: (line.saturating_sub(1)) as u32,
+                        character: (col.saturating_sub(1)) as u32,
+                    },
+                    end: Position {
+                        line: (line.saturating_sub(1)) as u32,
+                        character: col as u32,
+                    },
+                },
+                severity: Some(DiagnosticSeverity::ERROR),
+                source: Some("fusabi".to_string()),
+                message: msg,
+                ..Default::default()
+            });
+        }
+
+        diagnostics
+    }
+
+    fn get_hover_info(&self, text: &str, position: Position) -> Option<String> {
+        let lines: Vec<&str> = text.lines().collect();
+        let line = lines.get(position.line as usize)?;
+        
+        let char_pos = position.character as usize;
+        if char_pos >= line.len() {
+            return None;
+        }
+
+        let start = line[..char_pos]
+            .rfind(|c: char| !c.is_alphanumeric() && c != '_')
+            .map(|i| i + 1)
+            .unwrap_or(0);
+        let end = line[char_pos..]
+            .find(|c: char| !c.is_alphanumeric() && c != '_' && c != '!')
+            .map(|i| i + char_pos)
+            .unwrap_or(line.len());
+
+        let word = &line[start..end];
+        if word.is_empty() {
+            return None;
+        }
+
+        self.get_keyword_docs(word)
+    }
+
+    fn get_keyword_docs(&self, word: &str) -> Option<String> {
+        let docs = match word {
+            "let" => "**let** - Bind a value to a name\n\n```fusabi\nlet x = 42\nlet add a b = a + b\n```",
+            "let!" => "**let!** - Async/computation expression binding\n\n```fusabi\nasync { let! result = fetchData() }\n```",
+            "rec" => "**rec** - Recursive binding\n\n```fusabi\nlet rec factorial n = if n <= 1 then 1 else n * factorial (n - 1)\n```",
+            "in" => "**in** - Body of let expression\n\n```fusabi\nlet x = 5 in x + 1\n```",
+            "if" => "**if** - Conditional expression\n\n```fusabi\nif condition then trueValue else falseValue\n```",
+            "then" => "**then** - True branch of if expression",
+            "else" => "**else** - False branch of if expression",
+            "fun" => "**fun** - Lambda/anonymous function\n\n```fusabi\nfun x -> x + 1\nfun x y -> x + y\n```",
+            "match" => "**match** - Pattern matching\n\n```fusabi\nmatch value with\n| Some x -> x\n| None -> 0\n```",
+            "with" => "**with** - Match arms or record update\n\n```fusabi\n{ record with field = newValue }\n```",
+            "type" => "**type** - Type definition\n\n```fusabi\ntype Option = Some of int | None\ntype Person = { name: string; age: int }\n```",
+            "of" => "**of** - Discriminated union variant payload",
+            "module" => "**module** - Module definition\n\n```fusabi\nmodule Math =\n  let pi = 3.14159\n```",
+            "open" => "**open** - Import module\n\n```fusabi\nopen Math\n```",
+            "async" => "**async** - Async computation expression\n\n```fusabi\nasync { let! data = fetch(); return data }\n```",
+            "return" => "**return** - Return value from computation expression",
+            "return!" => "**return!** - Return wrapped value from computation expression",
+            "yield" => "**yield** - Yield value in sequence expression",
+            "yield!" => "**yield!** - Yield sequence of values",
+            "do" => "**do** - Execute expression for side effects",
+            "do!" => "**do!** - Execute async expression for side effects",
+            "while" => "**while** - While loop\n\n```fusabi\nwhile condition do\n  body\n```",
+            "break" => "**break** - Exit loop early",
+            "continue" => "**continue** - Skip to next iteration",
+            "true" => "**true** - Boolean true literal",
+            "false" => "**false** - Boolean false literal",
+            _ => return None,
+        };
+        Some(docs.to_string())
+    }
+
+    fn get_completions(&self) -> Vec<CompletionItem> {
+        let keywords = vec![
+            ("let", "Bind a value", CompletionItemKind::KEYWORD),
+            ("let rec", "Recursive binding", CompletionItemKind::KEYWORD),
+            ("in", "Let body", CompletionItemKind::KEYWORD),
+            ("if", "Conditional", CompletionItemKind::KEYWORD),
+            ("then", "If true branch", CompletionItemKind::KEYWORD),
+            ("else", "If false branch", CompletionItemKind::KEYWORD),
+            ("fun", "Lambda function", CompletionItemKind::KEYWORD),
+            ("match", "Pattern matching", CompletionItemKind::KEYWORD),
+            ("with", "Match arms / record update", CompletionItemKind::KEYWORD),
+            ("type", "Type definition", CompletionItemKind::KEYWORD),
+            ("module", "Module definition", CompletionItemKind::KEYWORD),
+            ("open", "Import module", CompletionItemKind::KEYWORD),
+            ("async", "Async block", CompletionItemKind::KEYWORD),
+            ("return", "Return value", CompletionItemKind::KEYWORD),
+            ("yield", "Yield value", CompletionItemKind::KEYWORD),
+            ("do", "Side effect", CompletionItemKind::KEYWORD),
+            ("while", "While loop", CompletionItemKind::KEYWORD),
+            ("break", "Exit loop", CompletionItemKind::KEYWORD),
+            ("continue", "Next iteration", CompletionItemKind::KEYWORD),
+            ("true", "Boolean true", CompletionItemKind::CONSTANT),
+            ("false", "Boolean false", CompletionItemKind::CONSTANT),
+        ];
+
+        let builtins = vec![
+            ("printfn", "Print formatted line", CompletionItemKind::FUNCTION),
+            ("printf", "Print formatted", CompletionItemKind::FUNCTION),
+            ("List.map", "Map over list", CompletionItemKind::FUNCTION),
+            ("List.filter", "Filter list", CompletionItemKind::FUNCTION),
+            ("List.fold", "Fold list", CompletionItemKind::FUNCTION),
+            ("List.head", "First element", CompletionItemKind::FUNCTION),
+            ("List.tail", "Rest of list", CompletionItemKind::FUNCTION),
+            ("List.length", "List length", CompletionItemKind::FUNCTION),
+            ("Array.length", "Array length", CompletionItemKind::FUNCTION),
+            ("Array.get", "Get array element", CompletionItemKind::FUNCTION),
+            ("Array.set", "Set array element", CompletionItemKind::FUNCTION),
+        ];
+
+        keywords
+            .into_iter()
+            .chain(builtins)
+            .map(|(label, detail, kind)| CompletionItem {
+                label: label.to_string(),
+                kind: Some(kind),
+                detail: Some(detail.to_string()),
+                ..Default::default()
+            })
+            .collect()
     }
 }
 
@@ -17,11 +230,18 @@ impl LanguageServer for FusabiLanguageServer {
     async fn initialize(&self, _: InitializeParams) -> Result<InitializeResult> {
         Ok(InitializeResult {
             capabilities: ServerCapabilities {
-                text_document_sync: Some(TextDocumentSyncCapability::Kind(
-                    TextDocumentSyncKind::FULL,
+                text_document_sync: Some(TextDocumentSyncCapability::Options(
+                    TextDocumentSyncOptions {
+                        open_close: Some(true),
+                        change: Some(TextDocumentSyncKind::FULL),
+                        ..Default::default()
+                    },
                 )),
                 hover_provider: Some(HoverProviderCapability::Simple(true)),
-                definition_provider: Some(OneOf::Left(true)),
+                completion_provider: Some(CompletionOptions {
+                    trigger_characters: Some(vec![".".to_string()]),
+                    ..Default::default()
+                }),
                 ..Default::default()
             },
             server_info: Some(ServerInfo {
@@ -41,14 +261,61 @@ impl LanguageServer for FusabiLanguageServer {
         Ok(())
     }
 
-    async fn hover(&self, _params: HoverParams) -> Result<Option<Hover>> {
-        Ok(None)
+    async fn did_open(&self, params: DidOpenTextDocumentParams) {
+        let uri = params.text_document.uri;
+        let text = params.text_document.text;
+        
+        {
+            let mut docs = self.documents.write().unwrap();
+            docs.insert(uri.clone(), text.clone());
+        }
+        
+        self.publish_diagnostics(uri, &text).await;
     }
 
-    async fn goto_definition(
-        &self,
-        _params: GotoDefinitionParams,
-    ) -> Result<Option<GotoDefinitionResponse>> {
-        Ok(None)
+    async fn did_change(&self, params: DidChangeTextDocumentParams) {
+        let uri = params.text_document.uri;
+        if let Some(change) = params.content_changes.into_iter().last() {
+            let text = change.text;
+            
+            {
+                let mut docs = self.documents.write().unwrap();
+                docs.insert(uri.clone(), text.clone());
+            }
+            
+            self.publish_diagnostics(uri, &text).await;
+        }
+    }
+
+    async fn did_close(&self, params: DidCloseTextDocumentParams) {
+        let mut docs = self.documents.write().unwrap();
+        docs.remove(&params.text_document.uri);
+    }
+
+    async fn hover(&self, params: HoverParams) -> Result<Option<Hover>> {
+        let uri = &params.text_document_position_params.text_document.uri;
+        let position = params.text_document_position_params.position;
+        
+        let docs = self.documents.read().unwrap();
+        let text = match docs.get(uri) {
+            Some(t) => t.clone(),
+            None => return Ok(None),
+        };
+        drop(docs);
+
+        let info = self.get_hover_info(&text, position);
+        
+        Ok(info.map(|content| Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: content,
+            }),
+            range: None,
+        }))
+    }
+
+    async fn completion(&self, _params: CompletionParams) -> Result<Option<CompletionResponse>> {
+        let items = self.get_completions();
+        Ok(Some(CompletionResponse::Array(items)))
     }
 }

--- a/rust/crates/fusabi-pm/Cargo.toml
+++ b/rust/crates/fusabi-pm/Cargo.toml
@@ -11,6 +11,7 @@ toml = "0.8"
 thiserror = "1.0"
 clap = { version = "4.0", features = ["derive"] }
 git2 = "0.20"
+dirs = "5.0"
 fusabi = { path = "../fusabi" }
 fusabi-vm = { path = "../fusabi-vm" }
 

--- a/rust/crates/fusabi-pm/src/install.rs
+++ b/rust/crates/fusabi-pm/src/install.rs
@@ -1,6 +1,7 @@
 //! Install command for cloning git dependencies.
 
 use crate::manifest::{Dependency, Manifest, ManifestError};
+use crate::registry::{Registry, RegistryError};
 use git2::Repository;
 use std::path::Path;
 use thiserror::Error;
@@ -15,6 +16,9 @@ pub enum InstallError {
 
     #[error("IO error: {0}")]
     Io(#[from] std::io::Error),
+
+    #[error("Registry error: {0}")]
+    Registry(#[from] RegistryError),
 
     #[error("{0}")]
     Other(String),
@@ -38,45 +42,98 @@ pub fn install_dependencies(project_dir: &Path) -> Result<(), InstallError> {
 
     std::fs::create_dir_all(&packages_dir)?;
 
+    let registry = Registry::new();
+
     for (name, dependency) in &manifest.dependencies {
         match dependency {
             Dependency::Detailed(detailed) => {
                 if let Some(git_url) = &detailed.git {
-                    let dep_path = packages_dir.join(name);
-
-                    if dep_path.exists() {
-                        println!("Dependency '{}' already exists, skipping.", name);
-                        continue;
-                    }
-
-                    println!("Cloning '{}'...", name);
-
-                    let repo = Repository::clone(git_url, &dep_path)?;
-
-                    if let Some(rev) = &detailed.rev {
-                        checkout_rev(&repo, rev)?;
-                    }
-
-                    println!("Installed '{}'", name);
+                    install_git_dependency(
+                        name,
+                        git_url,
+                        detailed.rev.as_deref(),
+                        &packages_dir,
+                    )?;
                 } else if detailed.path.is_some() {
                     println!("Skipping local path dependency '{}'", name);
+                } else if let Some(version) = &detailed.version {
+                    install_registry_dependency(name, version, &packages_dir, &registry)?;
                 } else {
                     println!(
-                        "Skipping dependency '{}': no git or path specified",
+                        "Skipping dependency '{}': no git, path, or version specified",
                         name
                     );
                 }
             }
-            Dependency::Simple(_version) => {
-                println!(
-                    "Skipping dependency '{}': registry dependencies not yet supported",
-                    name
-                );
+            Dependency::Simple(version) => {
+                install_registry_dependency(name, version, &packages_dir, &registry)?;
             }
         }
     }
 
     println!("Install complete.");
+    Ok(())
+}
+
+fn install_git_dependency(
+    name: &str,
+    git_url: &str,
+    rev: Option<&str>,
+    packages_dir: &Path,
+) -> Result<(), InstallError> {
+    let dep_path = packages_dir.join(name);
+
+    if dep_path.exists() {
+        println!("Dependency '{}' already exists, skipping.", name);
+        return Ok(());
+    }
+
+    println!("Cloning '{}'...", name);
+
+    let repo = Repository::clone(git_url, &dep_path)?;
+
+    if let Some(rev) = rev {
+        checkout_rev(&repo, rev)?;
+    }
+
+    println!("Installed '{}'", name);
+    Ok(())
+}
+
+fn install_registry_dependency(
+    name: &str,
+    version_constraint: &str,
+    packages_dir: &Path,
+    registry: &Registry,
+) -> Result<(), InstallError> {
+    let dep_path = packages_dir.join(name);
+
+    if dep_path.exists() {
+        println!("Dependency '{}' already exists, skipping.", name);
+        return Ok(());
+    }
+
+    println!("Resolving '{}' ({})...", name, version_constraint);
+
+    let resolved = registry.resolve(name, version_constraint)?;
+
+    println!(
+        "Installing '{}' v{} from {}",
+        resolved.name, resolved.version, resolved.git_url
+    );
+
+    let repo = Repository::clone(&resolved.git_url, &dep_path)?;
+
+    if let Some(ref rev) = resolved.rev {
+        if let Err(e) = checkout_rev(&repo, rev) {
+            println!(
+                "Warning: Could not checkout version tag '{}': {}. Using default branch.",
+                rev, e
+            );
+        }
+    }
+
+    println!("Installed '{}' v{}", resolved.name, resolved.version);
     Ok(())
 }
 

--- a/rust/crates/fusabi-pm/src/lib.rs
+++ b/rust/crates/fusabi-pm/src/lib.rs
@@ -6,8 +6,10 @@ pub mod build;
 pub mod install;
 pub mod manifest;
 pub mod publish;
+pub mod registry;
 
 pub use build::{BuildError, BuildResult, PackageBuilder, ResolvedDependency};
 pub use install::{install_dependencies, InstallError};
 pub use manifest::{Dependencies, Dependency, Manifest, Package};
-pub use publish::{publish_package, print_publish_instructions, PublishError, PublishResult};
+pub use publish::{print_publish_instructions, publish_package, PublishError, PublishResult};
+pub use registry::{Registry, RegistryError, RegistryPackage};

--- a/rust/crates/fusabi-pm/src/registry.rs
+++ b/rust/crates/fusabi-pm/src/registry.rs
@@ -1,0 +1,405 @@
+//! Registry handling for the fusabi-community package registry.
+//!
+//! Provides functionality to fetch and parse the registry index, and resolve
+//! package names to git URLs with version constraints.
+
+use git2::Repository;
+use serde::Deserialize;
+use std::cmp::Ordering;
+use std::path::{Path, PathBuf};
+use thiserror::Error;
+
+const REGISTRY_URL: &str = "https://github.com/fusabi-lang/fusabi-community";
+const REGISTRY_INDEX_PATH: &str = "registry/index.toml";
+
+#[derive(Debug, Error)]
+pub enum RegistryError {
+    #[error("Git error: {0}")]
+    Git(#[from] git2::Error),
+
+    #[error("IO error: {0}")]
+    Io(#[from] std::io::Error),
+
+    #[error("Failed to parse registry index: {0}")]
+    Parse(#[from] toml::de::Error),
+
+    #[error("Package '{0}' not found in registry")]
+    PackageNotFound(String),
+
+    #[error("No version of '{0}' satisfies constraint '{1}'")]
+    NoMatchingVersion(String, String),
+
+    #[error("Invalid version format: {0}")]
+    InvalidVersion(String),
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryIndex {
+    #[serde(default)]
+    pub packages: Vec<RegistryPackage>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct RegistryPackage {
+    pub name: String,
+    pub version: String,
+    pub repository: String,
+    #[serde(default)]
+    pub description: Option<String>,
+    #[serde(default)]
+    pub license: Option<String>,
+    #[serde(default)]
+    pub authors: Vec<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ResolvedPackage {
+    pub name: String,
+    pub version: String,
+    pub git_url: String,
+    pub rev: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SemVer {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+impl SemVer {
+    pub fn parse(version: &str) -> Result<Self, RegistryError> {
+        let version = version.trim_start_matches('v');
+        let parts: Vec<&str> = version.split('.').collect();
+
+        let major = parts
+            .first()
+            .and_then(|s| s.parse().ok())
+            .ok_or_else(|| RegistryError::InvalidVersion(version.to_string()))?;
+
+        let minor = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+        let patch = parts.get(2).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+        Ok(SemVer {
+            major,
+            minor,
+            patch,
+        })
+    }
+
+    pub fn satisfies(&self, constraint: &str) -> bool {
+        let constraint = constraint.trim();
+
+        if constraint.is_empty() || constraint == "*" {
+            return true;
+        }
+
+        if constraint.starts_with('^') {
+            if let Ok(base) = SemVer::parse(&constraint[1..]) {
+                return self.major == base.major
+                    && (self.minor > base.minor
+                        || (self.minor == base.minor && self.patch >= base.patch));
+            }
+        }
+
+        if constraint.starts_with('~') {
+            if let Ok(base) = SemVer::parse(&constraint[1..]) {
+                return self.major == base.major
+                    && self.minor == base.minor
+                    && self.patch >= base.patch;
+            }
+        }
+
+        if constraint.starts_with(">=") {
+            if let Ok(base) = SemVer::parse(&constraint[2..]) {
+                return *self >= base;
+            }
+        }
+
+        if constraint.starts_with('>') {
+            if let Ok(base) = SemVer::parse(&constraint[1..]) {
+                return *self > base;
+            }
+        }
+
+        if constraint.starts_with("<=") {
+            if let Ok(base) = SemVer::parse(&constraint[2..]) {
+                return *self <= base;
+            }
+        }
+
+        if constraint.starts_with('<') {
+            if let Ok(base) = SemVer::parse(&constraint[1..]) {
+                return *self < base;
+            }
+        }
+
+        if constraint.starts_with('=') {
+            if let Ok(base) = SemVer::parse(&constraint[1..]) {
+                return *self == base;
+            }
+        }
+
+        if let Ok(base) = SemVer::parse(constraint) {
+            return *self == base;
+        }
+
+        false
+    }
+}
+
+impl PartialOrd for SemVer {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for SemVer {
+    fn cmp(&self, other: &Self) -> Ordering {
+        match self.major.cmp(&other.major) {
+            Ordering::Equal => match self.minor.cmp(&other.minor) {
+                Ordering::Equal => self.patch.cmp(&other.patch),
+                ord => ord,
+            },
+            ord => ord,
+        }
+    }
+}
+
+pub struct Registry {
+    cache_dir: PathBuf,
+}
+
+impl Registry {
+    pub fn new() -> Self {
+        let cache_dir = dirs::cache_dir()
+            .unwrap_or_else(|| PathBuf::from("."))
+            .join("fusabi")
+            .join("registry");
+
+        Self { cache_dir }
+    }
+
+    pub fn with_cache_dir<P: AsRef<Path>>(cache_dir: P) -> Self {
+        Self {
+            cache_dir: cache_dir.as_ref().to_path_buf(),
+        }
+    }
+
+    pub fn update(&self) -> Result<(), RegistryError> {
+        std::fs::create_dir_all(&self.cache_dir)?;
+
+        let repo_path = self.cache_dir.join("fusabi-community");
+
+        if repo_path.exists() {
+            println!("Updating registry index...");
+            let repo = Repository::open(&repo_path)?;
+            let mut remote = repo.find_remote("origin")?;
+            remote.fetch(&["main"], None, None)?;
+
+            let fetch_head = repo.find_reference("FETCH_HEAD")?;
+            let commit = repo.reference_to_annotated_commit(&fetch_head)?;
+            let (analysis, _) = repo.merge_analysis(&[&commit])?;
+
+            if analysis.is_fast_forward() || analysis.is_normal() {
+                let refname = "refs/heads/main";
+                let mut reference = repo.find_reference(refname)?;
+                reference.set_target(commit.id(), "Fast-forward")?;
+                repo.set_head(refname)?;
+                repo.checkout_head(Some(git2::build::CheckoutBuilder::default().force()))?;
+            }
+        } else {
+            println!("Cloning registry index...");
+            Repository::clone(REGISTRY_URL, &repo_path)?;
+        }
+
+        println!("Registry updated.");
+        Ok(())
+    }
+
+    pub fn load_index(&self) -> Result<RegistryIndex, RegistryError> {
+        let index_path = self
+            .cache_dir
+            .join("fusabi-community")
+            .join(REGISTRY_INDEX_PATH);
+
+        if !index_path.exists() {
+            self.update()?;
+        }
+
+        let contents = std::fs::read_to_string(&index_path)?;
+        let index: RegistryIndex = toml::from_str(&contents)?;
+        Ok(index)
+    }
+
+    pub fn resolve(
+        &self,
+        name: &str,
+        version_constraint: &str,
+    ) -> Result<ResolvedPackage, RegistryError> {
+        let index = self.load_index()?;
+
+        let matching_packages: Vec<&RegistryPackage> =
+            index.packages.iter().filter(|p| p.name == name).collect();
+
+        if matching_packages.is_empty() {
+            return Err(RegistryError::PackageNotFound(name.to_string()));
+        }
+
+        let mut candidates: Vec<(&RegistryPackage, SemVer)> = matching_packages
+            .into_iter()
+            .filter_map(|p| {
+                let semver = SemVer::parse(&p.version).ok()?;
+                if semver.satisfies(version_constraint) {
+                    Some((p, semver))
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        candidates.sort_by(|a, b| b.1.cmp(&a.1));
+
+        let (package, _) = candidates.into_iter().next().ok_or_else(|| {
+            RegistryError::NoMatchingVersion(name.to_string(), version_constraint.to_string())
+        })?;
+
+        let rev = Some(format!("v{}", package.version));
+
+        Ok(ResolvedPackage {
+            name: package.name.clone(),
+            version: package.version.clone(),
+            git_url: package.repository.clone(),
+            rev,
+        })
+    }
+
+    pub fn search(&self, query: &str) -> Result<Vec<RegistryPackage>, RegistryError> {
+        let index = self.load_index()?;
+        let query_lower = query.to_lowercase();
+
+        Ok(index
+            .packages
+            .into_iter()
+            .filter(|p| {
+                p.name.to_lowercase().contains(&query_lower)
+                    || p.description
+                        .as_ref()
+                        .is_some_and(|d| d.to_lowercase().contains(&query_lower))
+            })
+            .collect())
+    }
+}
+
+impl Default for Registry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_semver_parse() {
+        let v = SemVer::parse("1.2.3").unwrap();
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 2);
+        assert_eq!(v.patch, 3);
+
+        let v = SemVer::parse("v2.0").unwrap();
+        assert_eq!(v.major, 2);
+        assert_eq!(v.minor, 0);
+        assert_eq!(v.patch, 0);
+
+        let v = SemVer::parse("1").unwrap();
+        assert_eq!(v.major, 1);
+        assert_eq!(v.minor, 0);
+        assert_eq!(v.patch, 0);
+    }
+
+    #[test]
+    fn test_semver_satisfies_star() {
+        let v = SemVer::parse("1.2.3").unwrap();
+        assert!(v.satisfies("*"));
+        assert!(v.satisfies(""));
+    }
+
+    #[test]
+    fn test_semver_satisfies_caret() {
+        let v100 = SemVer::parse("1.0.0").unwrap();
+        let v110 = SemVer::parse("1.1.0").unwrap();
+        let v200 = SemVer::parse("2.0.0").unwrap();
+
+        assert!(v100.satisfies("^1.0.0"));
+        assert!(v110.satisfies("^1.0.0"));
+        assert!(!v200.satisfies("^1.0.0"));
+        assert!(!v100.satisfies("^1.1.0"));
+    }
+
+    #[test]
+    fn test_semver_satisfies_tilde() {
+        let v100 = SemVer::parse("1.0.0").unwrap();
+        let v101 = SemVer::parse("1.0.1").unwrap();
+        let v110 = SemVer::parse("1.1.0").unwrap();
+
+        assert!(v100.satisfies("~1.0.0"));
+        assert!(v101.satisfies("~1.0.0"));
+        assert!(!v110.satisfies("~1.0.0"));
+    }
+
+    #[test]
+    fn test_semver_satisfies_exact() {
+        let v = SemVer::parse("1.2.3").unwrap();
+        assert!(v.satisfies("1.2.3"));
+        assert!(v.satisfies("=1.2.3"));
+        assert!(!v.satisfies("1.2.4"));
+    }
+
+    #[test]
+    fn test_semver_satisfies_comparison() {
+        let v = SemVer::parse("1.5.0").unwrap();
+
+        assert!(v.satisfies(">=1.0.0"));
+        assert!(v.satisfies(">1.0.0"));
+        assert!(v.satisfies("<=2.0.0"));
+        assert!(v.satisfies("<2.0.0"));
+        assert!(!v.satisfies(">2.0.0"));
+        assert!(!v.satisfies("<1.0.0"));
+    }
+
+    #[test]
+    fn test_semver_ordering() {
+        let v100 = SemVer::parse("1.0.0").unwrap();
+        let v101 = SemVer::parse("1.0.1").unwrap();
+        let v110 = SemVer::parse("1.1.0").unwrap();
+        let v200 = SemVer::parse("2.0.0").unwrap();
+
+        assert!(v100 < v101);
+        assert!(v101 < v110);
+        assert!(v110 < v200);
+    }
+
+    #[test]
+    fn test_registry_index_parse() {
+        let toml = r#"
+[[packages]]
+name = "test-pkg"
+version = "1.0.0"
+repository = "https://github.com/test/test-pkg"
+description = "A test package"
+
+[[packages]]
+name = "another-pkg"
+version = "0.1.0"
+repository = "https://github.com/test/another"
+"#;
+
+        let index: RegistryIndex = toml::from_str(toml).unwrap();
+        assert_eq!(index.packages.len(), 2);
+        assert_eq!(index.packages[0].name, "test-pkg");
+        assert_eq!(index.packages[1].name, "another-pkg");
+    }
+}

--- a/rust/crates/fusabi-vm/src/vm.rs
+++ b/rust/crates/fusabi-vm/src/vm.rs
@@ -798,6 +798,11 @@ impl Vm {
                         .ok_or(VmError::StackUnderflow)?;
                     let receiver = &self.stack[receiver_idx];
 
+                    // DEBUG: Inspect receiver for CallMethod bug
+                    eprintln!("DEBUG: CallMethod method_name='{}', argc={}", method_name, argc);
+                    eprintln!("DEBUG: CallMethod receiver_idx={}", receiver_idx);
+                    eprintln!("DEBUG: CallMethod receiver={:?} (type: {})", receiver, receiver.type_name());
+
                     // Check receiver type and dispatch accordingly
                     match receiver {
                         Value::HostData(host_data) => {


### PR DESCRIPTION
Closes #223 #224 #225

## Package Registry (#223)
- Add `registry.rs` with semver parsing and constraint matching
- Implement `Registry::update()` to fetch from fusabi-community
- Implement `Registry::search()` for package discovery
- Add `fpm update` and `fpm search` commands

## LSP Server (#224)
- Implement full diagnostics from lexer and parser errors
- Add hover documentation for keywords and builtins
- Add completion for keywords and stdlib functions
- Handle `didOpen`, `didChange`, `didClose` events

## Commander Documentation (#225)
- Create `docs/packages/commander.md` with usage guide
- Add `examples/commander/` package structure with fusabi.toml
- Document MVU architecture and TUI patterns