### PR TITLE
chore: bump version to v0.22.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fusabi-frontend"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Frontend (parser, compiler) for Fusabi language"
 license = "MIT"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.21.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.22.0" }

--- a/rust/crates/fusabi-lsp/Cargo.toml
+++ b/rust/crates/fusabi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-lsp"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "Language Server Protocol implementation for Fusabi"
 license = "MIT"
@@ -10,6 +10,6 @@ name = "fusabi-lsp"
 path = "src/main.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.21.0" }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.22.0" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "fusabi-mcp"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 description = "MCP (Model Context Protocol) integration for Fusabi"
 license = "MIT"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.21.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.22.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Virtual Machine for Fusabi language"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "A potent, functional scripting layer for Rust infrastructure."
@@ -16,8 +16,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.21.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.21.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.22.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.22.0", features = ["serde"] }
 colored = "2.1"
 
 [features]


### PR DESCRIPTION
## Summary

Version bump to v0.22.0 for release. This release includes:

- **feat:** `set_global()` values now visible in `eval()` context (fixes #244) 
- **feat:** `Engine::apply()` for calling function values (fixes #243)

## Changes

- Updated version from 0.21.0 to 0.22.0 in:
  - `fusabi` crate
  - `fusabi-vm` crate
  - `fusabi-frontend` crate
  - `fusabi-lsp` crate
  - `fusabi-mcp` crate

## Test plan

- [x] Build passes (`cargo build --all`)
- [x] Core feature tests pass (`test_set_global_visible_in_eval`, apply tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)