### PR TITLE
chore: bump version to v0.34.0

### DIFF
--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "fusabi-frontend"
-version = "0.23.0"
+version = "0.34.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Frontend (parser, compiler) for Fusabi language"
 license = "MIT"
 
 [dependencies]
-fusabi-vm = { path = "../fusabi-vm", version = "0.23.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.34.0" }

--- a/rust/crates/fusabi-lsp/Cargo.toml
+++ b/rust/crates/fusabi-lsp/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-lsp"
-version = "0.23.0"
+version = "0.34.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Language Server Protocol implementation for Fusabi"
@@ -11,6 +11,6 @@ name = "fusabi-lsp"
 path = "src/main.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.23.0" }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.34.0" }
 tower-lsp = "0.20"
 tokio = { version = "1", features = ["full"] }

--- a/rust/crates/fusabi-mcp/Cargo.toml
+++ b/rust/crates/fusabi-mcp/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "fusabi-mcp"
-version = "0.23.0"
+version = "0.34.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "MCP (Model Context Protocol) integration for Fusabi"
 license = "MIT"
 
 [dependencies]
-fusabi = { path = "../fusabi", version = "0.23.0", features = ["osc", "json"] }
+fusabi = { path = "../fusabi", version = "0.34.0", features = ["osc", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.35", features = ["full"] }

--- a/rust/crates/fusabi-vm/Cargo.toml
+++ b/rust/crates/fusabi-vm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi-vm"
-version = "0.23.0"
+version = "0.34.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "Virtual Machine for Fusabi language"

--- a/rust/crates/fusabi/Cargo.toml
+++ b/rust/crates/fusabi/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fusabi"
-version = "0.23.0"
+version = "0.34.0"
 edition = "2021"
 rust-version = "1.70.0"
 description = "A potent, functional scripting layer for Rust infrastructure."
@@ -16,8 +16,8 @@ name = "fusabi"
 path = "src/lib.rs"
 
 [dependencies]
-fusabi-frontend = { path = "../fusabi-frontend", version = "0.23.0" }
-fusabi-vm = { path = "../fusabi-vm", version = "0.23.0", features = ["serde"] }
+fusabi-frontend = { path = "../fusabi-frontend", version = "0.34.0" }
+fusabi-vm = { path = "../fusabi-vm", version = "0.34.0", features = ["serde"] }
 colored = "2.1"
 
 [features]


### PR DESCRIPTION
Release v0.34.0 with module namespace fix (Issue #242)