### PR TITLE
chore: add rust-version to all crates

### DIFF
--- a/rust/crates/fusabi-bench-compare/Cargo.toml
+++ b/rust/crates/fusabi-bench-compare/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fusabi-bench-compare"
 version = "0.11.0"
 edition = "2021"
+rust-version = "1.70.0"
 description = "Benchmarking comparison harness for Fusabi vs other embedded languages"
 
 [[bin]]

--- a/rust/crates/fusabi-lsp/Cargo.toml
+++ b/rust/crates/fusabi-lsp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fusabi-lsp"
 version = "0.22.0"
 edition = "2021"
+rust-version = "1.70.0"
 description = "Language Server Protocol implementation for Fusabi"
 license = "MIT"
 

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fusabi-mcp"
 version = "0.22.0"
 edition = "2021"
+rust-version = "1.70.0"
 description = "MCP (Model Context Protocol) integration for Fusabi"
 license = "MIT"
 

--- a/rust/crates/fusabi-pm/Cargo.toml
+++ b/rust/crates/fusabi-pm/Cargo.toml
@@ -2,6 +2,7 @@
 name = "fusabi-pm"
 version = "0.1.0"
 edition = "2021"
+rust-version = "1.70.0"
 description = "Fusabi Package Manager"
 license = "MIT"
 


### PR DESCRIPTION
## Summary

Fixes MSRV check in release workflow by adding `rust-version = "1.70.0"` to all crate manifests that were missing it.

## Changes

Added `rust-version = "1.70.0"` to:
- `fusabi-lsp`
- `fusabi-mcp`
- `fusabi-pm`
- `fusabi-bench-compare`

🤖 Generated with [Claude Code](https://claude.com/claude-code)