### PR TITLE
feat: fusabi-tui-widgets Phase 2 - Widget Framework

### DIFF
--- a/fusabi-tui-runtime/Cargo.lock
+++ b/fusabi-tui-runtime/Cargo.lock
@@ -66,6 +66,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fusabi-tui-widgets"
+version = "0.1.0"
+dependencies = [
+ "bitflags",
+ "fusabi-tui-core",
+ "unicode-width",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.178"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/Cargo.toml
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fusabi-tui-widgets"
+version = "0.1.0"
+edition = "2021"
+description = "Widget library for Fusabi TUI"
+license = "MIT"
+
+[dependencies]
+fusabi-tui-core = { path = "../fusabi-tui-core" }
+unicode-width = "0.1"
+bitflags = "2.4"

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/examples/block_demo.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/examples/block_demo.rs
@@ -1,0 +1,76 @@
+//! Demonstration of the Block widget with various configurations.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::{Color, Modifier, Style},
+};
+use fusabi_tui_widgets::{
+    block::{Block, Padding, Title, TitleAlignment, TitlePosition},
+    borders::{BorderType, Borders},
+    widget::Widget,
+};
+
+fn main() {
+    // Create a simple block with all borders
+    let block1 = Block::default()
+        .title("Simple Block")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Plain);
+
+    // Create a block with rounded borders and centered title
+    let block2 = Block::default()
+        .title("Rounded Block")
+        .borders(Borders::ALL)
+        .border_type(BorderType::Rounded)
+        .title_alignment(TitleAlignment::Center)
+        .border_style(Style::default().fg(Color::Cyan));
+
+    // Create a block with double borders, bottom title, and padding
+    let block3 = Block::default()
+        .title(
+            Title::new("Bottom Title")
+                .position(TitlePosition::Bottom)
+                .alignment(TitleAlignment::Right)
+                .style(Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD)),
+        )
+        .borders(Borders::ALL)
+        .border_type(BorderType::Double)
+        .border_style(Style::default().fg(Color::Green))
+        .padding(Padding::uniform(1));
+
+    // Render blocks to buffers
+    let area = Rect::new(0, 0, 30, 5);
+    let mut buffer1 = Buffer::new(area);
+    let mut buffer2 = Buffer::new(area);
+    let mut buffer3 = Buffer::new(area);
+
+    block1.render(area, &mut buffer1);
+    block2.render(area, &mut buffer2);
+    block3.render(area, &mut buffer3);
+
+    println!("Block 1 - Simple:");
+    print_buffer(&buffer1);
+
+    println!("\nBlock 2 - Rounded with centered title:");
+    print_buffer(&buffer2);
+
+    println!("\nBlock 3 - Double borders with bottom right title and padding:");
+    print_buffer(&buffer3);
+
+    // Demonstrate inner area calculation
+    let inner = block3.inner(area);
+    println!("\nInner area for block3: x={}, y={}, w={}, h={}",
+             inner.x, inner.y, inner.width, inner.height);
+}
+
+fn print_buffer(buffer: &Buffer) {
+    for y in 0..buffer.area.height {
+        for x in 0..buffer.area.width {
+            if let Some(cell) = buffer.get(x, y) {
+                print!("{}", cell.symbol);
+            }
+        }
+        println!();
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/block.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/block.rs
@@ -1,0 +1,650 @@
+//! Block widget for creating bordered containers.
+//!
+//! The Block widget is a fundamental building block for TUI layouts, providing
+//! a bordered container with optional title and padding.
+
+use crate::borders::{BorderType, Borders};
+use crate::widget::Widget;
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+};
+
+/// Position of the title within the block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TitlePosition {
+    /// Title at the top of the block
+    Top,
+    /// Title at the bottom of the block
+    Bottom,
+}
+
+impl Default for TitlePosition {
+    fn default() -> Self {
+        Self::Top
+    }
+}
+
+/// Horizontal alignment of the title text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TitleAlignment {
+    /// Align title to the left
+    Left,
+    /// Align title to the center
+    Center,
+    /// Align title to the right
+    Right,
+}
+
+impl Default for TitleAlignment {
+    fn default() -> Self {
+        Self::Left
+    }
+}
+
+/// A title for a block with position and alignment.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Title {
+    /// The text of the title
+    pub content: String,
+    /// The position of the title (top or bottom)
+    pub position: TitlePosition,
+    /// The alignment of the title (left, center, or right)
+    pub alignment: TitleAlignment,
+    /// The style of the title text
+    pub style: Style,
+}
+
+impl Title {
+    /// Creates a new title with the given text.
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            position: TitlePosition::default(),
+            alignment: TitleAlignment::default(),
+            style: Style::default(),
+        }
+    }
+
+    /// Sets the position of the title.
+    pub fn position(mut self, position: TitlePosition) -> Self {
+        self.position = position;
+        self
+    }
+
+    /// Sets the alignment of the title.
+    pub fn alignment(mut self, alignment: TitleAlignment) -> Self {
+        self.alignment = alignment;
+        self
+    }
+
+    /// Sets the style of the title.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+}
+
+impl<T> From<T> for Title
+where
+    T: Into<String>,
+{
+    fn from(content: T) -> Self {
+        Self::new(content)
+    }
+}
+
+/// A block widget that draws borders and an optional title.
+///
+/// Blocks are fundamental building blocks for creating structured TUI layouts.
+/// They can be used to create panels, containers, and organize content with
+/// visual boundaries.
+///
+/// # Examples
+///
+/// ```
+/// use fusabi_tui_widgets::block::{Block, TitleAlignment};
+/// use fusabi_tui_widgets::borders::{Borders, BorderType};
+/// use fusabi_tui_core::style::{Style, Color, Modifier};
+///
+/// let block = Block::default()
+///     .title("My Panel")
+///     .borders(Borders::ALL)
+///     .border_type(BorderType::Rounded)
+///     .border_style(Style::default().fg(Color::Cyan))
+///     .title_alignment(TitleAlignment::Center);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Block {
+    /// The title of the block
+    title: Option<Title>,
+    /// Which borders to draw
+    borders: Borders,
+    /// The type of border characters to use
+    border_type: BorderType,
+    /// The style to apply to the borders
+    border_style: Style,
+    /// The style to apply to the interior area
+    style: Style,
+    /// Padding inside the borders
+    padding: Padding,
+}
+
+/// Padding specification for a block.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Padding {
+    /// Left padding
+    pub left: u16,
+    /// Right padding
+    pub right: u16,
+    /// Top padding
+    pub top: u16,
+    /// Bottom padding
+    pub bottom: u16,
+}
+
+impl Padding {
+    /// Creates uniform padding on all sides.
+    pub const fn uniform(padding: u16) -> Self {
+        Self {
+            left: padding,
+            right: padding,
+            top: padding,
+            bottom: padding,
+        }
+    }
+
+    /// Creates horizontal padding (left and right).
+    pub const fn horizontal(padding: u16) -> Self {
+        Self {
+            left: padding,
+            right: padding,
+            top: 0,
+            bottom: 0,
+        }
+    }
+
+    /// Creates vertical padding (top and bottom).
+    pub const fn vertical(padding: u16) -> Self {
+        Self {
+            left: 0,
+            right: 0,
+            top: padding,
+            bottom: padding,
+        }
+    }
+
+    /// Creates zero padding.
+    pub const fn zero() -> Self {
+        Self {
+            left: 0,
+            right: 0,
+            top: 0,
+            bottom: 0,
+        }
+    }
+}
+
+impl Default for Padding {
+    fn default() -> Self {
+        Self::zero()
+    }
+}
+
+impl Default for Block {
+    fn default() -> Self {
+        Self {
+            title: None,
+            borders: Borders::NONE,
+            border_type: BorderType::default(),
+            border_style: Style::default(),
+            style: Style::default(),
+            padding: Padding::default(),
+        }
+    }
+}
+
+impl Block {
+    /// Creates a new block with default settings.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the title of the block.
+    pub fn title<T>(mut self, title: T) -> Self
+    where
+        T: Into<Title>,
+    {
+        self.title = Some(title.into());
+        self
+    }
+
+    /// Sets which borders to draw.
+    pub fn borders(mut self, borders: Borders) -> Self {
+        self.borders = borders;
+        self
+    }
+
+    /// Sets the type of border characters to use.
+    pub fn border_type(mut self, border_type: BorderType) -> Self {
+        self.border_type = border_type;
+        self
+    }
+
+    /// Sets the style of the borders.
+    pub fn border_style(mut self, style: Style) -> Self {
+        self.border_style = style;
+        self
+    }
+
+    /// Sets the style of the block's interior.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the title alignment.
+    pub fn title_alignment(mut self, alignment: TitleAlignment) -> Self {
+        if let Some(ref mut title) = self.title {
+            title.alignment = alignment;
+        }
+        self
+    }
+
+    /// Sets the title position.
+    pub fn title_position(mut self, position: TitlePosition) -> Self {
+        if let Some(ref mut title) = self.title {
+            title.position = position;
+        }
+        self
+    }
+
+    /// Sets uniform padding on all sides.
+    pub fn padding(mut self, padding: Padding) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    /// Computes the inner area after accounting for borders and padding.
+    ///
+    /// This is the area where child widgets should be rendered.
+    pub fn inner(&self, area: Rect) -> Rect {
+        let mut inner = area;
+
+        // Account for borders
+        if self.borders.contains(Borders::LEFT) {
+            inner.x = inner.x.saturating_add(1);
+            inner.width = inner.width.saturating_sub(1);
+        }
+        if self.borders.contains(Borders::RIGHT) {
+            inner.width = inner.width.saturating_sub(1);
+        }
+        if self.borders.contains(Borders::TOP) {
+            inner.y = inner.y.saturating_add(1);
+            inner.height = inner.height.saturating_sub(1);
+        }
+        if self.borders.contains(Borders::BOTTOM) {
+            inner.height = inner.height.saturating_sub(1);
+        }
+
+        // Account for padding
+        inner.x = inner.x.saturating_add(self.padding.left);
+        inner.width = inner.width.saturating_sub(self.padding.left + self.padding.right);
+        inner.y = inner.y.saturating_add(self.padding.top);
+        inner.height = inner.height.saturating_sub(self.padding.top + self.padding.bottom);
+
+        inner
+    }
+
+    /// Renders the border for the given edge.
+    fn render_border(&self, area: Rect, buf: &mut Buffer) {
+        let (horizontal, vertical, top_left, top_right, bottom_left, bottom_right) =
+            self.border_type.line_symbols();
+
+        // Draw corners
+        if self.borders.contains(Borders::TOP | Borders::LEFT) {
+            buf.set_string(area.x, area.y, top_left, self.border_style);
+        }
+        if self.borders.contains(Borders::TOP | Borders::RIGHT) && area.width > 0 {
+            buf.set_string(area.x + area.width - 1, area.y, top_right, self.border_style);
+        }
+        if self.borders.contains(Borders::BOTTOM | Borders::LEFT) && area.height > 0 {
+            buf.set_string(area.x, area.y + area.height - 1, bottom_left, self.border_style);
+        }
+        if self.borders.contains(Borders::BOTTOM | Borders::RIGHT) && area.width > 0 && area.height > 0 {
+            buf.set_string(
+                area.x + area.width - 1,
+                area.y + area.height - 1,
+                bottom_right,
+                self.border_style,
+            );
+        }
+
+        // Draw horizontal borders
+        if self.borders.contains(Borders::TOP) {
+            for x in (area.x + 1)..(area.x + area.width - 1) {
+                buf.set_string(x, area.y, horizontal, self.border_style);
+            }
+        }
+        if self.borders.contains(Borders::BOTTOM) && area.height > 0 {
+            for x in (area.x + 1)..(area.x + area.width - 1) {
+                buf.set_string(x, area.y + area.height - 1, horizontal, self.border_style);
+            }
+        }
+
+        // Draw vertical borders
+        if self.borders.contains(Borders::LEFT) {
+            for y in (area.y + 1)..(area.y + area.height - 1) {
+                buf.set_string(area.x, y, vertical, self.border_style);
+            }
+        }
+        if self.borders.contains(Borders::RIGHT) && area.width > 0 {
+            for y in (area.y + 1)..(area.y + area.height - 1) {
+                buf.set_string(area.x + area.width - 1, y, vertical, self.border_style);
+            }
+        }
+    }
+
+    /// Renders the title if present.
+    fn render_title(&self, area: Rect, buf: &mut Buffer) {
+        if let Some(ref title) = self.title {
+            let y = match title.position {
+                TitlePosition::Top => area.y,
+                TitlePosition::Bottom => area.y + area.height.saturating_sub(1),
+            };
+
+            // Calculate available width for title
+            let available_width = area.width.saturating_sub(2); // Account for border corners
+            if available_width == 0 {
+                return;
+            }
+
+            let title_text = &title.content;
+            let title_width = title_text.len().min(available_width as usize) as u16;
+
+            let x = match title.alignment {
+                TitleAlignment::Left => area.x + 1,
+                TitleAlignment::Center => {
+                    area.x + 1 + (available_width.saturating_sub(title_width)) / 2
+                }
+                TitleAlignment::Right => {
+                    area.x + 1 + available_width.saturating_sub(title_width)
+                }
+            };
+
+            // Render the title with padding spaces
+            let displayed_title = if title_text.len() > available_width as usize {
+                &title_text[..available_width as usize]
+            } else {
+                title_text
+            };
+
+            buf.set_string(x, y, displayed_title, title.style);
+        }
+    }
+}
+
+impl Widget for Block {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.width < 2 || area.height < 2 {
+            return;
+        }
+
+        // Fill the interior with the block's style
+        buf.set_style(area, self.style);
+
+        // Draw borders
+        if !self.borders.is_empty() {
+            self.render_border(area, buf);
+        }
+
+        // Draw title
+        self.render_title(area, buf);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_padding_uniform() {
+        let padding = Padding::uniform(2);
+        assert_eq!(padding.left, 2);
+        assert_eq!(padding.right, 2);
+        assert_eq!(padding.top, 2);
+        assert_eq!(padding.bottom, 2);
+    }
+
+    #[test]
+    fn test_padding_horizontal() {
+        let padding = Padding::horizontal(3);
+        assert_eq!(padding.left, 3);
+        assert_eq!(padding.right, 3);
+        assert_eq!(padding.top, 0);
+        assert_eq!(padding.bottom, 0);
+    }
+
+    #[test]
+    fn test_padding_vertical() {
+        let padding = Padding::vertical(1);
+        assert_eq!(padding.left, 0);
+        assert_eq!(padding.right, 0);
+        assert_eq!(padding.top, 1);
+        assert_eq!(padding.bottom, 1);
+    }
+
+    #[test]
+    fn test_title_creation() {
+        let title = Title::new("Test");
+        assert_eq!(title.content, "Test");
+        assert_eq!(title.position, TitlePosition::Top);
+        assert_eq!(title.alignment, TitleAlignment::Left);
+    }
+
+    #[test]
+    fn test_title_builder() {
+        let title = Title::new("Test")
+            .position(TitlePosition::Bottom)
+            .alignment(TitleAlignment::Center)
+            .style(Style::default().fg(Color::Red));
+
+        assert_eq!(title.position, TitlePosition::Bottom);
+        assert_eq!(title.alignment, TitleAlignment::Center);
+        assert_eq!(title.style.fg, Some(Color::Red));
+    }
+
+    #[test]
+    fn test_block_default() {
+        let block = Block::default();
+        assert!(block.title.is_none());
+        assert_eq!(block.borders, Borders::NONE);
+        assert_eq!(block.border_type, BorderType::Plain);
+    }
+
+    #[test]
+    fn test_block_builder() {
+        let block = Block::default()
+            .title("Test")
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded)
+            .border_style(Style::default().fg(Color::Cyan))
+            .padding(Padding::uniform(1));
+
+        assert!(block.title.is_some());
+        assert_eq!(block.borders, Borders::ALL);
+        assert_eq!(block.border_type, BorderType::Rounded);
+        assert_eq!(block.border_style.fg, Some(Color::Cyan));
+        assert_eq!(block.padding, Padding::uniform(1));
+    }
+
+    #[test]
+    fn test_block_inner_no_borders() {
+        let block = Block::default();
+        let area = Rect::new(0, 0, 10, 10);
+        let inner = block.inner(area);
+        assert_eq!(inner, area);
+    }
+
+    #[test]
+    fn test_block_inner_all_borders() {
+        let block = Block::default().borders(Borders::ALL);
+        let area = Rect::new(0, 0, 10, 10);
+        let inner = block.inner(area);
+        assert_eq!(inner, Rect::new(1, 1, 8, 8));
+    }
+
+    #[test]
+    fn test_block_inner_with_padding() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .padding(Padding::uniform(1));
+        let area = Rect::new(0, 0, 10, 10);
+        let inner = block.inner(area);
+        // 1 for border + 1 for padding on each side
+        assert_eq!(inner, Rect::new(2, 2, 6, 6));
+    }
+
+    #[test]
+    fn test_block_inner_top_bottom_only() {
+        let block = Block::default().borders(Borders::TOP | Borders::BOTTOM);
+        let area = Rect::new(0, 0, 10, 10);
+        let inner = block.inner(area);
+        assert_eq!(inner, Rect::new(0, 1, 10, 8));
+    }
+
+    #[test]
+    fn test_block_inner_left_right_only() {
+        let block = Block::default().borders(Borders::LEFT | Borders::RIGHT);
+        let area = Rect::new(0, 0, 10, 10);
+        let inner = block.inner(area);
+        assert_eq!(inner, Rect::new(1, 0, 8, 10));
+    }
+
+    #[test]
+    fn test_block_render_no_borders() {
+        let block = Block::default();
+        let area = Rect::new(0, 0, 5, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // All cells should be default
+        for y in 0..5 {
+            for x in 0..5 {
+                let cell = buffer.get(x, y).unwrap();
+                assert_eq!(cell.symbol, " ");
+            }
+        }
+    }
+
+    #[test]
+    fn test_block_render_all_borders() {
+        let block = Block::default().borders(Borders::ALL);
+        let area = Rect::new(0, 0, 5, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // Check corners
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "┌");
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "┐");
+        assert_eq!(buffer.get(0, 4).unwrap().symbol, "└");
+        assert_eq!(buffer.get(4, 4).unwrap().symbol, "┘");
+
+        // Check horizontal borders
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, "─");
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, "─");
+        assert_eq!(buffer.get(1, 4).unwrap().symbol, "─");
+
+        // Check vertical borders
+        assert_eq!(buffer.get(0, 1).unwrap().symbol, "│");
+        assert_eq!(buffer.get(0, 2).unwrap().symbol, "│");
+        assert_eq!(buffer.get(4, 1).unwrap().symbol, "│");
+    }
+
+    #[test]
+    fn test_block_render_with_title() {
+        let block = Block::default()
+            .title("Test")
+            .borders(Borders::ALL);
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // Check title characters
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, "T");
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, "e");
+        assert_eq!(buffer.get(3, 0).unwrap().symbol, "s");
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "t");
+    }
+
+    #[test]
+    fn test_block_render_rounded_borders() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_type(BorderType::Rounded);
+        let area = Rect::new(0, 0, 5, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // Check rounded corners
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "╭");
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "╮");
+        assert_eq!(buffer.get(0, 4).unwrap().symbol, "╰");
+        assert_eq!(buffer.get(4, 4).unwrap().symbol, "╯");
+    }
+
+    #[test]
+    fn test_block_title_alignment_center() {
+        let block = Block::default()
+            .title("Hi")
+            .borders(Borders::ALL)
+            .title_alignment(TitleAlignment::Center);
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // Title "Hi" should be centered in width 10 (minus 2 for borders = 8)
+        // Position should be around x=4
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "H");
+        assert_eq!(buffer.get(5, 0).unwrap().symbol, "i");
+    }
+
+    #[test]
+    fn test_block_title_position_bottom() {
+        let block = Block::default()
+            .title(Title::new("Bot").position(TitlePosition::Bottom))
+            .borders(Borders::ALL);
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // Title should be at the bottom (y=4)
+        assert_eq!(buffer.get(1, 4).unwrap().symbol, "B");
+        assert_eq!(buffer.get(2, 4).unwrap().symbol, "o");
+        assert_eq!(buffer.get(3, 4).unwrap().symbol, "t");
+    }
+
+    #[test]
+    fn test_block_border_style() {
+        let block = Block::default()
+            .borders(Borders::ALL)
+            .border_style(Style::default().fg(Color::Red));
+        let area = Rect::new(0, 0, 5, 5);
+        let mut buffer = Buffer::new(area);
+
+        block.render(area, &mut buffer);
+
+        // Check that border has the correct color
+        assert_eq!(buffer.get(0, 0).unwrap().fg, Color::Red);
+        assert_eq!(buffer.get(1, 0).unwrap().fg, Color::Red);
+        assert_eq!(buffer.get(0, 1).unwrap().fg, Color::Red);
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/borders.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/borders.rs
@@ -1,0 +1,197 @@
+//! Border types and border flags for widgets.
+
+use bitflags::bitflags;
+
+bitflags! {
+    /// Bitflags for specifying which borders to draw.
+    ///
+    /// Can be combined using bitwise operations to draw multiple borders.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use fusabi_tui_widgets::borders::Borders;
+    ///
+    /// // Draw all borders
+    /// let borders = Borders::ALL;
+    ///
+    /// // Draw only top and bottom
+    /// let borders = Borders::TOP | Borders::BOTTOM;
+    ///
+    /// // Draw left, right, and bottom
+    /// let borders = Borders::LEFT | Borders::RIGHT | Borders::BOTTOM;
+    /// ```
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct Borders: u8 {
+        /// No borders
+        const NONE = 0b0000;
+        /// Top border
+        const TOP = 0b0001;
+        /// Right border
+        const RIGHT = 0b0010;
+        /// Bottom border
+        const BOTTOM = 0b0100;
+        /// Left border
+        const LEFT = 0b1000;
+        /// All borders (top, right, bottom, left)
+        const ALL = Self::TOP.bits() | Self::RIGHT.bits() | Self::BOTTOM.bits() | Self::LEFT.bits();
+    }
+}
+
+impl Default for Borders {
+    fn default() -> Self {
+        Self::NONE
+    }
+}
+
+/// The type of border characters to use when drawing.
+///
+/// Different border types use different Unicode characters for drawing the border lines
+/// and corners.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BorderType {
+    /// Plain borders using simple box-drawing characters (┌─┐│└─┘)
+    Plain,
+    /// Rounded borders using rounded corners (╭─╮│╰─╯)
+    Rounded,
+    /// Double-line borders using double box-drawing characters (╔═╗║╚═╝)
+    Double,
+    /// Thick borders using heavy box-drawing characters (┏━┓┃┗━┛)
+    Thick,
+}
+
+impl Default for BorderType {
+    fn default() -> Self {
+        Self::Plain
+    }
+}
+
+impl BorderType {
+    /// Returns the Unicode characters for this border type.
+    ///
+    /// Returns a tuple of (horizontal, vertical, top_left, top_right, bottom_left, bottom_right).
+    pub(crate) fn line_symbols(self) -> (&'static str, &'static str, &'static str, &'static str, &'static str, &'static str) {
+        use fusabi_tui_core::symbols::line;
+
+        match self {
+            BorderType::Plain => (
+                line::HORIZONTAL,
+                line::VERTICAL,
+                line::TOP_LEFT,
+                line::TOP_RIGHT,
+                line::BOTTOM_LEFT,
+                line::BOTTOM_RIGHT,
+            ),
+            BorderType::Rounded => (
+                line::HORIZONTAL,
+                line::VERTICAL,
+                line::ROUNDED_TOP_LEFT,
+                line::ROUNDED_TOP_RIGHT,
+                line::ROUNDED_BOTTOM_LEFT,
+                line::ROUNDED_BOTTOM_RIGHT,
+            ),
+            BorderType::Double => (
+                line::DOUBLE_HORIZONTAL,
+                line::DOUBLE_VERTICAL,
+                line::DOUBLE_TOP_LEFT,
+                line::DOUBLE_TOP_RIGHT,
+                line::DOUBLE_BOTTOM_LEFT,
+                line::DOUBLE_BOTTOM_RIGHT,
+            ),
+            BorderType::Thick => (
+                line::THICK_HORIZONTAL,
+                line::THICK_VERTICAL,
+                line::THICK_TOP_LEFT,
+                line::THICK_TOP_RIGHT,
+                line::THICK_BOTTOM_LEFT,
+                line::THICK_BOTTOM_RIGHT,
+            ),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_borders_none() {
+        let borders = Borders::NONE;
+        assert!(!borders.contains(Borders::TOP));
+        assert!(!borders.contains(Borders::RIGHT));
+        assert!(!borders.contains(Borders::BOTTOM));
+        assert!(!borders.contains(Borders::LEFT));
+    }
+
+    #[test]
+    fn test_borders_all() {
+        let borders = Borders::ALL;
+        assert!(borders.contains(Borders::TOP));
+        assert!(borders.contains(Borders::RIGHT));
+        assert!(borders.contains(Borders::BOTTOM));
+        assert!(borders.contains(Borders::LEFT));
+    }
+
+    #[test]
+    fn test_borders_combination() {
+        let borders = Borders::TOP | Borders::BOTTOM;
+        assert!(borders.contains(Borders::TOP));
+        assert!(!borders.contains(Borders::RIGHT));
+        assert!(borders.contains(Borders::BOTTOM));
+        assert!(!borders.contains(Borders::LEFT));
+    }
+
+    #[test]
+    fn test_borders_default() {
+        assert_eq!(Borders::default(), Borders::NONE);
+    }
+
+    #[test]
+    fn test_border_type_default() {
+        assert_eq!(BorderType::default(), BorderType::Plain);
+    }
+
+    #[test]
+    fn test_border_type_plain_symbols() {
+        let (h, v, tl, tr, bl, br) = BorderType::Plain.line_symbols();
+        assert_eq!(h, "─");
+        assert_eq!(v, "│");
+        assert_eq!(tl, "┌");
+        assert_eq!(tr, "┐");
+        assert_eq!(bl, "└");
+        assert_eq!(br, "┘");
+    }
+
+    #[test]
+    fn test_border_type_rounded_symbols() {
+        let (h, v, tl, tr, bl, br) = BorderType::Rounded.line_symbols();
+        assert_eq!(h, "─");
+        assert_eq!(v, "│");
+        assert_eq!(tl, "╭");
+        assert_eq!(tr, "╮");
+        assert_eq!(bl, "╰");
+        assert_eq!(br, "╯");
+    }
+
+    #[test]
+    fn test_border_type_double_symbols() {
+        let (h, v, tl, tr, bl, br) = BorderType::Double.line_symbols();
+        assert_eq!(h, "═");
+        assert_eq!(v, "║");
+        assert_eq!(tl, "╔");
+        assert_eq!(tr, "╗");
+        assert_eq!(bl, "╚");
+        assert_eq!(br, "╝");
+    }
+
+    #[test]
+    fn test_border_type_thick_symbols() {
+        let (h, v, tl, tr, bl, br) = BorderType::Thick.line_symbols();
+        assert_eq!(h, "━");
+        assert_eq!(v, "┃");
+        assert_eq!(tl, "┏");
+        assert_eq!(tr, "┓");
+        assert_eq!(bl, "┗");
+        assert_eq!(br, "┛");
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/gauge.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/gauge.rs
@@ -1,0 +1,358 @@
+//! Gauge widget for displaying progress or percentage bars.
+//!
+//! This module provides a `Gauge` widget that visualizes progress using a horizontal bar
+//! with customizable filled and unfilled styles.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    symbols::block,
+};
+use unicode_width::UnicodeWidthStr;
+
+use crate::widget::Widget;
+
+/// Set of characters used to render a gauge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GaugeCharSet {
+    /// Full block character for filled portion
+    Full,
+    /// Vertical bar characters with varying widths
+    VerticalBars,
+}
+
+impl GaugeCharSet {
+    /// Returns the character to use for the filled portion.
+    fn filled_char(self) -> &'static str {
+        match self {
+            Self::Full => block::FULL,
+            Self::VerticalBars => block::FULL,
+        }
+    }
+
+    /// Returns the character to use for the empty portion.
+    fn empty_char(self) -> &'static str {
+        " "
+    }
+}
+
+/// A gauge widget for displaying progress as a horizontal bar.
+///
+/// The gauge can display either a ratio (0.0 to 1.0) or a percentage (0 to 100),
+/// with an optional label displayed in the center.
+///
+/// # Examples
+///
+/// ```
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect, style::{Color, Style}};
+/// use fusabi_tui_widgets::{Gauge, Widget};
+///
+/// let gauge = Gauge::default()
+///     .percent(75)
+///     .label("75%")
+///     .style(Style::default().fg(Color::White))
+///     .gauge_style(Style::default().fg(Color::Green));
+///
+/// let area = Rect::new(0, 0, 40, 1);
+/// let mut buffer = Buffer::new(area);
+/// gauge.render(area, &mut buffer);
+/// ```
+#[derive(Debug, Clone, PartialEq)]
+pub struct Gauge {
+    ratio: f64,
+    label: Option<String>,
+    style: Style,
+    gauge_style: Style,
+    char_set: GaugeCharSet,
+}
+
+impl Default for Gauge {
+    fn default() -> Self {
+        Self {
+            ratio: 0.0,
+            label: None,
+            style: Style::default(),
+            gauge_style: Style::default(),
+            char_set: GaugeCharSet::Full,
+        }
+    }
+}
+
+impl Gauge {
+    /// Creates a new gauge with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the ratio of the gauge (0.0 to 1.0).
+    ///
+    /// Values outside this range will be clamped.
+    pub fn ratio(mut self, ratio: f64) -> Self {
+        self.ratio = ratio.clamp(0.0, 1.0);
+        self
+    }
+
+    /// Sets the percentage of the gauge (0 to 100).
+    ///
+    /// Values outside this range will be clamped.
+    pub fn percent(mut self, percent: u16) -> Self {
+        let percent = percent.min(100);
+        self.ratio = f64::from(percent) / 100.0;
+        self
+    }
+
+    /// Sets the label to display in the center of the gauge.
+    pub fn label<T>(mut self, label: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.label = Some(label.into());
+        self
+    }
+
+    /// Sets the default style for the gauge (unfilled portion).
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the style for the filled portion of the gauge.
+    pub fn gauge_style(mut self, style: Style) -> Self {
+        self.gauge_style = style;
+        self
+    }
+
+    /// Sets the character set to use for rendering.
+    pub fn char_set(mut self, char_set: GaugeCharSet) -> Self {
+        self.char_set = char_set;
+        self
+    }
+
+    /// Calculates the width of the filled portion.
+    fn filled_width(&self, total_width: u16) -> u16 {
+        (f64::from(total_width) * self.ratio).round() as u16
+    }
+}
+
+impl Widget for Gauge {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.area() == 0 {
+            return;
+        }
+
+        // Only use the first row
+        let gauge_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        };
+
+        // Clear the area with the base style
+        for x in gauge_area.left()..gauge_area.right() {
+            if let Some(cell) = buf.get_mut(x, gauge_area.y) {
+                cell.symbol = " ".to_string();
+                cell.set_style(self.style);
+            }
+        }
+
+        // Calculate filled width
+        let filled_width = self.filled_width(gauge_area.width);
+
+        // Render filled portion
+        let filled_char = self.char_set.filled_char();
+        for i in 0..filled_width {
+            let x = gauge_area.x.saturating_add(i);
+            if x >= gauge_area.right() {
+                break;
+            }
+            if let Some(cell) = buf.get_mut(x, gauge_area.y) {
+                cell.symbol = filled_char.to_string();
+                cell.set_style(self.gauge_style);
+            }
+        }
+
+        // Render unfilled portion
+        let empty_char = self.char_set.empty_char();
+        for i in filled_width..gauge_area.width {
+            let x = gauge_area.x.saturating_add(i);
+            if x >= gauge_area.right() {
+                break;
+            }
+            if let Some(cell) = buf.get_mut(x, gauge_area.y) {
+                cell.symbol = empty_char.to_string();
+                cell.set_style(self.style);
+            }
+        }
+
+        // Render label in the center if present
+        if let Some(ref label) = self.label {
+            let label_width = label.width();
+            if label_width <= gauge_area.width as usize {
+                let label_x = gauge_area.x.saturating_add(
+                    (gauge_area.width.saturating_sub(label_width as u16)) / 2,
+                );
+
+                for (i, ch) in label.chars().enumerate() {
+                    let x = label_x.saturating_add(i as u16);
+                    if x >= gauge_area.right() {
+                        break;
+                    }
+                    if let Some(cell) = buf.get_mut(x, gauge_area.y) {
+                        cell.symbol = ch.to_string();
+                        // Keep the background style but use label foreground
+                        // Determine if this position is in the filled or unfilled area
+                        if x < gauge_area.x.saturating_add(filled_width) {
+                            // In filled area - use gauge style background with inverted foreground
+                            let mut label_style = self.gauge_style;
+                            if let Some(fg) = self.style.fg {
+                                label_style.fg = Some(fg);
+                            }
+                            cell.set_style(label_style);
+                        } else {
+                            // In unfilled area - use normal style
+                            let mut label_style = self.style;
+                            if let Some(fg) = self.gauge_style.fg {
+                                label_style.fg = Some(fg);
+                            }
+                            cell.set_style(label_style);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_gauge_new() {
+        let gauge = Gauge::new();
+        assert_eq!(gauge.ratio, 0.0);
+        assert_eq!(gauge.label, None);
+    }
+
+    #[test]
+    fn test_gauge_ratio() {
+        let gauge = Gauge::new().ratio(0.5);
+        assert_eq!(gauge.ratio, 0.5);
+    }
+
+    #[test]
+    fn test_gauge_ratio_clamping() {
+        let gauge1 = Gauge::new().ratio(-0.1);
+        assert_eq!(gauge1.ratio, 0.0);
+
+        let gauge2 = Gauge::new().ratio(1.5);
+        assert_eq!(gauge2.ratio, 1.0);
+    }
+
+    #[test]
+    fn test_gauge_percent() {
+        let gauge = Gauge::new().percent(75);
+        assert!((gauge.ratio - 0.75).abs() < f64::EPSILON);
+    }
+
+    #[test]
+    fn test_gauge_percent_clamping() {
+        let gauge = Gauge::new().percent(150);
+        assert_eq!(gauge.ratio, 1.0);
+    }
+
+    #[test]
+    fn test_gauge_label() {
+        let gauge = Gauge::new().label("50%");
+        assert_eq!(gauge.label, Some("50%".to_string()));
+    }
+
+    #[test]
+    fn test_gauge_filled_width() {
+        let gauge = Gauge::new().ratio(0.5);
+        assert_eq!(gauge.filled_width(100), 50);
+
+        let gauge = Gauge::new().ratio(0.75);
+        assert_eq!(gauge.filled_width(100), 75);
+    }
+
+    #[test]
+    fn test_gauge_render_empty() {
+        let gauge = Gauge::new().ratio(0.0);
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        gauge.render(area, &mut buffer);
+
+        // All cells should be empty
+        for x in 0..10 {
+            let cell = buffer.get(x, 0).unwrap();
+            assert_eq!(cell.symbol, " ");
+        }
+    }
+
+    #[test]
+    fn test_gauge_render_full() {
+        let gauge = Gauge::new().ratio(1.0).gauge_style(Style::default().fg(Color::Green));
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        gauge.render(area, &mut buffer);
+
+        // All cells should be filled
+        for x in 0..10 {
+            let cell = buffer.get(x, 0).unwrap();
+            assert_eq!(cell.symbol, block::FULL);
+            assert_eq!(cell.fg, Color::Green);
+        }
+    }
+
+    #[test]
+    fn test_gauge_render_half() {
+        let gauge = Gauge::new().ratio(0.5).gauge_style(Style::default().fg(Color::Blue));
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        gauge.render(area, &mut buffer);
+
+        // First half filled, second half empty
+        for x in 0..5 {
+            let cell = buffer.get(x, 0).unwrap();
+            assert_eq!(cell.symbol, block::FULL);
+            assert_eq!(cell.fg, Color::Blue);
+        }
+        for x in 5..10 {
+            let cell = buffer.get(x, 0).unwrap();
+            assert_eq!(cell.symbol, " ");
+        }
+    }
+
+    #[test]
+    fn test_gauge_render_with_label() {
+        let gauge = Gauge::new()
+            .ratio(0.5)
+            .label("50%")
+            .style(Style::default().fg(Color::White))
+            .gauge_style(Style::default().fg(Color::Green));
+
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buffer = Buffer::new(area);
+        gauge.render(area, &mut buffer);
+
+        // Label should be centered (position 8-11 for "50%" in width 20)
+        // Characters before and after should be gauge fill
+        let label_start = (20 - 3) / 2; // 8
+        assert_eq!(buffer.get(label_start, 0).unwrap().symbol, "5");
+        assert_eq!(buffer.get(label_start + 1, 0).unwrap().symbol, "0");
+        assert_eq!(buffer.get(label_start + 2, 0).unwrap().symbol, "%");
+    }
+
+    #[test]
+    fn test_gauge_char_set() {
+        let gauge1 = Gauge::new().char_set(GaugeCharSet::Full);
+        assert_eq!(gauge1.char_set, GaugeCharSet::Full);
+
+        let gauge2 = Gauge::new().char_set(GaugeCharSet::VerticalBars);
+        assert_eq!(gauge2.char_set, GaugeCharSet::VerticalBars);
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/lib.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/lib.rs
@@ -1,0 +1,80 @@
+//! Widget framework for Fusabi TUI.
+//!
+//! This crate provides a collection of reusable widgets for building terminal user interfaces
+//! in the Fusabi ecosystem. It builds on top of `fusabi-tui-core` to provide higher-level
+//! abstractions for common UI patterns.
+//!
+//! # Overview
+//!
+//! The crate is organized around the [`Widget`] and [`StatefulWidget`] traits, which define
+//! how components can be rendered to a buffer.
+//!
+//! ## Modules
+//!
+//! - [`widget`] - Core widget trait definitions
+//! - [`borders`] - Border types and styles
+//! - [`block`] - Block widget for bordered containers
+//! - [`table`] - Table widget for tabular data display
+//! - [`gauge`] - Gauge widget for progress bars
+//! - [`sparkline`] - Sparkline widget for inline mini-charts
+//! - [`tabs`] - Tabs widget for tab navigation
+//!
+//! # Quick Start
+//!
+//! ```rust
+//! use fusabi_tui_core::{buffer::Buffer, layout::Rect, style::Style};
+//! use fusabi_tui_widgets::{
+//!     block::Block,
+//!     borders::{Borders, BorderType},
+//!     widget::Widget,
+//! };
+//!
+//! // Create a block with borders
+//! let block = Block::default()
+//!     .title("My Panel")
+//!     .borders(Borders::ALL)
+//!     .border_type(BorderType::Rounded);
+//!
+//! // Render it to a buffer
+//! let area = Rect::new(0, 0, 20, 10);
+//! let mut buffer = Buffer::new(area);
+//! block.render(area, &mut buffer);
+//! ```
+//!
+//! # Design Philosophy
+//!
+//! Widgets in this crate are designed to be:
+//!
+//! - **Composable**: Small widgets can be combined to build complex UIs
+//! - **Immutable**: Widgets use builder patterns and don't mutate state
+//! - **Efficient**: Rendering is done through zero-copy buffers
+//! - **Flexible**: Extensive styling and customization options
+
+#![deny(missing_docs)]
+#![deny(unsafe_code)]
+#![warn(clippy::all)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+pub mod borders;
+pub mod block;
+pub mod gauge;
+pub mod list;
+pub mod paragraph;
+pub mod sparkline;
+pub mod table;
+pub mod tabs;
+pub mod text;
+pub mod widget;
+
+// Re-export commonly used types at the crate root for convenience
+pub use block::{Block, Padding, Title, TitleAlignment, TitlePosition};
+pub use borders::{BorderType, Borders};
+pub use gauge::{Gauge, GaugeCharSet};
+pub use list::{List, ListItem, ListState};
+pub use paragraph::{Alignment, Paragraph, Wrap};
+pub use sparkline::{Sparkline, SparklineBarSet};
+pub use table::{Row, Table, TableCell, TableState};
+pub use tabs::Tabs;
+pub use text::{Line, Span, Text};
+pub use widget::{StatefulWidget, Widget};

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/list.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/list.rs
@@ -1,0 +1,491 @@
+//! List widget for displaying scrollable lists with selection.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+};
+
+use crate::{
+    block::Block,
+    text::Text,
+    widget::{StatefulWidget, Widget},
+};
+
+/// A single item in a list.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::style::{Color, Style};
+/// use fusabi_tui_widgets::ListItem;
+///
+/// let item = ListItem::new("Item 1")
+///     .style(Style::default().fg(Color::White));
+/// ```
+#[derive(Debug, Clone)]
+pub struct ListItem<'a> {
+    /// The content of the item
+    content: Text<'a>,
+    /// The style of the item
+    style: Style,
+}
+
+impl<'a> ListItem<'a> {
+    /// Creates a new list item with the given content.
+    pub fn new<T>(content: T) -> Self
+    where
+        T: Into<Text<'a>>,
+    {
+        Self {
+            content: content.into(),
+            style: Style::default(),
+        }
+    }
+
+    /// Sets the style of the item.
+    #[must_use]
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Returns the height of the item in lines.
+    pub fn height(&self) -> usize {
+        self.content.height()
+    }
+}
+
+impl<'a> From<&'a str> for ListItem<'a> {
+    fn from(s: &'a str) -> Self {
+        Self::new(s)
+    }
+}
+
+impl From<String> for ListItem<'static> {
+    fn from(s: String) -> Self {
+        Self::new(s)
+    }
+}
+
+impl<'a> From<Text<'a>> for ListItem<'a> {
+    fn from(text: Text<'a>) -> Self {
+        Self::new(text)
+    }
+}
+
+/// State for a stateful list widget.
+///
+/// Tracks the currently selected item and scroll offset.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_widgets::ListState;
+///
+/// let mut state = ListState::default();
+/// state.select(Some(0));
+/// ```
+#[derive(Debug, Clone, Default)]
+pub struct ListState {
+    /// The index of the selected item
+    selected: Option<usize>,
+    /// The offset for scrolling
+    offset: usize,
+}
+
+impl ListState {
+    /// Creates a new list state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the currently selected index.
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Selects an item by index.
+    pub fn select(&mut self, index: Option<usize>) {
+        self.selected = index;
+    }
+
+    /// Returns the current scroll offset.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Sets the scroll offset.
+    pub fn set_offset(&mut self, offset: usize) {
+        self.offset = offset;
+    }
+
+    /// Selects the next item in the list.
+    ///
+    /// If no item is selected, selects the first item.
+    /// If the last item is selected, wraps around to the first item.
+    pub fn select_next(&mut self, len: usize) {
+        if len == 0 {
+            self.selected = None;
+            return;
+        }
+
+        self.selected = Some(match self.selected {
+            Some(i) => (i + 1) % len,
+            None => 0,
+        });
+    }
+
+    /// Selects the previous item in the list.
+    ///
+    /// If no item is selected, selects the last item.
+    /// If the first item is selected, wraps around to the last item.
+    pub fn select_previous(&mut self, len: usize) {
+        if len == 0 {
+            self.selected = None;
+            return;
+        }
+
+        self.selected = Some(match self.selected {
+            Some(0) => len - 1,
+            Some(i) => i - 1,
+            None => len - 1,
+        });
+    }
+
+    /// Selects the first item in the list.
+    pub fn select_first(&mut self) {
+        self.selected = Some(0);
+        self.offset = 0;
+    }
+
+    /// Selects the last item in the list.
+    pub fn select_last(&mut self, len: usize) {
+        if len > 0 {
+            self.selected = Some(len - 1);
+        }
+    }
+}
+
+/// A scrollable list widget with selection support.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect, style::{Color, Style}};
+/// use fusabi_tui_widgets::{List, ListItem, ListState, StatefulWidget};
+///
+/// let items = vec![
+///     ListItem::new("Item 1"),
+///     ListItem::new("Item 2"),
+///     ListItem::new("Item 3"),
+/// ];
+///
+/// let list = List::new(items)
+///     .highlight_style(Style::default().fg(Color::Yellow))
+///     .highlight_symbol("> ");
+///
+/// let mut state = ListState::default();
+/// state.select(Some(0));
+///
+/// let area = Rect::new(0, 0, 20, 5);
+/// let mut buffer = Buffer::new(area);
+/// list.render(area, &mut buffer, &mut state);
+/// ```
+#[derive(Debug, Clone)]
+pub struct List<'a> {
+    /// The items in the list
+    items: Vec<ListItem<'a>>,
+    /// Optional block to wrap the list
+    block: Option<Block>,
+    /// Style for the list
+    style: Style,
+    /// Style for the highlighted item
+    highlight_style: Style,
+    /// Symbol to show before the highlighted item
+    highlight_symbol: Option<&'a str>,
+}
+
+impl<'a> List<'a> {
+    /// Creates a new list with the given items.
+    pub fn new<T>(items: T) -> Self
+    where
+        T: Into<Vec<ListItem<'a>>>,
+    {
+        Self {
+            items: items.into(),
+            block: None,
+            style: Style::default(),
+            highlight_style: Style::default(),
+            highlight_symbol: None,
+        }
+    }
+
+    /// Wraps the list in a block.
+    #[must_use]
+    pub fn block(mut self, block: Block) -> Self {
+        self.block = Some(block);
+        self
+    }
+
+    /// Sets the style for the list.
+    #[must_use]
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the style for the highlighted item.
+    #[must_use]
+    pub fn highlight_style(mut self, style: Style) -> Self {
+        self.highlight_style = style;
+        self
+    }
+
+    /// Sets the symbol to show before the highlighted item.
+    #[must_use]
+    pub fn highlight_symbol(mut self, symbol: &'a str) -> Self {
+        self.highlight_symbol = Some(symbol);
+        self
+    }
+
+    /// Returns the number of items in the list.
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Returns whether the list is empty.
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+}
+
+impl StatefulWidget for List<'_> {
+    type State = ListState;
+
+    fn render(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        // Render block and get inner area
+        let list_area = if let Some(ref block) = self.block {
+            block.render(area, buf);
+            block.inner(area)
+        } else {
+            buf.set_style(area, self.style);
+            area
+        };
+
+        if list_area.width == 0 || list_area.height == 0 || self.items.is_empty() {
+            return;
+        }
+
+        // Calculate visible range
+        let list_height = list_area.height as usize;
+        let selected = state.selected();
+        
+        // Auto-scroll to keep selected item visible
+        if let Some(selected_idx) = selected {
+            if selected_idx < state.offset {
+                state.offset = selected_idx;
+            } else if selected_idx >= state.offset + list_height {
+                state.offset = selected_idx.saturating_sub(list_height - 1);
+            }
+        }
+
+        let start_idx = state.offset;
+        let end_idx = (start_idx + list_height).min(self.items.len());
+
+        // Render visible items
+        let mut current_y = list_area.y;
+        let highlight_symbol_width = self.highlight_symbol
+            .map(|s| s.len())
+            .unwrap_or(0) as u16;
+
+        for (idx, item) in self.items[start_idx..end_idx].iter().enumerate() {
+            let item_idx = start_idx + idx;
+            let is_selected = Some(item_idx) == selected;
+
+            // Determine item style
+            let item_style = if is_selected {
+                self.highlight_style
+            } else {
+                item.style
+            };
+
+            // Render highlight symbol
+            let mut x = list_area.x;
+            if let Some(symbol) = self.highlight_symbol {
+                if is_selected {
+                    buf.set_string(x, current_y, symbol, self.highlight_style);
+                }
+                x += highlight_symbol_width;
+            }
+
+            // Render item content
+            let content_width = list_area.width.saturating_sub(highlight_symbol_width);
+            
+            for (line_idx, line) in item.content.lines.iter().enumerate() {
+                if current_y >= list_area.y + list_area.height {
+                    break;
+                }
+
+                let mut line_x = x;
+                for span in &line.spans {
+                    let span_style = if is_selected {
+                        // Apply highlight style to the entire line
+                        self.highlight_style
+                    } else {
+                        span.style
+                    };
+
+                    // Render span content
+                    for ch in span.content.chars() {
+                        if line_x >= x + content_width {
+                            break;
+                        }
+                        buf.set_string(line_x, current_y, &ch.to_string(), span_style);
+                        line_x += unicode_width::UnicodeWidthStr::width(ch.to_string().as_str()) as u16;
+                    }
+                }
+
+                // Fill remaining space with highlight style if selected
+                if is_selected {
+                    while line_x < list_area.x + list_area.width {
+                        buf.set_string(line_x, current_y, " ", self.highlight_style);
+                        line_x += 1;
+                    }
+                }
+
+                current_y += 1;
+                
+                // Don't render more lines if this is a multi-line item
+                if line_idx == 0 {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_list_item_creation() {
+        let item = ListItem::new("test");
+        assert_eq!(item.content.lines.len(), 1);
+    }
+
+    #[test]
+    fn test_list_item_from_str() {
+        let item: ListItem = "test".into();
+        assert_eq!(item.content.lines.len(), 1);
+    }
+
+    #[test]
+    fn test_list_state_select() {
+        let mut state = ListState::default();
+        assert_eq!(state.selected(), None);
+
+        state.select(Some(2));
+        assert_eq!(state.selected(), Some(2));
+    }
+
+    #[test]
+    fn test_list_state_select_next() {
+        let mut state = ListState::default();
+        
+        state.select_next(3);
+        assert_eq!(state.selected(), Some(0));
+
+        state.select_next(3);
+        assert_eq!(state.selected(), Some(1));
+
+        state.select_next(3);
+        assert_eq!(state.selected(), Some(2));
+
+        state.select_next(3);
+        assert_eq!(state.selected(), Some(0)); // Wraps around
+    }
+
+    #[test]
+    fn test_list_state_select_previous() {
+        let mut state = ListState::default();
+        
+        state.select_previous(3);
+        assert_eq!(state.selected(), Some(2)); // Starts at last
+
+        state.select_previous(3);
+        assert_eq!(state.selected(), Some(1));
+
+        state.select_previous(3);
+        assert_eq!(state.selected(), Some(0));
+
+        state.select_previous(3);
+        assert_eq!(state.selected(), Some(2)); // Wraps around
+    }
+
+    #[test]
+    fn test_list_creation() {
+        let items = vec![
+            ListItem::new("Item 1"),
+            ListItem::new("Item 2"),
+        ];
+        let list = List::new(items);
+        assert_eq!(list.len(), 2);
+    }
+
+    #[test]
+    fn test_list_with_highlight() {
+        let items = vec![ListItem::new("Item 1")];
+        let list = List::new(items)
+            .highlight_symbol("> ")
+            .highlight_style(Style::default().fg(Color::Yellow));
+
+        let mut state = ListState::default();
+        state.select(Some(0));
+
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buffer = Buffer::new(area);
+        list.render(area, &mut buffer, &mut state);
+
+        // Check highlight symbol is rendered
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, ">");
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, " ");
+    }
+
+    #[test]
+    fn test_list_auto_scroll() {
+        let items: Vec<ListItem> = (0..10)
+            .map(|i| ListItem::new(format!("Item {}", i)))
+            .collect();
+
+        let list = List::new(items);
+        let mut state = ListState::default();
+
+        // Select an item beyond visible area
+        state.select(Some(8));
+
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buffer = Buffer::new(area);
+        list.render(area, &mut buffer, &mut state);
+
+        // Offset should be adjusted to keep selected item visible
+        assert!(state.offset() > 0);
+    }
+
+    #[test]
+    fn test_list_state_first_last() {
+        let mut state = ListState::default();
+
+        state.select_first();
+        assert_eq!(state.selected(), Some(0));
+
+        state.select_last(5);
+        assert_eq!(state.selected(), Some(4));
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/paragraph.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/paragraph.rs
@@ -1,0 +1,438 @@
+//! Paragraph widget for displaying multi-line text with wrapping and alignment.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+};
+use unicode_width::UnicodeWidthStr;
+
+use crate::{
+    block::Block,
+    text::{Line, Span, Text},
+    widget::Widget,
+};
+
+/// Text alignment options.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Alignment {
+    /// Align text to the left
+    Left,
+    /// Center text horizontally
+    Center,
+    /// Align text to the right
+    Right,
+}
+
+impl Default for Alignment {
+    fn default() -> Self {
+        Self::Left
+    }
+}
+
+/// Text wrapping modes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Wrap {
+    /// Don't wrap text, truncate if necessary
+    NoWrap,
+    /// Wrap at any character
+    Wrap,
+    /// Wrap at word boundaries
+    WordWrap,
+}
+
+impl Default for Wrap {
+    fn default() -> Self {
+        Self::NoWrap
+    }
+}
+
+/// A paragraph widget for displaying multi-line text.
+///
+/// Supports text wrapping, alignment, scrolling, and can be wrapped in a [`Block`].
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect, style::{Color, Style}};
+/// use fusabi_tui_widgets::{Paragraph, Wrap, Alignment, Widget};
+///
+/// let paragraph = Paragraph::new("Hello, World!")
+///     .style(Style::default().fg(Color::White))
+///     .alignment(Alignment::Center)
+///     .wrap(Wrap::WordWrap);
+///
+/// let area = Rect::new(0, 0, 20, 5);
+/// let mut buffer = Buffer::new(area);
+/// paragraph.render(area, &mut buffer);
+/// ```
+#[derive(Debug, Clone)]
+pub struct Paragraph<'a> {
+    /// The text content to display
+    text: Text<'a>,
+    /// Optional block to wrap the paragraph
+    block: Option<Block>,
+    /// Style for the paragraph
+    style: Style,
+    /// Text alignment
+    alignment: Alignment,
+    /// Text wrapping mode
+    wrap: Wrap,
+    /// Horizontal scroll offset
+    scroll_x: u16,
+    /// Vertical scroll offset
+    scroll_y: u16,
+}
+
+impl<'a> Paragraph<'a> {
+    /// Creates a new paragraph with the given text.
+    pub fn new<T>(text: T) -> Self
+    where
+        T: Into<Text<'a>>,
+    {
+        Self {
+            text: text.into(),
+            block: None,
+            style: Style::default(),
+            alignment: Alignment::default(),
+            wrap: Wrap::default(),
+            scroll_x: 0,
+            scroll_y: 0,
+        }
+    }
+
+    /// Wraps the paragraph in a block.
+    #[must_use]
+    pub fn block(mut self, block: Block) -> Self {
+        self.block = Some(block);
+        self
+    }
+
+    /// Sets the style for the paragraph.
+    #[must_use]
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the text alignment.
+    #[must_use]
+    pub fn alignment(mut self, alignment: Alignment) -> Self {
+        self.alignment = alignment;
+        self
+    }
+
+    /// Sets the text wrapping mode.
+    #[must_use]
+    pub fn wrap(mut self, wrap: Wrap) -> Self {
+        self.wrap = wrap;
+        self
+    }
+
+    /// Sets the scroll offset.
+    #[must_use]
+    pub fn scroll(mut self, x: u16, y: u16) -> Self {
+        self.scroll_x = x;
+        self.scroll_y = y;
+        self
+    }
+
+    /// Wraps a line of text to fit within the given width.
+    fn wrap_line(&self, line: &'a Line<'a>, width: usize) -> Vec<Line<'a>> {
+        match self.wrap {
+            Wrap::NoWrap => vec![line.clone()],
+            Wrap::Wrap => self.wrap_line_char(line, width),
+            Wrap::WordWrap => self.wrap_line_word(line, width),
+        }
+    }
+
+    /// Wraps a line at any character boundary.
+    fn wrap_line_char(&self, line: &Line<'a>, width: usize) -> Vec<Line<'a>> {
+        let mut wrapped = Vec::new();
+        let mut current_line = Vec::new();
+        let mut current_width = 0;
+
+        for span in &line.spans {
+            let content = span.content.as_ref();
+            let mut chars = content.chars().peekable();
+
+            while chars.peek().is_some() {
+                let mut segment = String::new();
+                let mut segment_width = 0;
+
+                while let Some(&ch) = chars.peek() {
+                    let ch_width = ch.to_string().width();
+                    if current_width + segment_width + ch_width > width {
+                        break;
+                    }
+                    segment.push(ch);
+                    segment_width += ch_width;
+                    chars.next();
+                }
+
+                if !segment.is_empty() {
+                    current_line.push(Span::styled(segment, span.style));
+                    current_width += segment_width;
+                }
+
+                if current_width >= width || chars.peek().is_some() {
+                    if !current_line.is_empty() {
+                        wrapped.push(Line::from_spans(current_line));
+                        current_line = Vec::new();
+                        current_width = 0;
+                    }
+                }
+            }
+        }
+
+        if !current_line.is_empty() {
+            wrapped.push(Line::from_spans(current_line));
+        }
+
+        if wrapped.is_empty() {
+            wrapped.push(Line::empty());
+        }
+
+        wrapped
+    }
+
+    /// Wraps a line at word boundaries.
+    fn wrap_line_word(&self, line: &'a Line<'a>, width: usize) -> Vec<Line<'a>> {
+        let mut wrapped = Vec::new();
+        let mut current_line = Vec::new();
+        let mut current_width = 0;
+
+        for span in &line.spans {
+            let content = span.content.as_ref();
+            let words: Vec<&str> = content.split_inclusive(char::is_whitespace).collect();
+
+            for word in words {
+                let word_width = word.width();
+
+                if current_width + word_width > width && current_width > 0 {
+                    // Start a new line
+                    wrapped.push(Line::from_spans(current_line));
+                    current_line = Vec::new();
+                    current_width = 0;
+                }
+
+                if word_width > width {
+                    // Word is too long, wrap at character boundary
+                    let char_wrapped = self.wrap_line_char(
+                        &Line::from(Span::styled(word, span.style)),
+                        width,
+                    );
+                    for (i, char_line) in char_wrapped.into_iter().enumerate() {
+                        if i > 0 && !current_line.is_empty() {
+                            wrapped.push(Line::from_spans(current_line));
+                            current_line = Vec::new();
+                            current_width = 0;
+                        }
+                        current_line.extend(char_line.spans);
+                        current_width = current_line.iter().map(Span::width).sum();
+                    }
+                } else {
+                    current_line.push(Span::styled(word, span.style));
+                    current_width += word_width;
+                }
+            }
+        }
+
+        if !current_line.is_empty() {
+            wrapped.push(Line::from_spans(current_line));
+        }
+
+        if wrapped.is_empty() {
+            wrapped.push(Line::empty());
+        }
+
+        wrapped
+    }
+
+    /// Aligns a line of text within the given width.
+    fn align_line<'b>(&self, line: &'b Line<'a>, width: usize) -> (usize, &'b Line<'a>) {
+        let line_width = line.width();
+        let offset = match self.alignment {
+            Alignment::Left => 0,
+            Alignment::Center => width.saturating_sub(line_width) / 2,
+            Alignment::Right => width.saturating_sub(line_width),
+        };
+        (offset, line)
+    }
+}
+
+impl Widget for Paragraph<'_> {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.width == 0 || area.height == 0 {
+            return;
+        }
+
+        // Render block and get inner area
+        let text_area = if let Some(ref block) = self.block {
+            block.render(area, buf);
+            block.inner(area)
+        } else {
+            buf.set_style(area, self.style);
+            area
+        };
+
+        if text_area.width == 0 || text_area.height == 0 {
+            return;
+        }
+
+        // Wrap all lines
+        let mut wrapped_lines = Vec::new();
+        for line in &self.text.lines {
+            wrapped_lines.extend(self.wrap_line(line, text_area.width as usize));
+        }
+
+        // Apply vertical scroll
+        let start_line = self.scroll_y as usize;
+        let end_line = (start_line + text_area.height as usize).min(wrapped_lines.len());
+
+        // Render visible lines
+        for (y, line) in wrapped_lines[start_line..end_line].iter().enumerate() {
+            let (x_offset, line) = self.align_line(line, text_area.width as usize);
+            let mut x = text_area.x + x_offset as u16;
+            let y = text_area.y + y as u16;
+
+            // Apply horizontal scroll to spans
+            let mut skip_width = self.scroll_x as usize;
+            
+            for span in &line.spans {
+                let span_width = span.width();
+                
+                if skip_width >= span_width {
+                    skip_width -= span_width;
+                    continue;
+                }
+
+                let content = if skip_width > 0 {
+                    // Skip some characters from this span
+                    let mut skipped = 0;
+                    let mut chars_to_skip = 0;
+                    for ch in span.content.chars() {
+                        let ch_width = ch.to_string().width();
+                        if skipped + ch_width > skip_width {
+                            break;
+                        }
+                        skipped += ch_width;
+                        chars_to_skip += 1;
+                    }
+                    span.content.chars().skip(chars_to_skip).collect::<String>()
+                } else {
+                    span.content.to_string()
+                };
+
+                skip_width = 0;
+
+                // Render the span
+                for ch in content.chars() {
+                    if x >= text_area.x + text_area.width {
+                        break;
+                    }
+                    buf.set_string(x, y, &ch.to_string(), span.style);
+                    x += ch.to_string().width() as u16;
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_paragraph_creation() {
+        let p = Paragraph::new("test");
+        assert_eq!(p.text.lines.len(), 1);
+    }
+
+    #[test]
+    fn test_paragraph_with_block() {
+        use crate::{Block, Borders};
+        
+        let block = Block::default().borders(Borders::ALL);
+        let p = Paragraph::new("test").block(block);
+        assert!(p.block.is_some());
+    }
+
+    #[test]
+    fn test_paragraph_alignment() {
+        let p = Paragraph::new("test")
+            .alignment(Alignment::Center);
+        assert_eq!(p.alignment, Alignment::Center);
+    }
+
+    #[test]
+    fn test_paragraph_wrap() {
+        let p = Paragraph::new("test")
+            .wrap(Wrap::WordWrap);
+        assert_eq!(p.wrap, Wrap::WordWrap);
+    }
+
+    #[test]
+    fn test_paragraph_render() {
+        let p = Paragraph::new("Hello\nWorld")
+            .style(Style::default().fg(Color::Green));
+
+        let area = Rect::new(0, 0, 10, 5);
+        let mut buffer = Buffer::new(area);
+        p.render(area, &mut buffer);
+
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "H");
+        assert_eq!(buffer.get(0, 1).unwrap().symbol, "W");
+    }
+
+    #[test]
+    fn test_wrap_line_char() {
+        let p = Paragraph::new("").wrap(Wrap::Wrap);
+        let line = Line::from("Hello World");
+        let wrapped = p.wrap_line(&line, 5);
+        
+        assert!(wrapped.len() >= 2);
+    }
+
+    #[test]
+    fn test_wrap_line_word() {
+        let p = Paragraph::new("").wrap(Wrap::WordWrap);
+        let line = Line::from("Hello World");
+        let wrapped = p.wrap_line(&line, 7);
+        
+        assert!(wrapped.len() >= 2);
+    }
+
+    #[test]
+    fn test_align_line_center() {
+        let p = Paragraph::new("").alignment(Alignment::Center);
+        let line = Line::from("Hi");
+        let (offset, _) = p.align_line(&line, 10);
+        
+        assert_eq!(offset, 4); // (10 - 2) / 2 = 4
+    }
+
+    #[test]
+    fn test_align_line_right() {
+        let p = Paragraph::new("").alignment(Alignment::Right);
+        let line = Line::from("Hi");
+        let (offset, _) = p.align_line(&line, 10);
+        
+        assert_eq!(offset, 8); // 10 - 2 = 8
+    }
+
+    #[test]
+    fn test_paragraph_scroll() {
+        let p = Paragraph::new("Line1\nLine2\nLine3\nLine4")
+            .scroll(0, 1);
+
+        let area = Rect::new(0, 0, 10, 2);
+        let mut buffer = Buffer::new(area);
+        p.render(area, &mut buffer);
+
+        // Should render Line2 and Line3 (skipping Line1 due to scroll)
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "L");
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "2");
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/sparkline.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/sparkline.rs
@@ -1,0 +1,353 @@
+//! Sparkline widget for inline mini-charts.
+//!
+//! This module provides a `Sparkline` widget that displays a small inline chart
+//! using vertical bar characters to visualize data trends.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+    symbols::bar,
+};
+
+use crate::widget::Widget;
+
+/// Set of bar characters to use for rendering sparklines.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SparklineBarSet {
+    /// Unicode vertical bars (default): ▁▂▃▄▅▆▇█
+    Unicode,
+    /// ASCII characters: _.,:|
+    Ascii,
+}
+
+impl SparklineBarSet {
+    /// Returns the bar character for a given value (0-8).
+    fn get_bar(&self, value: usize) -> &'static str {
+        match self {
+            Self::Unicode => {
+                let index = value.min(8);
+                bar::VERTICAL_BARS[index]
+            }
+            Self::Ascii => match value {
+                0 => " ",
+                1..=2 => "_",
+                3..=4 => ".",
+                5..=6 => ":",
+                7 => "|",
+                _ => "|",
+            },
+        }
+    }
+}
+
+/// A sparkline widget for displaying inline mini-charts.
+///
+/// Sparklines are small, word-sized graphics that can be embedded in text to
+/// show trends and variations in data.
+///
+/// # Examples
+///
+/// ```
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect, style::{Color, Style}};
+/// use fusabi_tui_widgets::{Sparkline, Widget};
+///
+/// let data = vec![1, 5, 3, 8, 2, 4, 7, 6];
+/// let sparkline = Sparkline::default()
+///     .data(&data)
+///     .style(Style::default().fg(Color::Cyan))
+///     .max(10);
+///
+/// let area = Rect::new(0, 0, 20, 1);
+/// let mut buffer = Buffer::new(area);
+/// sparkline.render(area, &mut buffer);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Sparkline {
+    data: Vec<u64>,
+    max: Option<u64>,
+    style: Style,
+    bar_set: SparklineBarSet,
+}
+
+impl Default for Sparkline {
+    fn default() -> Self {
+        Self {
+            data: Vec::new(),
+            max: None,
+            style: Style::default(),
+            bar_set: SparklineBarSet::Unicode,
+        }
+    }
+}
+
+impl Sparkline {
+    /// Creates a new sparkline with default values.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Sets the data points for the sparkline.
+    pub fn data(mut self, data: &[u64]) -> Self {
+        self.data = data.to_vec();
+        self
+    }
+
+    /// Sets the maximum value for scaling.
+    ///
+    /// If not set, the maximum value in the data will be used.
+    pub fn max(mut self, max: u64) -> Self {
+        self.max = Some(max);
+        self
+    }
+
+    /// Sets the style for the sparkline bars.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the bar character set to use.
+    pub fn bar_set(mut self, bar_set: SparklineBarSet) -> Self {
+        self.bar_set = bar_set;
+        self
+    }
+
+    /// Calculates the maximum value for scaling.
+    fn calculate_max(&self) -> u64 {
+        if let Some(max) = self.max {
+            max
+        } else {
+            self.data.iter().copied().max().unwrap_or(1)
+        }
+    }
+
+    /// Scales a data value to a bar index (0-8).
+    fn scale_value(&self, value: u64, max: u64) -> usize {
+        if max == 0 {
+            return 0;
+        }
+        let ratio = value as f64 / max as f64;
+        (ratio * 8.0).round() as usize
+    }
+}
+
+impl Widget for Sparkline {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.area() == 0 || self.data.is_empty() {
+            return;
+        }
+
+        // Only use the first row
+        let sparkline_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        };
+
+        let max_value = self.calculate_max();
+        let mut x = sparkline_area.x;
+
+        // Render each data point
+        for &value in &self.data {
+            if x >= sparkline_area.right() {
+                break;
+            }
+
+            let bar_index = self.scale_value(value, max_value);
+            let bar_char = self.bar_set.get_bar(bar_index);
+
+            if let Some(cell) = buf.get_mut(x, sparkline_area.y) {
+                cell.symbol = bar_char.to_string();
+                cell.set_style(self.style);
+            }
+
+            x = x.saturating_add(1);
+        }
+
+        // Fill remaining space with empty bars
+        while x < sparkline_area.right() {
+            if let Some(cell) = buf.get_mut(x, sparkline_area.y) {
+                cell.symbol = self.bar_set.get_bar(0).to_string();
+                cell.set_style(self.style);
+            }
+            x = x.saturating_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_sparkline_new() {
+        let sparkline = Sparkline::new();
+        assert!(sparkline.data.is_empty());
+        assert_eq!(sparkline.max, None);
+        assert_eq!(sparkline.bar_set, SparklineBarSet::Unicode);
+    }
+
+    #[test]
+    fn test_sparkline_data() {
+        let data = vec![1, 2, 3, 4, 5];
+        let sparkline = Sparkline::new().data(&data);
+        assert_eq!(sparkline.data, data);
+    }
+
+    #[test]
+    fn test_sparkline_max() {
+        let sparkline = Sparkline::new().max(100);
+        assert_eq!(sparkline.max, Some(100));
+    }
+
+    #[test]
+    fn test_sparkline_calculate_max_from_data() {
+        let sparkline = Sparkline::new().data(&[1, 5, 3, 8, 2]);
+        assert_eq!(sparkline.calculate_max(), 8);
+    }
+
+    #[test]
+    fn test_sparkline_calculate_max_explicit() {
+        let sparkline = Sparkline::new().data(&[1, 5, 3, 8, 2]).max(10);
+        assert_eq!(sparkline.calculate_max(), 10);
+    }
+
+    #[test]
+    fn test_sparkline_calculate_max_empty() {
+        let sparkline = Sparkline::new();
+        assert_eq!(sparkline.calculate_max(), 1);
+    }
+
+    #[test]
+    fn test_sparkline_scale_value() {
+        let sparkline = Sparkline::new();
+        assert_eq!(sparkline.scale_value(0, 10), 0);
+        assert_eq!(sparkline.scale_value(5, 10), 4);
+        assert_eq!(sparkline.scale_value(10, 10), 8);
+    }
+
+    #[test]
+    fn test_sparkline_scale_value_zero_max() {
+        let sparkline = Sparkline::new();
+        assert_eq!(sparkline.scale_value(5, 0), 0);
+    }
+
+    #[test]
+    fn test_sparkline_bar_set_unicode() {
+        let bar_set = SparklineBarSet::Unicode;
+        assert_eq!(bar_set.get_bar(0), bar::EMPTY);
+        assert_eq!(bar_set.get_bar(4), bar::HALF);
+        assert_eq!(bar_set.get_bar(8), bar::FULL);
+    }
+
+    #[test]
+    fn test_sparkline_bar_set_ascii() {
+        let bar_set = SparklineBarSet::Ascii;
+        assert_eq!(bar_set.get_bar(0), " ");
+        assert_eq!(bar_set.get_bar(1), "_");
+        assert_eq!(bar_set.get_bar(3), ".");
+        assert_eq!(bar_set.get_bar(5), ":");
+        assert_eq!(bar_set.get_bar(7), "|");
+        assert_eq!(bar_set.get_bar(8), "|");
+    }
+
+    #[test]
+    fn test_sparkline_render_empty() {
+        let sparkline = Sparkline::new();
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        sparkline.render(area, &mut buffer);
+
+        // All cells should be empty bars
+        for x in 0..10 {
+            let cell = buffer.get(x, 0).unwrap();
+            assert_eq!(cell.symbol, bar::EMPTY);
+        }
+    }
+
+    #[test]
+    fn test_sparkline_render_with_data() {
+        let data = vec![0, 4, 8];
+        let sparkline = Sparkline::new()
+            .data(&data)
+            .max(8)
+            .style(Style::default().fg(Color::Green));
+
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        sparkline.render(area, &mut buffer);
+
+        // Check first three bars
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, bar::EMPTY);
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, bar::HALF);
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, bar::FULL);
+
+        // Check style
+        assert_eq!(buffer.get(0, 0).unwrap().fg, Color::Green);
+        assert_eq!(buffer.get(1, 0).unwrap().fg, Color::Green);
+        assert_eq!(buffer.get(2, 0).unwrap().fg, Color::Green);
+
+        // Remaining should be empty
+        for x in 3..10 {
+            assert_eq!(buffer.get(x, 0).unwrap().symbol, bar::EMPTY);
+        }
+    }
+
+    #[test]
+    fn test_sparkline_render_ascii() {
+        let data = vec![0, 2, 5, 8];
+        let sparkline = Sparkline::new()
+            .data(&data)
+            .max(8)
+            .bar_set(SparklineBarSet::Ascii);
+
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        sparkline.render(area, &mut buffer);
+
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, " ");
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, "_");
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, ":");
+        assert_eq!(buffer.get(3, 0).unwrap().symbol, "|");
+    }
+
+    #[test]
+    fn test_sparkline_render_truncated() {
+        let data = vec![1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+        let sparkline = Sparkline::new().data(&data);
+
+        let area = Rect::new(0, 0, 5, 1); // Only 5 cells wide
+        let mut buffer = Buffer::new(area);
+        sparkline.render(area, &mut buffer);
+
+        // Should only render first 5 values
+        for x in 0..5 {
+            let cell = buffer.get(x, 0).unwrap();
+            // All should have some bar (not error)
+            assert!(!cell.symbol.is_empty());
+        }
+    }
+
+    #[test]
+    fn test_sparkline_auto_scale() {
+        let data = vec![10, 20, 30];
+        let sparkline = Sparkline::new().data(&data);
+
+        // Should auto-scale to max value of 30
+        assert_eq!(sparkline.calculate_max(), 30);
+
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        sparkline.render(area, &mut buffer);
+
+        // Values should be scaled relative to 30
+        // 10/30 ≈ 0.33 -> bar index ~3
+        // 20/30 ≈ 0.67 -> bar index ~5
+        // 30/30 = 1.0 -> bar index 8 (full)
+        let cell2 = buffer.get(2, 0).unwrap();
+        assert_eq!(cell2.symbol, bar::FULL);
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/table.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/table.rs
@@ -1,0 +1,584 @@
+//! Table widget for displaying tabular data.
+//!
+//! This module provides a `Table` widget that can display data in rows and columns
+//! with support for headers, column width constraints, and row selection.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::{Constraint, Rect},
+    style::Style,
+};
+use unicode_width::UnicodeWidthStr;
+
+use crate::widget::{StatefulWidget, Widget};
+
+/// A cell within a table row.
+///
+/// Contains the content to display and optional styling.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TableCell {
+    content: String,
+    style: Style,
+}
+
+impl TableCell {
+    /// Creates a new table cell with the given content.
+    pub fn new(content: impl Into<String>) -> Self {
+        Self {
+            content: content.into(),
+            style: Style::default(),
+        }
+    }
+
+    /// Sets the style for this cell.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Returns the content of this cell.
+    pub fn content(&self) -> &str {
+        &self.content
+    }
+
+    /// Returns the width of the cell content in columns.
+    pub fn width(&self) -> usize {
+        self.content.width()
+    }
+}
+
+impl<T> From<T> for TableCell
+where
+    T: Into<String>,
+{
+    fn from(content: T) -> Self {
+        Self::new(content)
+    }
+}
+
+/// A row in a table.
+///
+/// Contains a sequence of cells with optional height and style.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Row {
+    cells: Vec<TableCell>,
+    height: u16,
+    style: Style,
+    bottom_margin: u16,
+}
+
+impl Row {
+    /// Creates a new row with the given cells.
+    pub fn new<T>(cells: Vec<T>) -> Self
+    where
+        T: Into<TableCell>,
+    {
+        Self {
+            cells: cells.into_iter().map(Into::into).collect(),
+            height: 1,
+            style: Style::default(),
+            bottom_margin: 0,
+        }
+    }
+
+    /// Sets the height of this row.
+    pub fn height(mut self, height: u16) -> Self {
+        self.height = height;
+        self
+    }
+
+    /// Sets the style for this row.
+    ///
+    /// This style will be applied to all cells that don't have their own style.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the bottom margin for this row.
+    pub fn bottom_margin(mut self, margin: u16) -> Self {
+        self.bottom_margin = margin;
+        self
+    }
+
+    /// Returns the cells in this row.
+    pub fn cells(&self) -> &[TableCell] {
+        &self.cells
+    }
+
+    /// Returns the total height including margins.
+    pub fn total_height(&self) -> u16 {
+        self.height.saturating_add(self.bottom_margin)
+    }
+}
+
+/// State for a stateful table widget.
+///
+/// Tracks the selected row and scroll offset.
+#[derive(Debug, Clone, Default)]
+pub struct TableState {
+    selected: Option<usize>,
+    offset: usize,
+}
+
+impl TableState {
+    /// Creates a new table state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the index of the selected row.
+    pub fn selected(&self) -> Option<usize> {
+        self.selected
+    }
+
+    /// Selects a row by index.
+    pub fn select(&mut self, index: Option<usize>) {
+        self.selected = index;
+    }
+
+    /// Returns the scroll offset.
+    pub fn offset(&self) -> usize {
+        self.offset
+    }
+
+    /// Sets the scroll offset.
+    pub fn set_offset(&mut self, offset: usize) {
+        self.offset = offset;
+    }
+}
+
+/// A table widget for displaying tabular data.
+///
+/// # Examples
+///
+/// ```
+/// use fusabi_tui_core::{buffer::Buffer, layout::{Constraint, Rect}, style::{Color, Style}};
+/// use fusabi_tui_widgets::{Table, Row, StatefulWidget};
+/// use fusabi_tui_widgets::table::TableState;
+///
+/// let mut state = TableState::default();
+/// state.select(Some(0));
+///
+/// let table = Table::new(vec![
+///     Row::new(vec!["Row 1 Col 1", "Row 1 Col 2"]),
+///     Row::new(vec!["Row 2 Col 1", "Row 2 Col 2"]),
+/// ])
+/// .header(Row::new(vec!["Header 1", "Header 2"]).style(Style::default().fg(Color::Yellow)))
+/// .widths(&[Constraint::Length(15), Constraint::Length(15)])
+/// .column_spacing(1)
+/// .highlight_style(Style::default().fg(Color::Green));
+///
+/// let area = Rect::new(0, 0, 40, 10);
+/// let mut buffer = Buffer::new(area);
+/// table.render(area, &mut buffer, &mut state);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Table {
+    rows: Vec<Row>,
+    header: Option<Row>,
+    widths: Vec<Constraint>,
+    column_spacing: u16,
+    style: Style,
+    highlight_style: Style,
+}
+
+impl Table {
+    /// Creates a new table with the given rows.
+    pub fn new<T>(rows: Vec<T>) -> Self
+    where
+        T: Into<Row>,
+    {
+        Self {
+            rows: rows.into_iter().map(Into::into).collect(),
+            header: None,
+            widths: Vec::new(),
+            column_spacing: 1,
+            style: Style::default(),
+            highlight_style: Style::default(),
+        }
+    }
+
+    /// Sets the header row for the table.
+    pub fn header(mut self, header: Row) -> Self {
+        self.header = Some(header);
+        self
+    }
+
+    /// Sets the column width constraints.
+    pub fn widths(mut self, widths: &[Constraint]) -> Self {
+        self.widths = widths.to_vec();
+        self
+    }
+
+    /// Sets the spacing between columns.
+    pub fn column_spacing(mut self, spacing: u16) -> Self {
+        self.column_spacing = spacing;
+        self
+    }
+
+    /// Sets the default style for the table.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the highlight style for the selected row.
+    pub fn highlight_style(mut self, style: Style) -> Self {
+        self.highlight_style = style;
+        self
+    }
+
+    /// Calculates column widths based on constraints and available space.
+    fn calculate_widths(&self, max_width: u16) -> Vec<u16> {
+        if self.widths.is_empty() {
+            return Vec::new();
+        }
+
+        // Account for column spacing
+        let spacing_width = self.column_spacing.saturating_mul(self.widths.len().saturating_sub(1) as u16);
+        let available = max_width.saturating_sub(spacing_width);
+
+        // Calculate widths based on constraints
+        let mut widths = vec![0u16; self.widths.len()];
+        let mut remaining = available;
+        let mut fill_count = 0;
+
+        // First pass: calculate non-Fill constraints
+        for (i, constraint) in self.widths.iter().enumerate() {
+            match constraint {
+                Constraint::Fill(_) => {
+                    fill_count += 1;
+                }
+                Constraint::Percentage(_) | Constraint::Ratio(_, _) => {
+                    let width = match constraint {
+                        Constraint::Percentage(p) => {
+                            let p = (*p).min(100);
+                            (available as u32 * p as u32 / 100) as u16
+                        }
+                        Constraint::Ratio(n, d) => {
+                            if *d == 0 {
+                                0
+                            } else {
+                                (available as u32 * n / d) as u16
+                            }
+                        }
+                        _ => 0,
+                    };
+                    widths[i] = width;
+                    remaining = remaining.saturating_sub(width);
+                }
+                Constraint::Length(l) => {
+                    let width = (*l).min(remaining);
+                    widths[i] = width;
+                    remaining = remaining.saturating_sub(width);
+                }
+                Constraint::Min(m) | Constraint::Max(m) => {
+                    let width = (*m).min(remaining);
+                    widths[i] = width;
+                    remaining = remaining.saturating_sub(width);
+                }
+            }
+        }
+
+        // Second pass: distribute remaining space among Fill constraints
+        if fill_count > 0 && remaining > 0 {
+            let fill_width = remaining / fill_count as u16;
+            let remainder = remaining % fill_count as u16;
+            let mut remainder_distributed = 0;
+
+            for (i, constraint) in self.widths.iter().enumerate() {
+                if matches!(constraint, Constraint::Fill(_)) {
+                    widths[i] = fill_width;
+                    if remainder_distributed < remainder {
+                        widths[i] += 1;
+                        remainder_distributed += 1;
+                    }
+                }
+            }
+        }
+
+        widths
+    }
+
+    /// Renders a single row at the given position.
+    fn render_row(
+        &self,
+        buf: &mut Buffer,
+        area: Rect,
+        row: &Row,
+        widths: &[u16],
+        style: Style,
+    ) {
+        let mut x = area.x;
+        let y = area.y;
+
+        for (i, cell) in row.cells().iter().enumerate() {
+            if i >= widths.len() {
+                break;
+            }
+
+            let width = widths[i];
+            if x >= area.right() || width == 0 {
+                break;
+            }
+
+            // Determine cell style
+            let cell_style = if cell.style != Style::default() {
+                cell.style
+            } else if row.style != Style::default() {
+                row.style
+            } else {
+                style
+            };
+
+            // Render cell content
+            let content = cell.content();
+            let display_width = width as usize;
+
+            // Truncate content if it's too wide
+            let mut truncated = String::new();
+            let mut current_width = 0;
+            for ch in content.chars() {
+                let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                if current_width + ch_width > display_width {
+                    break;
+                }
+                truncated.push(ch);
+                current_width += ch_width;
+            }
+
+            buf.set_string(x, y, &truncated, cell_style);
+
+            x = x.saturating_add(width).saturating_add(self.column_spacing);
+        }
+    }
+}
+
+impl StatefulWidget for Table {
+    type State = TableState;
+
+    fn render(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+        if area.area() == 0 {
+            return;
+        }
+
+        // Apply default style to the entire area
+        for y in area.top()..area.bottom() {
+            for x in area.left()..area.right() {
+                if let Some(cell) = buf.get_mut(x, y) {
+                    cell.set_style(self.style);
+                }
+            }
+        }
+
+        let widths = self.calculate_widths(area.width);
+        if widths.is_empty() {
+            return;
+        }
+
+        let mut y = area.y;
+
+        // Render header if present
+        if let Some(ref header) = self.header {
+            if y < area.bottom() {
+                let header_area = Rect {
+                    x: area.x,
+                    y,
+                    width: area.width,
+                    height: header.height.min(area.bottom().saturating_sub(y)),
+                };
+                self.render_row(buf, header_area, header, &widths, self.style);
+                y = y.saturating_add(header.total_height());
+            }
+        }
+
+        // Render rows
+        let mut row_index = state.offset;
+        while row_index < self.rows.len() && y < area.bottom() {
+            let row = &self.rows[row_index];
+            let row_height = row.height.min(area.bottom().saturating_sub(y));
+
+            if row_height == 0 {
+                break;
+            }
+
+            let row_area = Rect {
+                x: area.x,
+                y,
+                width: area.width,
+                height: row_height,
+            };
+
+            // Determine row style (highlight if selected)
+            let row_style = if Some(row_index) == state.selected {
+                self.highlight_style
+            } else {
+                self.style
+            };
+
+            // Apply highlight to entire row if selected
+            if Some(row_index) == state.selected {
+                for row_y in row_area.top()..row_area.bottom() {
+                    for row_x in row_area.left()..row_area.right() {
+                        if let Some(cell) = buf.get_mut(row_x, row_y) {
+                            cell.set_style(self.highlight_style);
+                        }
+                    }
+                }
+            }
+
+            self.render_row(buf, row_area, row, &widths, row_style);
+            y = y.saturating_add(row.total_height());
+            row_index += 1;
+        }
+    }
+}
+
+impl Widget for Table {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        let mut state = TableState::default();
+        StatefulWidget::render(self, area, buf, &mut state);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_table_cell_new() {
+        let cell = TableCell::new("test");
+        assert_eq!(cell.content(), "test");
+        assert_eq!(cell.style, Style::default());
+    }
+
+    #[test]
+    fn test_table_cell_width() {
+        let cell = TableCell::new("hello");
+        assert_eq!(cell.width(), 5);
+    }
+
+    #[test]
+    fn test_table_cell_style() {
+        let style = Style::default().fg(Color::Red);
+        let cell = TableCell::new("test").style(style);
+        assert_eq!(cell.style, style);
+    }
+
+    #[test]
+    fn test_row_new() {
+        let row = Row::new(vec!["a", "b", "c"]);
+        assert_eq!(row.cells().len(), 3);
+        assert_eq!(row.height, 1);
+        assert_eq!(row.bottom_margin, 0);
+    }
+
+    #[test]
+    fn test_row_total_height() {
+        let row = Row::new(vec!["test"]).height(2).bottom_margin(1);
+        assert_eq!(row.total_height(), 3);
+    }
+
+    #[test]
+    fn test_table_state() {
+        let mut state = TableState::new();
+        assert_eq!(state.selected(), None);
+        assert_eq!(state.offset(), 0);
+
+        state.select(Some(5));
+        assert_eq!(state.selected(), Some(5));
+
+        state.set_offset(10);
+        assert_eq!(state.offset(), 10);
+    }
+
+    #[test]
+    fn test_table_new() {
+        let table = Table::new(vec![
+            Row::new(vec!["a", "b"]),
+            Row::new(vec!["c", "d"]),
+        ]);
+        assert_eq!(table.rows.len(), 2);
+        assert_eq!(table.header, None);
+    }
+
+    #[test]
+    fn test_table_with_header() {
+        let table = Table::new(vec![Row::new(vec!["a", "b"])])
+            .header(Row::new(vec!["H1", "H2"]));
+        assert!(table.header.is_some());
+    }
+
+    #[test]
+    fn test_table_calculate_widths_length() {
+        let table = Table::new(vec![Row::new(vec!["a", "b"])])
+            .widths(&[Constraint::Length(10), Constraint::Length(20)]);
+        let widths = table.calculate_widths(100);
+        assert_eq!(widths, vec![10, 20]);
+    }
+
+    #[test]
+    fn test_table_calculate_widths_percentage() {
+        let table = Table::new(vec![Row::new(vec!["a", "b"])])
+            .widths(&[Constraint::Percentage(50), Constraint::Percentage(50)])
+            .column_spacing(0);
+        let widths = table.calculate_widths(100);
+        assert_eq!(widths, vec![50, 50]);
+    }
+
+    #[test]
+    fn test_table_calculate_widths_fill() {
+        let table = Table::new(vec![Row::new(vec!["a", "b", "c"])])
+            .widths(&[
+                Constraint::Length(10),
+                Constraint::Fill(1),
+                Constraint::Fill(1),
+            ])
+            .column_spacing(0);
+        let widths = table.calculate_widths(100);
+        assert_eq!(widths, vec![10, 45, 45]);
+    }
+
+    #[test]
+    fn test_table_render() {
+        let table = Table::new(vec![
+            Row::new(vec!["a", "b"]),
+            Row::new(vec!["c", "d"]),
+        ])
+        .widths(&[Constraint::Length(5), Constraint::Length(5)]);
+
+        let area = Rect::new(0, 0, 20, 10);
+        let mut buffer = Buffer::new(area);
+        let mut state = TableState::default();
+
+        StatefulWidget::render(&table, area, &mut buffer, &mut state);
+
+        // Check that cells were written
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "a");
+        assert_eq!(buffer.get(0, 1).unwrap().symbol, "c");
+    }
+
+    #[test]
+    fn test_table_render_with_selection() {
+        let highlight_style = Style::default().fg(Color::Green);
+        let table = Table::new(vec![
+            Row::new(vec!["a", "b"]),
+            Row::new(vec!["c", "d"]),
+        ])
+        .widths(&[Constraint::Length(5), Constraint::Length(5)])
+        .highlight_style(highlight_style);
+
+        let area = Rect::new(0, 0, 20, 10);
+        let mut buffer = Buffer::new(area);
+        let mut state = TableState::default();
+        state.select(Some(1));
+
+        StatefulWidget::render(&table, area, &mut buffer, &mut state);
+
+        // Second row should have highlight style
+        let cell = buffer.get(0, 1).unwrap();
+        assert_eq!(cell.fg, Color::Green);
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/tabs.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/tabs.rs
@@ -1,0 +1,369 @@
+//! Tabs widget for tab navigation.
+//!
+//! This module provides a `Tabs` widget that displays a list of tab titles with
+//! highlighting for the selected tab and customizable dividers.
+
+use fusabi_tui_core::{
+    buffer::Buffer,
+    layout::Rect,
+    style::Style,
+};
+
+use crate::widget::Widget;
+
+/// A tabs widget for displaying tab navigation.
+///
+/// Shows a horizontal list of tab titles with the selected tab highlighted.
+/// Tabs are separated by a divider character.
+///
+/// # Examples
+///
+/// ```
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect, style::{Color, Style}};
+/// use fusabi_tui_widgets::{Tabs, Widget};
+///
+/// let tabs = Tabs::new(vec!["Tab 1", "Tab 2", "Tab 3"])
+///     .select(1)
+///     .style(Style::default().fg(Color::White))
+///     .highlight_style(Style::default().fg(Color::Yellow))
+///     .divider("|");
+///
+/// let area = Rect::new(0, 0, 40, 1);
+/// let mut buffer = Buffer::new(area);
+/// tabs.render(area, &mut buffer);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Tabs {
+    titles: Vec<String>,
+    selected: usize,
+    style: Style,
+    highlight_style: Style,
+    divider: String,
+}
+
+impl Tabs {
+    /// Creates a new tabs widget with the given titles.
+    pub fn new<T>(titles: Vec<T>) -> Self
+    where
+        T: Into<String>,
+    {
+        Self {
+            titles: titles.into_iter().map(Into::into).collect(),
+            selected: 0,
+            style: Style::default(),
+            highlight_style: Style::default(),
+            divider: " ".to_string(),
+        }
+    }
+
+    /// Sets the index of the selected tab.
+    pub fn select(mut self, index: usize) -> Self {
+        self.selected = index;
+        self
+    }
+
+    /// Sets the default style for unselected tabs.
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+
+    /// Sets the style for the selected tab.
+    pub fn highlight_style(mut self, style: Style) -> Self {
+        self.highlight_style = style;
+        self
+    }
+
+    /// Sets the divider string between tabs.
+    pub fn divider<T>(mut self, divider: T) -> Self
+    where
+        T: Into<String>,
+    {
+        self.divider = divider.into();
+        self
+    }
+
+    /// Returns the titles of all tabs.
+    pub fn titles(&self) -> &[String] {
+        &self.titles
+    }
+
+    /// Returns the index of the selected tab.
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+}
+
+impl Widget for Tabs {
+    fn render(&self, area: Rect, buf: &mut Buffer) {
+        if area.area() == 0 || self.titles.is_empty() {
+            return;
+        }
+
+        // Only use the first row
+        let tabs_area = Rect {
+            x: area.x,
+            y: area.y,
+            width: area.width,
+            height: 1,
+        };
+
+        // Clear the area with the base style
+        for x in tabs_area.left()..tabs_area.right() {
+            if let Some(cell) = buf.get_mut(x, tabs_area.y) {
+                cell.symbol = " ".to_string();
+                cell.set_style(self.style);
+            }
+        }
+
+        let mut x = tabs_area.x;
+
+        // Render each tab
+        for (i, title) in self.titles.iter().enumerate() {
+            // Check if we have space
+            if x >= tabs_area.right() {
+                break;
+            }
+
+            // Determine style for this tab
+            let tab_style = if i == self.selected {
+                self.highlight_style
+            } else {
+                self.style
+            };
+
+            // Calculate how much space we have left
+            let remaining_width = tabs_area.right().saturating_sub(x) as usize;
+
+            // Render the tab title (truncate if necessary)
+            let mut current_width = 0;
+            for ch in title.chars() {
+                if x >= tabs_area.right() {
+                    break;
+                }
+                let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                if current_width + ch_width > remaining_width {
+                    break;
+                }
+
+                if let Some(cell) = buf.get_mut(x, tabs_area.y) {
+                    cell.symbol = ch.to_string();
+                    cell.set_style(tab_style);
+                }
+
+                x = x.saturating_add(1);
+                current_width += ch_width;
+            }
+
+            // Add divider after tab (except for the last tab)
+            if i < self.titles.len() - 1 {
+                let divider_remaining = tabs_area.right().saturating_sub(x) as usize;
+                let mut divider_current = 0;
+
+                for ch in self.divider.chars() {
+                    if x >= tabs_area.right() {
+                        break;
+                    }
+                    let ch_width = unicode_width::UnicodeWidthChar::width(ch).unwrap_or(0);
+                    if divider_current + ch_width > divider_remaining {
+                        break;
+                    }
+
+                    if let Some(cell) = buf.get_mut(x, tabs_area.y) {
+                        cell.symbol = ch.to_string();
+                        cell.set_style(self.style);
+                    }
+
+                    x = x.saturating_add(1);
+                    divider_current += ch_width;
+                }
+            }
+        }
+
+        // Fill remaining space with default style
+        while x < tabs_area.right() {
+            if let Some(cell) = buf.get_mut(x, tabs_area.y) {
+                cell.symbol = " ".to_string();
+                cell.set_style(self.style);
+            }
+            x = x.saturating_add(1);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_tabs_new() {
+        let tabs = Tabs::new(vec!["Tab 1", "Tab 2", "Tab 3"]);
+        assert_eq!(tabs.titles.len(), 3);
+        assert_eq!(tabs.selected, 0);
+        assert_eq!(tabs.divider, " ");
+    }
+
+    #[test]
+    fn test_tabs_select() {
+        let tabs = Tabs::new(vec!["A", "B", "C"]).select(2);
+        assert_eq!(tabs.selected, 2);
+    }
+
+    #[test]
+    fn test_tabs_style() {
+        let style = Style::default().fg(Color::White);
+        let tabs = Tabs::new(vec!["A", "B"]).style(style);
+        assert_eq!(tabs.style, style);
+    }
+
+    #[test]
+    fn test_tabs_highlight_style() {
+        let style = Style::default().fg(Color::Yellow);
+        let tabs = Tabs::new(vec!["A", "B"]).highlight_style(style);
+        assert_eq!(tabs.highlight_style, style);
+    }
+
+    #[test]
+    fn test_tabs_divider() {
+        let tabs = Tabs::new(vec!["A", "B"]).divider("|");
+        assert_eq!(tabs.divider, "|");
+    }
+
+    #[test]
+    fn test_tabs_titles() {
+        let tabs = Tabs::new(vec!["Tab 1", "Tab 2"]);
+        assert_eq!(tabs.titles(), &["Tab 1", "Tab 2"]);
+    }
+
+    #[test]
+    fn test_tabs_selected() {
+        let tabs = Tabs::new(vec!["A", "B", "C"]).select(1);
+        assert_eq!(tabs.selected(), 1);
+    }
+
+    #[test]
+    fn test_tabs_render_empty() {
+        let tabs = Tabs::new::<String>(vec![]);
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // Should just fill with spaces
+        for x in 0..20 {
+            assert_eq!(buffer.get(x, 0).unwrap().symbol, " ");
+        }
+    }
+
+    #[test]
+    fn test_tabs_render_single() {
+        let tabs = Tabs::new(vec!["Single"])
+            .style(Style::default().fg(Color::White))
+            .highlight_style(Style::default().fg(Color::Yellow));
+
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // Check the tab title
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "S");
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, "i");
+        assert_eq!(buffer.get(5, 0).unwrap().symbol, "e");
+
+        // Should be highlighted (selected by default)
+        assert_eq!(buffer.get(0, 0).unwrap().fg, Color::Yellow);
+    }
+
+    #[test]
+    fn test_tabs_render_multiple() {
+        let tabs = Tabs::new(vec!["Tab1", "Tab2", "Tab3"])
+            .select(1)
+            .style(Style::default().fg(Color::White))
+            .highlight_style(Style::default().fg(Color::Green))
+            .divider("|");
+
+        let area = Rect::new(0, 0, 30, 1);
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // First tab should not be highlighted
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "T");
+        assert_eq!(buffer.get(0, 0).unwrap().fg, Color::White);
+
+        // Divider after first tab
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "|");
+
+        // Second tab should be highlighted
+        assert_eq!(buffer.get(5, 0).unwrap().symbol, "T");
+        assert_eq!(buffer.get(5, 0).unwrap().fg, Color::Green);
+
+        // Divider after second tab
+        assert_eq!(buffer.get(9, 0).unwrap().symbol, "|");
+
+        // Third tab should not be highlighted
+        assert_eq!(buffer.get(10, 0).unwrap().symbol, "T");
+        assert_eq!(buffer.get(10, 0).unwrap().fg, Color::White);
+    }
+
+    #[test]
+    fn test_tabs_render_with_spaces_divider() {
+        let tabs = Tabs::new(vec!["A", "B", "C"])
+            .divider(" | ");
+
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // "A | B | C"
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "A");
+        assert_eq!(buffer.get(1, 0).unwrap().symbol, " ");
+        assert_eq!(buffer.get(2, 0).unwrap().symbol, "|");
+        assert_eq!(buffer.get(3, 0).unwrap().symbol, " ");
+        assert_eq!(buffer.get(4, 0).unwrap().symbol, "B");
+    }
+
+    #[test]
+    fn test_tabs_render_truncated() {
+        let tabs = Tabs::new(vec!["VeryLongTabName1", "VeryLongTabName2"])
+            .divider("|");
+
+        let area = Rect::new(0, 0, 10, 1); // Only 10 cells wide
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // Should truncate the first tab
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "V");
+        // Should not overflow
+        for x in 0..10 {
+            let cell = buffer.get(x, 0).unwrap();
+            assert!(!cell.symbol.is_empty() || cell.symbol == " ");
+        }
+    }
+
+    #[test]
+    fn test_tabs_render_out_of_bounds_selection() {
+        let tabs = Tabs::new(vec!["A", "B"]).select(5); // Out of bounds
+
+        let area = Rect::new(0, 0, 10, 1);
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // Should render without panic, no tab will be highlighted
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "A");
+        assert_eq!(buffer.get(0, 0).unwrap().fg, Color::Reset); // Default style
+    }
+
+    #[test]
+    fn test_tabs_render_unicode_divider() {
+        let tabs = Tabs::new(vec!["Tab1", "Tab2"])
+            .divider(" │ ");
+
+        let area = Rect::new(0, 0, 20, 1);
+        let mut buffer = Buffer::new(area);
+        tabs.render(area, &mut buffer);
+
+        // Should handle unicode divider correctly
+        assert_eq!(buffer.get(0, 0).unwrap().symbol, "T");
+        assert_eq!(buffer.get(5, 0).unwrap().symbol, "│");
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/text.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/text.rs
@@ -1,0 +1,364 @@
+//! Text primitives for building styled text content.
+//!
+//! This module provides the building blocks for composing styled text:
+//! - [`Span`] - A single styled text segment
+//! - [`Line`] - A sequence of spans forming a single line
+//! - [`Text`] - A sequence of lines forming multi-line text
+
+use fusabi_tui_core::style::Style;
+use unicode_width::UnicodeWidthStr;
+
+/// A styled text segment.
+///
+/// A span represents a contiguous piece of text with a single style applied.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::style::{Color, Style};
+/// use fusabi_tui_widgets::Span;
+///
+/// let span = Span::styled("Hello", Style::default().fg(Color::Green));
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Span<'a> {
+    /// The text content
+    pub content: std::borrow::Cow<'a, str>,
+    /// The style to apply
+    pub style: Style,
+}
+
+impl<'a> Span<'a> {
+    /// Creates a new unstyled span.
+    pub fn raw<T>(content: T) -> Self
+    where
+        T: Into<std::borrow::Cow<'a, str>>,
+    {
+        Self {
+            content: content.into(),
+            style: Style::default(),
+        }
+    }
+
+    /// Creates a new styled span.
+    pub fn styled<T>(content: T, style: Style) -> Self
+    where
+        T: Into<std::borrow::Cow<'a, str>>,
+    {
+        Self {
+            content: content.into(),
+            style,
+        }
+    }
+
+    /// Returns the width of the span in terminal cells.
+    pub fn width(&self) -> usize {
+        self.content.width()
+    }
+
+    /// Sets the style of the span.
+    #[must_use]
+    pub fn style(mut self, style: Style) -> Self {
+        self.style = style;
+        self
+    }
+}
+
+impl<'a> From<&'a str> for Span<'a> {
+    fn from(s: &'a str) -> Self {
+        Self::raw(s)
+    }
+}
+
+impl From<String> for Span<'static> {
+    fn from(s: String) -> Self {
+        Self::raw(s)
+    }
+}
+
+impl<'a> From<&'a String> for Span<'a> {
+    fn from(s: &'a String) -> Self {
+        Self::raw(s.as_str())
+    }
+}
+
+/// A line of text composed of styled spans.
+///
+/// A line is a horizontal sequence of spans. Lines are separated by newlines
+/// when rendered as part of [`Text`].
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::style::{Color, Style};
+/// use fusabi_tui_widgets::{Line, Span};
+///
+/// let line = Line::from(vec![
+///     Span::raw("Hello "),
+///     Span::styled("World", Style::default().fg(Color::Green)),
+/// ]);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct Line<'a> {
+    /// The spans that make up this line
+    pub spans: Vec<Span<'a>>,
+}
+
+impl<'a> Line<'a> {
+    /// Creates a new line from a vector of spans.
+    pub fn from_spans(spans: Vec<Span<'a>>) -> Self {
+        Self { spans }
+    }
+
+    /// Creates a new empty line.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Returns the width of the line in terminal cells.
+    pub fn width(&self) -> usize {
+        self.spans.iter().map(Span::width).sum()
+    }
+
+    /// Returns the number of spans in the line.
+    pub fn span_count(&self) -> usize {
+        self.spans.len()
+    }
+
+    /// Adds a span to the line.
+    pub fn push_span(&mut self, span: Span<'a>) {
+        self.spans.push(span);
+    }
+
+    /// Applies a style to all spans in the line that don't have a style set.
+    #[must_use]
+    pub fn style(mut self, style: Style) -> Self {
+        for span in &mut self.spans {
+            if span.style == Style::default() {
+                span.style = style;
+            }
+        }
+        self
+    }
+}
+
+impl<'a> From<&'a str> for Line<'a> {
+    fn from(s: &'a str) -> Self {
+        Self {
+            spans: vec![Span::raw(s)],
+        }
+    }
+}
+
+impl From<String> for Line<'static> {
+    fn from(s: String) -> Self {
+        Self {
+            spans: vec![Span::raw(s)],
+        }
+    }
+}
+
+impl<'a> From<Span<'a>> for Line<'a> {
+    fn from(span: Span<'a>) -> Self {
+        Self { spans: vec![span] }
+    }
+}
+
+impl<'a> From<Vec<Span<'a>>> for Line<'a> {
+    fn from(spans: Vec<Span<'a>>) -> Self {
+        Self { spans }
+    }
+}
+
+/// Multi-line text composed of lines.
+///
+/// Text is the top-level structure for representing styled text content.
+/// It can be constructed from strings, lines, or vectors of lines.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::style::{Color, Style};
+/// use fusabi_tui_widgets::{Text, Line, Span};
+///
+/// // From a simple string
+/// let text = Text::from("Hello\nWorld");
+///
+/// // From styled lines
+/// let text = Text::from(vec![
+///     Line::from("Header"),
+///     Line::from(vec![
+///         Span::raw("Styled "),
+///         Span::styled("text", Style::default().fg(Color::Green)),
+///     ]),
+/// ]);
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Default)]
+pub struct Text<'a> {
+    /// The lines that make up this text
+    pub lines: Vec<Line<'a>>,
+}
+
+impl<'a> Text<'a> {
+    /// Creates a new text from a vector of lines.
+    pub fn from_lines(lines: Vec<Line<'a>>) -> Self {
+        Self { lines }
+    }
+
+    /// Creates a new empty text.
+    pub fn empty() -> Self {
+        Self::default()
+    }
+
+    /// Returns the number of lines in the text.
+    pub fn line_count(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Returns the width of the longest line in terminal cells.
+    pub fn width(&self) -> usize {
+        self.lines.iter().map(Line::width).max().unwrap_or(0)
+    }
+
+    /// Returns the height of the text in lines.
+    pub fn height(&self) -> usize {
+        self.lines.len()
+    }
+
+    /// Adds a line to the text.
+    pub fn push_line(&mut self, line: Line<'a>) {
+        self.lines.push(line);
+    }
+
+    /// Applies a style to all lines that don't have a style set.
+    #[must_use]
+    pub fn style(mut self, style: Style) -> Self {
+        for line in &mut self.lines {
+            *line = std::mem::take(line).style(style);
+        }
+        self
+    }
+}
+
+impl<'a> From<&'a str> for Text<'a> {
+    fn from(s: &'a str) -> Self {
+        let lines = s.lines().map(Line::from).collect();
+        Self { lines }
+    }
+}
+
+impl From<String> for Text<'static> {
+    fn from(s: String) -> Self {
+        let lines = s.lines().map(|line| Line::from(line.to_string())).collect();
+        Self { lines }
+    }
+}
+
+impl<'a> From<Line<'a>> for Text<'a> {
+    fn from(line: Line<'a>) -> Self {
+        Self { lines: vec![line] }
+    }
+}
+
+impl<'a> From<Vec<Line<'a>>> for Text<'a> {
+    fn from(lines: Vec<Line<'a>>) -> Self {
+        Self { lines }
+    }
+}
+
+impl<'a> From<Span<'a>> for Text<'a> {
+    fn from(span: Span<'a>) -> Self {
+        Self {
+            lines: vec![Line::from(span)],
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use fusabi_tui_core::style::Color;
+
+    #[test]
+    fn test_span_creation() {
+        let span = Span::raw("test");
+        assert_eq!(span.content, "test");
+        assert_eq!(span.style, Style::default());
+
+        let styled = Span::styled("test", Style::default().fg(Color::Green));
+        assert_eq!(styled.content, "test");
+        assert_eq!(styled.style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_span_width() {
+        let span = Span::raw("hello");
+        assert_eq!(span.width(), 5);
+
+        let wide = Span::raw("你好");
+        assert_eq!(wide.width(), 4); // Chinese characters are 2 cells wide
+    }
+
+    #[test]
+    fn test_span_from_str() {
+        let span: Span = "test".into();
+        assert_eq!(span.content, "test");
+    }
+
+    #[test]
+    fn test_line_creation() {
+        let line = Line::from("test");
+        assert_eq!(line.spans.len(), 1);
+        assert_eq!(line.spans[0].content, "test");
+
+        let line = Line::from(vec![Span::raw("a"), Span::raw("b")]);
+        assert_eq!(line.spans.len(), 2);
+    }
+
+    #[test]
+    fn test_line_width() {
+        let line = Line::from(vec![Span::raw("hello "), Span::raw("world")]);
+        assert_eq!(line.width(), 11);
+    }
+
+    #[test]
+    fn test_line_style() {
+        let style = Style::default().fg(Color::Green);
+        let line = Line::from(vec![Span::raw("test")]).style(style);
+        assert_eq!(line.spans[0].style.fg, Some(Color::Green));
+    }
+
+    #[test]
+    fn test_text_from_str() {
+        let text = Text::from("line1\nline2\nline3");
+        assert_eq!(text.lines.len(), 3);
+        assert_eq!(text.lines[0].spans[0].content, "line1");
+        assert_eq!(text.lines[1].spans[0].content, "line2");
+        assert_eq!(text.lines[2].spans[0].content, "line3");
+    }
+
+    #[test]
+    fn test_text_dimensions() {
+        let text = Text::from("hello\nworld!\nhi");
+        assert_eq!(text.height(), 3);
+        assert_eq!(text.width(), 6); // "world!" is the longest
+    }
+
+    #[test]
+    fn test_text_from_lines() {
+        let text = Text::from(vec![
+            Line::from("line1"),
+            Line::from("line2"),
+        ]);
+        assert_eq!(text.lines.len(), 2);
+    }
+
+    #[test]
+    fn test_text_style() {
+        let style = Style::default().fg(Color::Blue);
+        let text = Text::from(vec![
+            Line::from(Span::raw("test")),
+        ]).style(style);
+        assert_eq!(text.lines[0].spans[0].style.fg, Some(Color::Blue));
+    }
+}

--- a/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/widget.rs
+++ b/fusabi-tui-runtime/crates/fusabi-tui-widgets/src/widget.rs
@@ -1,0 +1,74 @@
+//! Core widget trait definitions.
+//!
+//! This module defines the fundamental traits that all widgets must implement.
+
+use fusabi_tui_core::{buffer::Buffer, layout::Rect};
+
+/// Trait for stateless widgets.
+///
+/// A widget is any component that can be rendered to a terminal buffer.
+/// Stateless widgets don't maintain any state between renders.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect};
+/// use fusabi_tui_widgets::Widget;
+///
+/// struct MyWidget;
+///
+/// impl Widget for MyWidget {
+///     fn render(&self, area: Rect, buf: &mut Buffer) {
+///         buf.set_string(area.x, area.y, "Hello!", Default::default());
+///     }
+/// }
+/// ```
+pub trait Widget {
+    /// Renders the widget to the given area in the buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `area` - The rectangular area where the widget should be rendered
+    /// * `buf` - The buffer to render into
+    fn render(&self, area: Rect, buf: &mut Buffer);
+}
+
+/// Trait for stateful widgets.
+///
+/// Stateful widgets maintain state between renders, such as scroll position
+/// or selected item index.
+///
+/// # Examples
+///
+/// ```rust
+/// use fusabi_tui_core::{buffer::Buffer, layout::Rect};
+/// use fusabi_tui_widgets::StatefulWidget;
+///
+/// struct MyStatefulWidget;
+///
+/// struct MyState {
+///     selected: usize,
+/// }
+///
+/// impl StatefulWidget for MyStatefulWidget {
+///     type State = MyState;
+///
+///     fn render(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State) {
+///         let text = format!("Selected: {}", state.selected);
+///         buf.set_string(area.x, area.y, &text, Default::default());
+///     }
+/// }
+/// ```
+pub trait StatefulWidget {
+    /// The state type associated with this widget.
+    type State;
+
+    /// Renders the widget to the given area in the buffer using the provided state.
+    ///
+    /// # Arguments
+    ///
+    /// * `area` - The rectangular area where the widget should be rendered
+    /// * `buf` - The buffer to render into
+    /// * `state` - Mutable reference to the widget's state
+    fn render(&self, area: Rect, buf: &mut Buffer, state: &mut Self::State);
+}

--- a/fusabi-tui-runtime/fsx/examples/dashboard.fsx
+++ b/fusabi-tui-runtime/fsx/examples/dashboard.fsx
@@ -1,0 +1,134 @@
+// TUI Dashboard Example
+// Demonstrates using multiple widgets to create a dashboard layout
+
+#load "../tui.fsx"
+
+// Create a styled title block
+let createTitleBlock title =
+    let titleStyle = emptyStyle |> withFg cyan |> withBg black in
+    createBlock
+    |> withTitle title
+    |> withBorders allBorders
+    |> withBorderType roundedBorder
+    |> withBlockStyle titleStyle
+
+// Example 1: Block with title and borders
+let statusBlock =
+    createTitleBlock "System Status"
+    |> withPadding 1 1 0 0
+
+// Example 2: List with items
+let createStatusList =
+    let item1 = listItemFromString "CPU Usage: 45%" in
+    let item2Style = emptyStyle |> withFg green in
+    let item2 = styledListItem "Memory: 2.4GB / 8GB" item2Style in
+    let highlightStyle = emptyStyle |> withFg black |> withBg cyan in
+
+    createList item1
+    |> withListBlock statusBlock
+    |> withHighlightStyle highlightStyle
+
+// Example 3: Paragraph with styled text
+let createLogParagraph =
+    let logText = textFromString "Application started successfully. All systems operational." in
+    let logStyle = emptyStyle |> withFg white in
+    let logBlock = createTitleBlock "Logs" in
+
+    createParagraph logText
+    |> withParagraphBlock logBlock
+    |> withParagraphStyle logStyle
+    |> withAlignment leftAlign
+    |> withWrap wrapWord
+
+// Example 4: Gauge showing progress
+let createCpuGauge =
+    let gaugeBlock = createTitleBlock "CPU Load" in
+    let gaugeStyle = emptyStyle |> withFg yellow in
+    let barStyle = emptyStyle |> withFg green in
+
+    gaugeFromPercent 45
+    |> withLabel "Processing..."
+    |> withGaugeBlock gaugeBlock
+    |> withGaugeStyle gaugeStyle
+    |> withGaugeBarStyle barStyle
+
+// Example 5: Gauge showing memory usage
+let createMemoryGauge =
+    let gaugeBlock = createTitleBlock "Memory Usage" in
+    let gaugeStyle = emptyStyle |> withFg blue in
+    let barStyle = emptyStyle |> withFg cyan in
+
+    gaugeFromPercent 30
+    |> withLabel "2.4GB / 8GB"
+    |> withGaugeBlock gaugeBlock
+    |> withGaugeStyle gaugeStyle
+    |> withGaugeBarStyle barStyle
+
+// Example 6: Sparkline for showing trends
+let createNetworkSparkline =
+    let sparklineBlock = createTitleBlock "Network Activity" in
+    let sparklineStyle = emptyStyle |> withFg magenta in
+
+    sparklineFromData 75
+    |> withMax 100
+    |> withSparklineBlock sparklineBlock
+    |> withSparklineStyle sparklineStyle
+    |> withDirection leftToRight
+
+// Example 7: Tabs for navigation
+let createNavTabs =
+    let tabsBlock = createBlock |> withBorders bottomBorder in
+    let normalStyle = emptyStyle |> withFg white in
+    let highlightStyle = emptyStyle |> withFg cyan in
+
+    tabsFromTitles "Dashboard"
+    |> withSelected 0
+    |> withDivider pipeDivider
+    |> withTabsBlock tabsBlock
+    |> withTabsStyle normalStyle
+    |> withTabsHighlightStyle highlightStyle
+
+// Example 8: Table for displaying data
+let createDataTable =
+    let headerCell = styledTableCell "Metric" (emptyStyle |> withFg yellow) in
+    let headerRow = createTableRow headerCell (emptyStyle |> withFg yellow) in
+
+    let dataCell = tableCellFromString "CPU: 45%" in
+    let dataRow = tableRowFromCell dataCell in
+
+    let tableBlock = createTitleBlock "System Metrics" in
+
+    createTable dataRow
+    |> withTableHeader headerRow
+    |> withTableBlock tableBlock
+    |> withTableStyle (emptyStyle |> withFg white)
+    |> withColumnWidths (columnPercentage 50)
+
+// Main dashboard layout
+let createDashboard =
+    let mainBlock = createTitleBlock "Fusabi TUI Dashboard v0.1.0" in
+
+    // Create layout areas
+    let area = createRect 0 0 80 24 in
+    let layoutMargin = 1 in
+
+    // Layout constraints
+    let verticalConstraints = [Percentage 30; Percentage 40; Percentage 30] in
+    let horizontalConstraints = [Percentage 50; Percentage 50] in
+
+    // This is a simplified example showing widget creation
+    // Actual rendering would require integration with the TUI runtime
+    mainBlock
+
+// Example usage
+let dashboard = createDashboard
+let statusList = createStatusList
+let logParagraph = createLogParagraph
+let cpuGauge = createCpuGauge
+let memoryGauge = createMemoryGauge
+let networkSparkline = createNetworkSparkline
+let navTabs = createNavTabs
+let dataTable = createDataTable
+
+// Display message
+let dashboardMessage = "Dashboard widgets created successfully!"

--- a/fusabi-tui-runtime/fsx/tui.fsx
+++ b/fusabi-tui-runtime/fsx/tui.fsx
@@ -8,6 +8,7 @@
 #load "tui/buffer.fsx"
 #load "tui/layout.fsx"
 #load "tui/symbols.fsx"
+#load "tui/widgets.fsx"
 
 // TUI library version
 let tuiVersion = "0.1.0"

--- a/fusabi-tui-runtime/fsx/tui/widgets.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets.fsx
@@ -1,0 +1,14 @@
+// TUI Widgets Library
+// Main entry point that loads all widget modules
+
+#load "widgets/text.fsx"
+#load "widgets/block.fsx"
+#load "widgets/paragraph.fsx"
+#load "widgets/list.fsx"
+#load "widgets/table.fsx"
+#load "widgets/gauge.fsx"
+#load "widgets/sparkline.fsx"
+#load "widgets/tabs.fsx"
+
+// Widgets library version
+let widgetsVersion = "0.1.0"

--- a/fusabi-tui-runtime/fsx/tui/widgets/block.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/block.fsx
@@ -1,0 +1,88 @@
+#load "../style.fsx"
+
+// TUI Block Widget
+// Represents a bordered container for other widgets
+
+// Border type variations
+type BorderType =
+    | Plain
+    | Rounded
+    | Double
+    | Thick
+
+// Border flags for which sides to draw
+type Borders =
+    | None
+    | Top
+    | Right
+    | Bottom
+    | Left
+    | TopRight
+    | TopBottom
+    | TopLeft
+    | RightBottom
+    | RightLeft
+    | BottomLeft
+    | TopRightBottom
+    | TopRightLeft
+    | TopBottomLeft
+    | RightBottomLeft
+    | All
+
+// Option type for strings (for optional title)
+type OptionString =
+    | NoneString
+    | SomeString of string
+
+// Padding represented as left * right * top * bottom
+type Padding =
+    | Padding of int * int * int * int
+
+// Block widget
+// Represented as title * borders * borderType * style * padding
+type Block =
+    | Block of OptionString * Borders * BorderType * Style * Padding
+
+// Block constructors and utilities
+let emptyBlock = Block (NoneString, None, Plain, emptyStyle, Padding (0, 0, 0, 0))
+
+let createBlock = Block (NoneString, All, Plain, emptyStyle, Padding (0, 0, 0, 0))
+
+let withTitle title block =
+    match block with
+    | Block (_, borders, borderType, style, padding) ->
+        Block (SomeString title, borders, borderType, style, padding)
+
+let withBorders borders block =
+    match block with
+    | Block (title, _, borderType, style, padding) ->
+        Block (title, borders, borderType, style, padding)
+
+let withBorderType borderType block =
+    match block with
+    | Block (title, borders, _, style, padding) ->
+        Block (title, borders, borderType, style, padding)
+
+let withBlockStyle style block =
+    match block with
+    | Block (title, borders, borderType, _, padding) ->
+        Block (title, borders, borderType, style, padding)
+
+let withPadding left right top bottom block =
+    match block with
+    | Block (title, borders, borderType, style, _) ->
+        Block (title, borders, borderType, style, Padding (left, right, top, bottom))
+
+// Border type constructors
+let plainBorder = Plain
+let roundedBorder = Rounded
+let doubleBorder = Double
+let thickBorder = Thick
+
+// Border flag helpers
+let noBorders = None
+let allBorders = All
+let topBorder = Top
+let rightBorder = Right
+let bottomBorder = Bottom
+let leftBorder = Left

--- a/fusabi-tui-runtime/fsx/tui/widgets/gauge.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/gauge.fsx
@@ -1,0 +1,56 @@
+#load "block.fsx"
+
+// TUI Gauge Widget
+// Displays a progress bar or percentage indicator
+
+// Option type for label
+type OptionLabel =
+    | NoneLabel
+    | SomeLabel of string
+
+// Gauge widget
+// Represented as ratio * label * block * style * gaugeStyle
+// ratio is 0-100 representing percentage
+type Gauge =
+    | Gauge of int * OptionLabel * OptionBlock * Style * Style
+
+// Gauge constructors and utilities
+let emptyGauge = Gauge (0, NoneLabel, NoneBlock, emptyStyle, emptyStyle)
+
+let createGauge ratio = Gauge (ratio, NoneLabel, NoneBlock, emptyStyle, emptyStyle)
+
+let gaugeFromPercent percent =
+    let clampedPercent = if percent > 100 then 100 else if percent < 0 then 0 else percent in
+    Gauge (clampedPercent, NoneLabel, NoneBlock, emptyStyle, emptyStyle)
+
+let withRatio ratio gauge =
+    match gauge with
+    | Gauge (_, label, block, style, gaugeStyle) ->
+        let clampedRatio = if ratio > 100 then 100 else if ratio < 0 then 0 else ratio in
+        Gauge (clampedRatio, label, block, style, gaugeStyle)
+
+let withLabel label gauge =
+    match gauge with
+    | Gauge (ratio, _, block, style, gaugeStyle) ->
+        Gauge (ratio, SomeLabel label, block, style, gaugeStyle)
+
+let withGaugeBlock block gauge =
+    match gauge with
+    | Gauge (ratio, label, _, style, gaugeStyle) ->
+        Gauge (ratio, label, SomeBlock block, style, gaugeStyle)
+
+let withGaugeStyle style gauge =
+    match gauge with
+    | Gauge (ratio, label, block, _, gaugeStyle) ->
+        Gauge (ratio, label, block, style, gaugeStyle)
+
+let withGaugeBarStyle style gauge =
+    match gauge with
+    | Gauge (ratio, label, block, gaugeStyle, _) ->
+        Gauge (ratio, label, block, gaugeStyle, style)
+
+// Helper functions
+let percentToRatio percent =
+    if percent > 100 then 100 else if percent < 0 then 0 else percent
+
+let ratioToPercent ratio = ratio

--- a/fusabi-tui-runtime/fsx/tui/widgets/list.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/list.fsx
@@ -1,0 +1,78 @@
+#load "text.fsx"
+#load "block.fsx"
+
+// TUI List Widget
+// Displays a selectable list of items
+
+// ListItem - a single item in the list
+// Represented as text * style
+type ListItem =
+    | ListItem of Text * Style
+
+// Option type for selected index
+type OptionInt =
+    | NoneInt
+    | SomeInt of int
+
+// ListState - tracks selection state
+// Represented as selected index
+type ListState =
+    | ListState of OptionInt
+
+// List widget
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// List represented as item * block * style * highlightStyle
+// (single item instead of list of items)
+type List =
+    | List of ListItem * OptionBlock * Style * Style
+
+// ListItem constructors
+let createListItem text style = ListItem (text, style)
+
+let listItemFromString str = ListItem (textFromString str, emptyStyle)
+
+let styledListItem str style = ListItem (textFromString str, style)
+
+// ListState constructors
+let emptyListState = ListState NoneInt
+
+let createListState = ListState NoneInt
+
+let selectListItem index state =
+    ListState (SomeInt index)
+
+let deselectListItem state = ListState NoneInt
+
+let nextListItem state =
+    match state with
+    | ListState (SomeInt idx) -> ListState (SomeInt (idx + 1))
+    | ListState NoneInt -> ListState (SomeInt 0)
+
+let prevListItem state =
+    match state with
+    | ListState (SomeInt idx) ->
+        let newIdx = if idx > 0 then idx - 1 else 0 in
+        ListState (SomeInt newIdx)
+    | ListState NoneInt -> ListState (SomeInt 0)
+
+// List constructors
+let emptyList = List (listItemFromString "", NoneBlock, emptyStyle, emptyStyle)
+
+let createList item = List (item, NoneBlock, emptyStyle, emptyStyle)
+
+let listFromItems item = List (item, NoneBlock, emptyStyle, emptyStyle)
+
+let withListBlock block list =
+    match list with
+    | List (item, _, style, highlightStyle) ->
+        List (item, SomeBlock block, style, highlightStyle)
+
+let withListStyle style list =
+    match list with
+    | List (item, block, _, highlightStyle) ->
+        List (item, block, style, highlightStyle)
+
+let withHighlightStyle style list =
+    match list with
+    | List (item, block, listStyle, _) ->
+        List (item, block, listStyle, style)

--- a/fusabi-tui-runtime/fsx/tui/widgets/paragraph.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/paragraph.fsx
@@ -1,0 +1,71 @@
+#load "text.fsx"
+#load "block.fsx"
+
+// TUI Paragraph Widget
+// Displays multi-line text with optional wrapping and alignment
+
+// Wrap mode for text
+type Wrap =
+    | NoWrap
+    | WrapChar
+    | WrapWord
+
+// Text alignment
+type Alignment =
+    | Left
+    | Center
+    | Right
+
+// Option type for Block (for optional block)
+type OptionBlock =
+    | NoneBlock
+    | SomeBlock of Block
+
+// Paragraph widget
+// Represented as text * block * style * alignment * wrap
+type Paragraph =
+    | Paragraph of Text * OptionBlock * Style * Alignment * Wrap
+
+// Paragraph constructors and utilities
+let emptyParagraph = Paragraph (TextEmpty, NoneBlock, emptyStyle, Left, NoWrap)
+
+let createParagraph text = Paragraph (text, NoneBlock, emptyStyle, Left, NoWrap)
+
+let paragraphFromString str =
+    let text = textFromString str in
+    Paragraph (text, NoneBlock, emptyStyle, Left, NoWrap)
+
+let withParagraphText text paragraph =
+    match paragraph with
+    | Paragraph (_, block, style, alignment, wrap) ->
+        Paragraph (text, block, style, alignment, wrap)
+
+let withParagraphBlock block paragraph =
+    match paragraph with
+    | Paragraph (text, _, style, alignment, wrap) ->
+        Paragraph (text, SomeBlock block, style, alignment, wrap)
+
+let withParagraphStyle style paragraph =
+    match paragraph with
+    | Paragraph (text, block, _, alignment, wrap) ->
+        Paragraph (text, block, style, alignment, wrap)
+
+let withAlignment alignment paragraph =
+    match paragraph with
+    | Paragraph (text, block, style, _, wrap) ->
+        Paragraph (text, block, style, alignment, wrap)
+
+let withWrap wrap paragraph =
+    match paragraph with
+    | Paragraph (text, block, style, alignment, _) ->
+        Paragraph (text, block, style, alignment, wrap)
+
+// Wrap mode constructors
+let noWrap = NoWrap
+let wrapChar = WrapChar
+let wrapWord = WrapWord
+
+// Alignment constructors
+let leftAlign = Left
+let centerAlign = Center
+let rightAlign = Right

--- a/fusabi-tui-runtime/fsx/tui/widgets/sparkline.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/sparkline.fsx
@@ -1,0 +1,56 @@
+#load "block.fsx"
+
+// TUI Sparkline Widget
+// Displays a compact line chart for visualizing data trends
+
+// Direction for sparkline rendering
+type SparklineDirection =
+    | LeftToRight
+    | RightToLeft
+
+// Option type for max value
+type OptionMax =
+    | NoneMax
+    | SomeMax of int
+
+// Sparkline widget
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// Sparkline represented as data value * max * block * style * direction
+type Sparkline =
+    | Sparkline of int * OptionMax * OptionBlock * Style * SparklineDirection
+
+// Sparkline constructors and utilities
+let emptySparkline = Sparkline (0, NoneMax, NoneBlock, emptyStyle, LeftToRight)
+
+let createSparkline data = Sparkline (data, NoneMax, NoneBlock, emptyStyle, LeftToRight)
+
+let sparklineFromData data = Sparkline (data, NoneMax, NoneBlock, emptyStyle, LeftToRight)
+
+let withSparklineData data sparkline =
+    match sparkline with
+    | Sparkline (_, max, block, style, direction) ->
+        Sparkline (data, max, block, style, direction)
+
+let withMax max sparkline =
+    match sparkline with
+    | Sparkline (data, _, block, style, direction) ->
+        Sparkline (data, SomeMax max, block, style, direction)
+
+let withSparklineBlock block sparkline =
+    match sparkline with
+    | Sparkline (data, max, _, style, direction) ->
+        Sparkline (data, max, SomeBlock block, style, direction)
+
+let withSparklineStyle style sparkline =
+    match sparkline with
+    | Sparkline (data, max, block, _, direction) ->
+        Sparkline (data, max, block, style, direction)
+
+let withDirection direction sparkline =
+    match sparkline with
+    | Sparkline (data, max, block, style, _) ->
+        Sparkline (data, max, block, style, direction)
+
+// Direction constructors
+let leftToRight = LeftToRight
+let rightToLeft = RightToLeft

--- a/fusabi-tui-runtime/fsx/tui/widgets/table.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/table.fsx
@@ -1,0 +1,107 @@
+#load "text.fsx"
+#load "block.fsx"
+
+// TUI Table Widget
+// Displays data in a tabular format with rows and columns
+
+// TableCell - a single cell in the table
+// Represented as text * style
+type TableCell =
+    | TableCell of Text * Style
+
+// TableRow - a row in the table
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// TableRow represented as a single cell
+type TableRow =
+    | TableRow of TableCell * Style
+
+// Constraint for column widths
+type ColumnConstraint =
+    | ColumnPercentage of int
+    | ColumnLength of int
+    | ColumnMin of int
+    | ColumnMax of int
+    | ColumnFill of int
+
+// Option type for header
+type OptionRow =
+    | NoneRow
+    | SomeRow of TableRow
+
+// TableState - tracks selection state
+// Represented as selected row index
+type TableState =
+    | TableState of OptionInt
+
+// Table widget
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// Table represented as row * header * block * style * widthConstraint
+type Table =
+    | Table of TableRow * OptionRow * OptionBlock * Style * ColumnConstraint
+
+// TableCell constructors
+let createTableCell text style = TableCell (text, style)
+
+let tableCellFromString str = TableCell (textFromString str, emptyStyle)
+
+let styledTableCell str style = TableCell (textFromString str, style)
+
+// TableRow constructors
+let createTableRow cell style = TableRow (cell, style)
+
+let tableRowFromCell cell = TableRow (cell, emptyStyle)
+
+let tableRowFromStrings str = TableRow (tableCellFromString str, emptyStyle)
+
+// TableState constructors
+let emptyTableState = TableState NoneInt
+
+let createTableState = TableState NoneInt
+
+let selectTableRow index state = TableState (SomeInt index)
+
+let deselectTableRow state = TableState NoneInt
+
+let nextTableRow state =
+    match state with
+    | TableState (SomeInt idx) -> TableState (SomeInt (idx + 1))
+    | TableState NoneInt -> TableState (SomeInt 0)
+
+let prevTableRow state =
+    match state with
+    | TableState (SomeInt idx) ->
+        let newIdx = if idx > 0 then idx - 1 else 0 in
+        TableState (SomeInt newIdx)
+    | TableState NoneInt -> TableState (SomeInt 0)
+
+// Table constructors
+let emptyTable = Table (tableRowFromStrings "", NoneRow, NoneBlock, emptyStyle, ColumnFill 1)
+
+let createTable row = Table (row, NoneRow, NoneBlock, emptyStyle, ColumnFill 1)
+
+let withTableHeader header table =
+    match table with
+    | Table (row, _, block, style, widths) ->
+        Table (row, SomeRow header, block, style, widths)
+
+let withTableBlock block table =
+    match table with
+    | Table (row, header, _, style, widths) ->
+        Table (row, header, SomeBlock block, style, widths)
+
+let withTableStyle style table =
+    match table with
+    | Table (row, header, block, _, widths) ->
+        Table (row, header, block, style, widths)
+
+let withColumnWidths constraint table =
+    match table with
+    | Table (row, header, block, style, _) ->
+        Table (row, header, block, style, constraint)
+
+// Column constraint constructors
+let columnPercentage pct = ColumnPercentage pct
+let columnLength len = ColumnLength len
+let columnMin min = ColumnMin min
+let columnMax max = ColumnMax max
+let columnFill weight = ColumnFill weight

--- a/fusabi-tui-runtime/fsx/tui/widgets/tabs.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/tabs.fsx
@@ -1,0 +1,65 @@
+#load "block.fsx"
+
+// TUI Tabs Widget
+// Displays a tabbed interface with selectable tabs
+
+// Tabs widget
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// Tabs represented as title * selected * divider * block * style * highlightStyle
+type Tabs =
+    | Tabs of string * int * string * OptionBlock * Style * Style
+
+// Tabs constructors and utilities
+let emptyTabs = Tabs ("", 0, " ", NoneBlock, emptyStyle, emptyStyle)
+
+let createTabs title = Tabs (title, 0, " ", NoneBlock, emptyStyle, emptyStyle)
+
+let tabsFromTitles title = Tabs (title, 0, " ", NoneBlock, emptyStyle, emptyStyle)
+
+let withTabTitles title tabs =
+    match tabs with
+    | Tabs (_, selected, divider, block, style, highlightStyle) ->
+        Tabs (title, selected, divider, block, style, highlightStyle)
+
+let withSelected index tabs =
+    match tabs with
+    | Tabs (title, _, divider, block, style, highlightStyle) ->
+        Tabs (title, index, divider, block, style, highlightStyle)
+
+let withDivider divider tabs =
+    match tabs with
+    | Tabs (title, selected, _, block, style, highlightStyle) ->
+        Tabs (title, selected, divider, block, style, highlightStyle)
+
+let withTabsBlock block tabs =
+    match tabs with
+    | Tabs (title, selected, divider, _, style, highlightStyle) ->
+        Tabs (title, selected, divider, SomeBlock block, style, highlightStyle)
+
+let withTabsStyle style tabs =
+    match tabs with
+    | Tabs (title, selected, divider, block, _, highlightStyle) ->
+        Tabs (title, selected, divider, block, style, highlightStyle)
+
+let withTabsHighlightStyle style tabs =
+    match tabs with
+    | Tabs (title, selected, divider, block, tabsStyle, _) ->
+        Tabs (title, selected, divider, block, tabsStyle, style)
+
+// Tab navigation
+let nextTab tabs =
+    match tabs with
+    | Tabs (title, selected, divider, block, style, highlightStyle) ->
+        Tabs (title, selected + 1, divider, block, style, highlightStyle)
+
+let prevTab tabs =
+    match tabs with
+    | Tabs (title, selected, divider, block, style, highlightStyle) ->
+        let newSelected = if selected > 0 then selected - 1 else 0 in
+        Tabs (title, newSelected, divider, block, style, highlightStyle)
+
+// Common dividers
+let pipeDivider = "|"
+let slashDivider = "/"
+let spaceDivider = " "
+let dotDivider = "·"

--- a/fusabi-tui-runtime/fsx/tui/widgets/text.fsx
+++ b/fusabi-tui-runtime/fsx/tui/widgets/text.fsx
@@ -1,0 +1,53 @@
+#load "../style.fsx"
+
+// TUI Text Primitives
+// Represents styled text content: Span, Line, and Text
+
+// Span - a styled text segment
+// Represented as content * style
+type Span =
+    | Span of string * Style
+
+// Line - a sequence of spans
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// Line represented as a single span (for simplicity)
+type Line =
+    | Line of Span
+    | LineEmpty
+
+// Text - a sequence of lines
+// Note: Since Fusabi doesn't support lists in DUs, we use a simplified representation
+// Text represented as a single line (for simplicity)
+type Text =
+    | Text of Line
+    | TextEmpty
+
+// Span constructors and utilities
+let createSpan content style = Span (content, style)
+
+let rawSpan content = Span (content, emptyStyle)
+
+let styledSpan content fg bg =
+    let style = emptyStyle |> withFg fg |> withBg bg in
+    Span (content, style)
+
+// Line constructors
+let emptyLine = LineEmpty
+
+let lineFromSpan span = Line span
+
+let lineFromText text = Line (Span (text, emptyStyle))
+
+let styledLine text style = Line (Span (text, style))
+
+// Text constructors
+let emptyText = TextEmpty
+
+let textFromLine line = Text line
+
+let textFromString str = Text (Line (Span (str, emptyStyle)))
+
+let styledText str style = Text (Line (Span (str, style)))
+
+// Helper for creating multi-colored text
+let textFromSpans span = Text (Line span)


### PR DESCRIPTION
## Summary

This PR implements Phase 2 of the fusabi-tui-runtime roadmap: the Widget Framework.

### Widgets Added (7 total)

| Widget | Description | Tests |
|--------|-------------|-------|
| **Block** | Bordered container with title, padding, border types | 28 |
| **Paragraph** | Text display with wrapping and alignment | 10 |
| **List** | Scrollable list with selection (StatefulWidget) | 9 |
| **Table** | Tabular data with headers and column constraints | 11 |
| **Gauge** | Progress/percentage bar with label | 14 |
| **Sparkline** | Inline mini-chart for data visualization | 13 |
| **Tabs** | Tab navigation with selection | 12 |

### Supporting Types

- **Widget/StatefulWidget traits** - Base traits for all widgets
- **Borders** - Bitflags (TOP, RIGHT, BOTTOM, LEFT, ALL, NONE)
- **BorderType** - Plain, Rounded, Double, Thick
- **Text primitives** - Span, Line, Text

### FSX Bindings

```
fsx/tui/widgets/
├── block.fsx, text.fsx, paragraph.fsx
├── list.fsx, table.fsx
├── gauge.fsx, sparkline.fsx, tabs.fsx
```

Plus `examples/dashboard.fsx` demonstrating all widgets.

### Test Results

- **111 unit tests** + **21 doc tests** = **132 tests passing**

## Test Plan

- [x] `cargo test -p fusabi-tui-widgets` passes
- [x] All widgets implement Widget/StatefulWidget correctly
- [x] FSX bindings follow established patterns

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)