### PR TITLE
feat: Multi-file module system with #load directive

### DIFF
--- a/examples/multifile/README.md
+++ b/examples/multifile/README.md
@@ -1,0 +1,33 @@
+# Multi-file Module System Example
+
+This directory demonstrates the `#load` directive for multi-file module support in Fusabi.
+
+## Files
+
+- `utils.fsx` - Basic utility functions
+- `math.fsx` - Math functions that depend on utils
+- `main.fsx` - Main entry point that uses both modules
+
+## Usage
+
+The files demonstrate:
+1. Loading dependencies with `#load "path.fsx"`
+2. Circular dependency detection (utils is loaded once, not twice)
+3. Module scoping across files
+
+## How it works
+
+```fsharp
+// main.fsx loads both math.fsx and utils.fsx
+#load "math.fsx"  // This also loads utils.fsx transitively
+#load "utils.fsx" // Already loaded, uses cached version
+
+// All modules are now available
+let result = Math.pythagorean 3 4  // Uses Math.pythagorean from math.fsx
+let simple = Utils.add 10 20       // Uses Utils.add from utils.fsx
+```
+
+The loader:
+- Resolves paths relative to the current file
+- Detects and prevents circular dependencies
+- Caches loaded files to avoid recompilation

--- a/examples/multifile/main.fsx
+++ b/examples/multifile/main.fsx
@@ -1,0 +1,10 @@
+// Main file demonstrating multi-file module system
+
+#load "math.fsx"
+#load "utils.fsx"
+
+// Use functions from loaded modules
+let result = Math.pythagorean 3 4
+let simple = Utils.add 10 20
+
+result

--- a/examples/multifile/math.fsx
+++ b/examples/multifile/math.fsx
@@ -1,0 +1,9 @@
+// Math module that depends on utils
+
+#load "utils.fsx"
+
+module Math =
+    let pythagorean a b =
+        let a2 = Utils.square a
+        let b2 = Utils.square b
+        Utils.add a2 b2

--- a/examples/multifile/utils.fsx
+++ b/examples/multifile/utils.fsx
@@ -1,0 +1,6 @@
+// Utility functions for the multifile example
+
+module Utils =
+    let add x y = x + y
+    let multiply x y = x * y
+    let square x = x * x

--- a/rust/crates/fusabi-frontend/Cargo.toml
+++ b/rust/crates/fusabi-frontend/Cargo.toml
@@ -8,3 +8,6 @@ license = "MIT"
 
 [dependencies]
 fusabi-vm = { path = "../fusabi-vm", version = "0.34.0" }
+
+[dev-dependencies]
+tempfile = "3.8"

--- a/rust/crates/fusabi-frontend/src/ast.rs
+++ b/rust/crates/fusabi-frontend/src/ast.rs
@@ -1155,12 +1155,30 @@ impl fmt::Display for Import {
     }
 }
 
