### PR TITLE
feat: auto-update Homebrew formula on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -165,6 +165,58 @@ jobs:
           cd rust
           cargo publish -p fusabi
 
+  # Update Homebrew formula
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: [create-release, build-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version
+        id: version
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          URL="https://github.com/fusabi-lang/fusabi/archive/refs/tags/${{ needs.create-release.outputs.version }}.tar.gz"
+          SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Checkout homebrew-fusabi
+        uses: actions/checkout@v4
+        with:
+          repository: fusabi-lang/homebrew-fusabi
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-fusabi
+
+      - name: Update formula
+        run: |
+          cd homebrew-fusabi
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA256="${{ steps.sha256.outputs.sha256 }}"
+          URL="${{ steps.sha256.outputs.url }}"
+
+          # Update version, URL, and SHA256 in formula
+          sed -i "s|url \".*\"|url \"$URL\"|" Formula/fusabi.rb
+          sed -i "s|sha256 \".*\"|sha256 \"$SHA256\"|" Formula/fusabi.rb
+
+          echo "Updated formula to v$VERSION"
+          cat Formula/fusabi.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-fusabi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/fusabi.rb
+          git commit -m "fusabi ${{ needs.create-release.outputs.version }}"
+          git push
+
   # Publish documentation
   publish-docs:
     name: Publish Documentation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -160,6 +160,58 @@ jobs:
           cd rust
           cargo publish -p fusabi
 
+  # Update Homebrew formula
+  update-homebrew:
+    name: Update Homebrew Formula
+    needs: [create-release, build-release]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get version
+        id: version
+        run: |
+          VERSION="${{ needs.create-release.outputs.version }}"
+          # Remove 'v' prefix if present
+          VERSION="${VERSION#v}"
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Calculate SHA256
+        id: sha256
+        run: |
+          URL="https://github.com/fusabi-lang/fusabi/archive/refs/tags/${{ needs.create-release.outputs.version }}.tar.gz"
+          SHA256=$(curl -sL "$URL" | sha256sum | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+          echo "url=$URL" >> $GITHUB_OUTPUT
+
+      - name: Checkout homebrew-fusabi
+        uses: actions/checkout@v4
+        with:
+          repository: fusabi-lang/homebrew-fusabi
+          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          path: homebrew-fusabi
+
+      - name: Update formula
+        run: |
+          cd homebrew-fusabi
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA256="${{ steps.sha256.outputs.sha256 }}"
+          URL="${{ steps.sha256.outputs.url }}"
+
+          # Update version, URL, and SHA256 in formula
+          sed -i "s|url \".*\"|url \"$URL\"|" Formula/fusabi.rb
+          sed -i "s|sha256 \".*\"|sha256 \"$SHA256\"|" Formula/fusabi.rb
+
+          echo "Updated formula to v$VERSION"
+          cat Formula/fusabi.rb
+
+      - name: Commit and push
+        run: |
+          cd homebrew-fusabi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add Formula/fusabi.rb
+          git commit -m "fusabi ${{ needs.create-release.outputs.version }}"
+          git push
+
   # Publish documentation
   publish-docs:
     name: Publish Documentation


### PR DESCRIPTION
## Summary

Adds `update-homebrew` job to the release workflow that automatically updates the Homebrew formula when a new release is tagged.

## Changes

- Calculates SHA256 of the release tarball
- Clones `homebrew-fusabi` repo
- Updates `Formula/fusabi.rb` with new version and SHA256
- Commits and pushes the change

## Setup Required

Create a `HOMEBREW_TAP_TOKEN` secret in this repo:
1. Go to Settings → Secrets → Actions
2. Create new secret named `HOMEBREW_TAP_TOKEN`
3. Value should be a Personal Access Token with `repo` scope

## Testing

The workflow will be triggered on next release tag (e.g., `v0.36.0`).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)