### PR TITLE
chore: remove debug statements and fix VM return handling

### DIFF
--- a/examples/async_demo.fsx
+++ b/examples/async_demo.fsx
@@ -1,6 +1,6 @@
-// Async Demo Debug 7: Bypass Sprintf
 let log msg =
-    printfn msg
+    let t = Time.format "%H:%M:%S" (Time.now())
+    printfn (sprintf "[%s] %s" [t; msg])
 
 let sleep ms = async {
     log (sprintf "Sleeping for %d ms..." [ms])

--- a/rust/crates/fusabi-vm/src/stdlib/string.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/string.rs
@@ -166,12 +166,10 @@ pub fn string_ends_with(suffix: &Value, s: &Value) -> Result<Value, VmError> {
 /// Supported specifiers: %s (string), %d (int), %f (float), %.Nf (float with precision), %% (literal %)
 /// Example: String.format "%s version %d.%d" ["MyApp"; 1; 0] returns "MyApp version 1.0"
 pub fn string_format(format_str: &Value, args: &Value) -> Result<Value, VmError> {
-    eprintln!("DEBUG: string_format called. format_str={:?} (type: {}), args={:?}", format_str, format_str.type_name(), args);
     // Extract the format string
     let fmt = match format_str {
         Value::Str(s) => s,
         _ => {
-            eprintln!("ERROR: string_format - format_str is not a string!");
             return Err(VmError::TypeMismatch {
                 expected: "string",
                 got: format_str.type_name(),
@@ -182,7 +180,6 @@ pub fn string_format(format_str: &Value, args: &Value) -> Result<Value, VmError>
     // Convert the list to a Vec for easier indexing
     let mut arg_vec = Vec::new();
     let mut current = args.clone();
-    eprintln!("DEBUG: string_format - processing args list");
     loop {
         match current {
             Value::Nil => break,
@@ -191,7 +188,6 @@ pub fn string_format(format_str: &Value, args: &Value) -> Result<Value, VmError>
                 current = (*tail).clone();
             }
             _ => {
-                eprintln!("ERROR: string_format - args is not a list!");
                 return Err(VmError::TypeMismatch {
                     expected: "list",
                     got: current.type_name(),
@@ -199,7 +195,6 @@ pub fn string_format(format_str: &Value, args: &Value) -> Result<Value, VmError>
             }
         }
     }
-    eprintln!("DEBUG: string_format - arg_vec: {:?}", arg_vec);
 
     // Process the format string
     let mut result = String::new();
@@ -340,7 +335,6 @@ pub fn string_format(format_str: &Value, args: &Value) -> Result<Value, VmError>
             arg_vec.len()
         )));
     }
-
     Ok(Value::Str(result))
 }
 

--- a/rust/crates/fusabi-vm/src/vm.rs
+++ b/rust/crates/fusabi-vm/src/vm.rs
@@ -798,11 +798,6 @@ impl Vm {
                         .ok_or(VmError::StackUnderflow)?;
                     let receiver = &self.stack[receiver_idx];
 
-                    // DEBUG: Inspect receiver for CallMethod bug
-                    eprintln!("DEBUG: CallMethod method_name='{}', argc={}", method_name, argc);
-                    eprintln!("DEBUG: CallMethod receiver_idx={}", receiver_idx);
-                    eprintln!("DEBUG: CallMethod receiver={:?} (type: {})", receiver, receiver.type_name());
-
                     // Check receiver type and dispatch accordingly
                     match receiver {
                         Value::HostData(host_data) => {
@@ -922,14 +917,16 @@ impl Vm {
                 }
 
                 Instruction::Return => {
+                    let returned_value = self.pop().unwrap_or(Value::Unit);
+
                     // Pop the frame
                     self.frames.pop();
 
                     // If we've dropped below the starting depth, we're done with this run() call
                     if self.frames.len() < start_depth {
-                        // Return the top of stack or Unit if empty
-                        return Ok(self.stack.pop().unwrap_or(Value::Unit));
+                        return Ok(returned_value);
                     }
+                    self.push(returned_value); // Push back if not final return
                 }
 
                 // List operations


### PR DESCRIPTION
## Summary
- Remove debug `eprintln!` statements from `string_format` in `stdlib/string.rs`
- Remove debug `eprintln!` statements for `CallMethod` in `vm.rs`
- Fix `Return` instruction to properly capture return value before popping frame
- Update `async_demo.fsx` with proper timestamp logging using Time module

## Test plan
- [x] Verified code compiles
- [x] String formatting tests pass
- [x] Process tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)