+/// Load directive for multi-file module system
+///
+/// Represents a #load directive that imports another .fsx file.
+/// Example: #load "utils.fsx"
+#[derive(Debug, Clone, PartialEq)]
+pub struct LoadDirective {
+    /// Path to the file to load
+    pub path: String,
+}
+
+impl fmt::Display for LoadDirective {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "#load \"{}\"", self.path)
+    }
+}
+
 /// Complete program with modules and main expression
 ///
 /// Top-level structure representing a complete Fusabi program with
 /// module definitions, imports, and an optional main expression.
 #[derive(Debug, Clone, PartialEq)]
 pub struct Program {
+    /// Load directives (must appear before other declarations)
+    pub directives: Vec<LoadDirective>,
     /// Module definitions
     pub modules: Vec<ModuleDef>,
     /// Import statements
@@ -1173,6 +1191,12 @@ pub struct Program {
 
 impl fmt::Display for Program {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for directive in &self.directives {
+            writeln!(f, "{}", directive)?;
+        }
+        if !self.directives.is_empty() && (!self.imports.is_empty() || !self.modules.is_empty()) {
+            writeln!(f)?;
+        }
         for import in &self.imports {
             writeln!(f, "{}", import)?;
         }

--- a/rust/crates/fusabi-frontend/src/lib.rs
+++ b/rust/crates/fusabi-frontend/src/lib.rs
@@ -58,6 +58,7 @@ pub mod compiler;
 pub mod error;
 pub mod inference;
 pub mod lexer;
+pub mod loader;
 pub mod modules;
 pub mod parser;
 pub mod span;
@@ -65,11 +66,12 @@ pub mod typed_ast;
 pub mod types;
 
 // Re-export commonly used types for convenience
-pub use ast::{BinOp, Expr, Literal, ModuleDef, ModuleItem, Pattern, Program};
+pub use ast::{BinOp, Expr, Literal, LoadDirective, ModuleDef, ModuleItem, Pattern, Program};
 pub use compiler::{CompileError, CompileOptions, Compiler};
 pub use error::{TypeError, TypeErrorKind};
 pub use inference::TypeInference;
 pub use lexer::{LexError, Lexer, Position, Token, TokenWithPos};
+pub use loader::{FileLoader, LoadError, LoadedFile};
 pub use modules::{Module, ModulePath, ModuleRegistry, TypeDefinition as ModuleTypeDef};
 pub use parser::{ParseError, Parser};
 pub use span::Span;

--- a/rust/crates/fusabi-frontend/src/loader.rs
+++ b/rust/crates/fusabi-frontend/src/loader.rs
@@ -1,0 +1,266 @@
+//! File loader for multi-file module system
+//!
+//! This module implements the `FileLoader` for loading and caching `.fsx` files
+//! referenced by `#load` directives. It handles:
+//! - Path resolution (relative and absolute paths)
+//! - Circular dependency detection
+//! - Caching of loaded files to avoid recompilation
+//!
+//! # Example
+//!
+//! ```rust
+//! use fusabi_frontend::loader::FileLoader;
+//! use std::path::PathBuf;
+//!
+//! let mut loader = FileLoader::new(PathBuf::from("."));
+//! // Load a file (with circular dependency detection and caching)
+//! // let loaded = loader.load("utils.fsx", &PathBuf::from("main.fsx")).unwrap();
+//! ```
+
+use crate::ast::Program;
+use crate::lexer::{LexError, Lexer};
+use crate::parser::{ParseError, Parser};
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+use std::path::{Path, PathBuf};
+
+/// Errors that can occur during file loading
+#[derive(Debug, Clone)]
+pub enum LoadError {
+    /// File not found at the specified path
+    FileNotFound(PathBuf),
+    /// Circular dependency detected
+    CircularDependency(Vec<PathBuf>),
+    /// Parse error in loaded file
+    ParseError(PathBuf, ParseError),
+    /// Lexer error in loaded file
+    LexError(PathBuf, LexError),
+    /// IO error reading file
+    IoError(String),
+}
+
+impl fmt::Display for LoadError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            LoadError::FileNotFound(path) => write!(f, "File not found: {}", path.display()),
+            LoadError::CircularDependency(paths) => {
+                write!(f, "Circular dependency detected: ")?;
+                for (i, path) in paths.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, " -> ")?;
+                    }
+                    write!(f, "{}", path.display())?;
+                }
+                Ok(())
+            }
+            LoadError::ParseError(path, err) => {
+                write!(f, "Parse error in {}: {}", path.display(), err)
+            }
+            LoadError::LexError(path, err) => write!(f, "Lex error in {}: {}", path.display(), err),
+            LoadError::IoError(msg) => write!(f, "IO error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+/// A loaded file with its parsed program
+#[derive(Debug, Clone)]
+pub struct LoadedFile {
+    /// Canonical path to the file
+    pub path: PathBuf,
+    /// Parsed program AST
+    pub program: Program,
+}
+
+/// File loader with caching and circular dependency detection
+pub struct FileLoader {
+    /// Cache of already-loaded files (canonical path -> LoadedFile)
+    cache: HashMap<PathBuf, LoadedFile>,
+    /// Currently loading files (for cycle detection)
+    loading: HashSet<PathBuf>,
+    /// Base directory for relative path resolution
+    base_dir: PathBuf,
+}
+
+impl FileLoader {
+    /// Create a new file loader with the given base directory
+    pub fn new(base_dir: PathBuf) -> Self {
+        Self {
+            cache: HashMap::new(),
+            loading: HashSet::new(),
+            base_dir,
+        }
+    }
+
+    /// Load a file and all its dependencies
+    ///
+    /// # Arguments
+    /// * `path` - Path to load (can be relative or absolute)
+    /// * `from_file` - The file containing the #load directive (for relative path resolution)
+    ///
+    /// # Returns
+    /// Reference to the loaded file (from cache)
+    pub fn load(&mut self, path: &str, from_file: &Path) -> Result<&LoadedFile, LoadError> {
+        let resolved = self.resolve_path(path, from_file)?;
+
+        // Check cache first
+        if self.cache.contains_key(&resolved) {
+            return Ok(self.cache.get(&resolved).unwrap());
+        }
+
+        // Check for cycles
+        if self.loading.contains(&resolved) {
+            let mut cycle: Vec<PathBuf> = self.loading.iter().cloned().collect();
+            cycle.push(resolved.clone());
+            return Err(LoadError::CircularDependency(cycle));
+        }
+
+        // Mark as loading
+        self.loading.insert(resolved.clone());
+
+        // Read and parse file
+        let source = std::fs::read_to_string(&resolved)
+            .map_err(|e| LoadError::IoError(format!("{}: {}", resolved.display(), e)))?;
+
+        let mut lexer = Lexer::new(&source);
+        let tokens = lexer
+            .tokenize()
+            .map_err(|e| LoadError::LexError(resolved.clone(), e))?;
+
+        let mut parser = Parser::new(tokens);
+        let program = parser
+            .parse_program()
+            .map_err(|e| LoadError::ParseError(resolved.clone(), e))?;
+
+        // Recursively load dependencies
+        for directive in &program.directives {
+            self.load(&directive.path, &resolved)?;
+        }
+
+        // Create loaded file
+        let loaded = LoadedFile {
+            path: resolved.clone(),
+            program,
+        };
+
+        // Remove from loading, add to cache
+        self.loading.remove(&resolved);
+        self.cache.insert(resolved.clone(), loaded);
+
+        Ok(self.cache.get(&resolved).unwrap())
+    }
+
+    /// Resolve a path relative to a source file
+    fn resolve_path(&self, path: &str, from_file: &Path) -> Result<PathBuf, LoadError> {
+        let resolved = if path.starts_with('/') {
+            // Absolute path
+            PathBuf::from(path)
+        } else {
+            // Relative to from_file's directory
+            from_file
+                .parent()
+                .unwrap_or(&self.base_dir)
+                .join(path)
+        };
+
+        // Canonicalize to get absolute path and resolve symlinks
+        resolved
+            .canonicalize()
+            .map_err(|_| LoadError::FileNotFound(resolved.clone()))
+    }
+
+    /// Get a loaded file from cache (if it exists)
+    pub fn get_cached(&self, path: &Path) -> Option<&LoadedFile> {
+        self.cache.get(path)
+    }
+
+    /// Clear the cache (useful for hot reload scenarios)
+    pub fn clear_cache(&mut self) {
+        self.cache.clear();
+    }
+
+    /// Invalidate a specific file in the cache
+    pub fn invalidate(&mut self, path: &Path) {
+        self.cache.remove(path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_load_simple_file() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("test.fsx");
+        let from_file = temp_dir.path().join("from.fsx");
+        fs::write(&test_file, "let x = 42").unwrap();
+
+        let mut loader = FileLoader::new(temp_dir.path().to_path_buf());
+        let loaded = loader.load("test.fsx", &from_file).unwrap();
+
+        assert_eq!(loaded.program.items.len(), 1);
+    }
+
+    #[test]
+    fn test_circular_dependency_detection() {
+        let temp_dir = TempDir::new().unwrap();
+        let a_file = temp_dir.path().join("a.fsx");
+        let b_file = temp_dir.path().join("b.fsx");
+
+        fs::write(&a_file, "#load \"b.fsx\"\nlet a = 1").unwrap();
+        fs::write(&b_file, "#load \"a.fsx\"\nlet b = 2").unwrap();
+
+        let mut loader = FileLoader::new(temp_dir.path().to_path_buf());
+        let result = loader.load("a.fsx", &a_file);
+
+        assert!(matches!(result, Err(LoadError::CircularDependency(_))));
+    }
+
+    #[test]
+    fn test_caching() {
+        let temp_dir = TempDir::new().unwrap();
+        let test_file = temp_dir.path().join("cached.fsx");
+        let from_file = temp_dir.path().join("from.fsx");
+        fs::write(&test_file, "let x = 42").unwrap();
+
+        let mut loader = FileLoader::new(temp_dir.path().to_path_buf());
+
+        // Load twice
+        loader.load("cached.fsx", &from_file).unwrap();
+        loader.load("cached.fsx", &from_file).unwrap();
+
+        // Should only be loaded once
+        assert_eq!(loader.cache.len(), 1);
+    }
+
+    #[test]
+    fn test_nested_loads() {
+        let temp_dir = TempDir::new().unwrap();
+        let utils_file = temp_dir.path().join("utils.fsx");
+        let main_file = temp_dir.path().join("main.fsx");
+
+        fs::write(&utils_file, "let helper x = x + 1").unwrap();
+        fs::write(&main_file, "#load \"utils.fsx\"\nlet result = helper 42").unwrap();
+
+        let mut loader = FileLoader::new(temp_dir.path().to_path_buf());
+        let loaded = loader.load("main.fsx", &main_file).unwrap();
+
+        // main.fsx should be loaded, and utils.fsx should be in cache
+        assert_eq!(loaded.program.directives.len(), 1);
+        assert_eq!(loader.cache.len(), 2); // both main and utils
+    }
+
+    #[test]
+    fn test_file_not_found() {
+        let temp_dir = TempDir::new().unwrap();
+        let from_file = temp_dir.path().join("from.fsx");
+        let mut loader = FileLoader::new(temp_dir.path().to_path_buf());
+        let result = loader.load("nonexistent.fsx", &from_file);
+
+        assert!(matches!(result, Err(LoadError::FileNotFound(_))));
+    }
+}

--- a/rust/crates/fusabi-frontend/tests/compiler_modules.rs
+++ b/rust/crates/fusabi-frontend/tests/compiler_modules.rs
@@ -28,6 +28,7 @@ fn make_import(module_name: &str) -> Import {
 #[test]
 fn test_compile_empty_program() {
     let program = Program {
+        directives: vec![],
         modules: vec![],
         imports: vec![],
         items: vec![],
@@ -47,6 +48,7 @@ fn test_compile_program_with_simple_module_constant() {
     let math_module = make_simple_module("Math", "pi", Expr::Lit(Literal::Int(3)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![],
         items: vec![],
@@ -70,6 +72,7 @@ fn test_compile_program_with_import() {
     let constants_module = make_simple_module("Constants", "value", Expr::Lit(Literal::Int(10)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![constants_module],
         imports: vec![make_import("Constants")],
         items: vec![],
@@ -89,6 +92,7 @@ fn test_compile_qualified_name() {
     let math_module = make_simple_module("Math", "value", Expr::Lit(Literal::Int(100)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![],
         items: vec![],
@@ -111,6 +115,7 @@ fn test_compile_imported_binding() {
     let constants_module = make_simple_module("Constants", "answer", Expr::Lit(Literal::Int(42)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![constants_module],
         imports: vec![make_import("Constants")],
         items: vec![],
@@ -135,6 +140,7 @@ fn test_compile_multiple_modules() {
     let physics_module = make_simple_module("Physics", "c", Expr::Lit(Literal::Int(300000000)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module, physics_module],
         imports: vec![],
         items: vec![],
@@ -160,6 +166,7 @@ fn test_compile_multiple_imports() {
     let physics_module = make_simple_module("Physics", "c", Expr::Lit(Literal::Int(300000000)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module, physics_module],
         imports: vec![make_import("Math"), make_import("Physics")],
         items: vec![],
@@ -186,6 +193,7 @@ fn test_compile_module_with_multiple_bindings() {
     };
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![],
         items: vec![],
@@ -211,6 +219,7 @@ fn test_compile_nested_modules() {
     };
 
     let program = Program {
+        directives: vec![],
         modules: vec![outer_module],
         imports: vec![],
         items: vec![],
@@ -237,6 +246,7 @@ fn test_compile_module_with_constant() {
     };
 
     let program = Program {
+        directives: vec![],
         modules: vec![constants_module],
         imports: vec![],
         items: vec![],
@@ -259,6 +269,7 @@ fn test_compile_program_using_imported_constant() {
     let constants_module = make_simple_module("Constants", "value", Expr::Lit(Literal::Int(99)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![constants_module],
         imports: vec![make_import("Constants")],
         items: vec![],
@@ -274,6 +285,7 @@ fn test_compile_program_using_imported_constant() {
 fn test_compile_error_undefined_module() {
     // Reference a module that doesn't exist
     let program = Program {
+        directives: vec![],
         modules: vec![],
         imports: vec![],
         items: vec![],
@@ -299,6 +311,7 @@ fn test_compile_error_undefined_binding_in_module() {
     let math_module = make_simple_module("Math", "value", Expr::Lit(Literal::Int(10)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![],
         items: vec![],
@@ -334,6 +347,7 @@ fn test_compile_module_with_expression() {
     );
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![],
         items: vec![],
@@ -355,6 +369,7 @@ fn test_compile_program_with_expression_using_module() {
     let math_module = make_simple_module("Math", "value", Expr::Lit(Literal::Int(10)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![],
         items: vec![],
@@ -389,6 +404,7 @@ fn test_compile_imported_expression() {
     );
 
     let program = Program {
+        directives: vec![],
         modules: vec![math_module],
         imports: vec![make_import("Math")],
         items: vec![],
@@ -409,6 +425,7 @@ fn test_compile_module_with_bool() {
     let flags_module = make_simple_module("Flags", "enabled", Expr::Lit(Literal::Bool(true)));
 
     let program = Program {
+        directives: vec![],
         modules: vec![flags_module],
         imports: vec![],
         items: vec![],
@@ -435,6 +452,7 @@ fn test_compile_module_with_string() {
     );
 
     let program = Program {
+        directives: vec![],
         modules: vec![messages_module],
         imports: vec![],
         items: vec![],

--- a/rust/crates/fusabi-lsp/src/lib.rs
+++ b/rust/crates/fusabi-lsp/src/lib.rs
@@ -54,6 +54,11 @@ impl FusabiLanguageServer {
                     fusabi_frontend::LexError::UnterminatedComment(pos) => {
                         (pos.line, pos.column, "Unterminated comment".to_string())
                     }
+                    fusabi_frontend::LexError::UnknownDirective(name, pos) => (
+                        pos.line,
+                        pos.column,
+                        format!("Unknown directive: '{}'", name),
+                    ),
                 };
                 diagnostics.push(Diagnostic {
                     range: Range {


### PR DESCRIPTION
## Summary
Implements RFC-003: Multi-file Module System

This PR adds support for multi-file module organization using the `#load` directive, enabling better code organization and reusability across Fusabi projects.

## Changes
- **Lexer**: Added `LoadDirective` token for `#load "path"` syntax
- **AST**: Added `LoadDirective` struct and updated `Program` to include directives
- **Parser**: Parse directives at the start of files
- **FileLoader**: New module for loading/caching files with cycle detection
- **LSP Integration**: Updated to handle the new `UnknownDirective` error variant
- **Examples**: Added example files demonstrating multi-file usage

## Implementation Details

### Lexer
- Added `#` character handling in `next_token()`
- Implemented `lex_directive()` method to parse `#load "path"` syntax
- Added `UnknownDirective` error variant for invalid directives

### Parser
- Added `parse_load_directive()` method
- Updated `parse_program()` to parse directives before other content
- Directives must appear at the start of files

### FileLoader
- Path resolution (relative and absolute paths)
- Circular dependency detection using a loading set
- File caching to avoid recompilation
- Clean error messages for common issues

## Testing
- **Unit tests** for FileLoader functionality:
  - Simple file loading
  - Circular dependency detection
  - Caching verification
  - Nested loads
  - File not found errors
- **Integration tests**: All existing tests pass
- **Example files**: Multi-file examples in `examples/multifile/`

## Usage Example

```fsharp
// utils.fsx
module Utils =
    let add x y = x + y
    let square x = x * x

// math.fsx
#load "utils.fsx"

module Math =
    let pythagorean a b =
        let a2 = Utils.square a
        let b2 = Utils.square b
        Utils.add a2 b2

// main.fsx
#load "math.fsx"
#load "utils.fsx"  // Already loaded, uses cached version

let result = Math.pythagorean 3 4
```

## Benefits
- Enables better code organization for larger projects
- Supports code reuse across multiple files
- Prevents circular dependencies automatically
- Caches loaded files for performance
- Foundation for future package management features

## Future Work
- Integration with compiler for cross-file type checking
- Hot reload support for development
- Package path resolution (`#load "pkg:package/file.fsx"`)
- Dependency graph visualization

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)