### PR TITLE
ci: native aarch64-unknown-linux-gnu build for CI and release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,6 +130,37 @@ jobs:
       - name: Run frontend tests
         run: just test-frontend
 
+  # Native aarch64 Linux smoke test. Does not run the full just test-*
+  # matrix (that needs nushell + just on aarch64, which can come later);
+  # this is a build-and-test guard so the aarch64 release builds don't
+  # start failing silently for DGX Spark consumers.
+  test-aarch64:
+    name: Test Suite (aarch64-unknown-linux-gnu)
+    needs: check
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+          key: ubuntu-24.04-arm-stable
+
+      - name: Build workspace
+        run: |
+          cd rust
+          cargo build --workspace
+
+      - name: Run tests
+        run: |
+          cd rust
+          cargo test --workspace
+
   # Build release binaries to ensure release mode works
   build-release:
     name: Release Build
@@ -338,7 +369,7 @@ jobs:
   # All checks passed
   ci-success:
     name: CI Success
-    needs: [check, msrv-check, test, build-release, coverage, security-audit, docs, docs-freshness]
+    needs: [check, msrv-check, test, test-aarch64, build-release, coverage, security-audit, docs, docs-freshness]
     runs-on: ubuntu-latest
     steps:
       - name: Mark CI as successful

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
             target: x86_64-unknown-linux-gnu
             artifact_name: fus
             asset_name: fusabi-linux-x86_64
-          - os: ubuntu-latest
+          # Native aarch64 Linux runner (GA on GitHub-hosted runners).
+          # Preferred over QEMU / gcc-aarch64 cross: faster and correct
+          # for any native deps we pick up over time.
+          - os: ubuntu-24.04-arm
             target: aarch64-unknown-linux-gnu
             artifact_name: fus
             asset_name: fusabi-linux-aarch64
@@ -87,18 +90,10 @@ jobs:
         with:
           targets: ${{ matrix.target }}
 
-      - name: Install cross-compilation tools (Linux ARM64)
-        if: matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y gcc-aarch64-linux-gnu
-
       - name: Build release binary
         run: |
           cd rust
           cargo build --release --target ${{ matrix.target }} -p fusabi
-        env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
 
       - name: Strip binary (Unix)
         if: runner.os != 'Windows'


### PR DESCRIPTION
## Motivation

DGX Spark is an aarch64 box (Grace CPU + Blackwell GPU, 128 GB unified
memory) and the primary target for the upcoming `raibid-harness` harness
for coding agents. Consumers currently have to build Fusabi from source
on ARM64 because no prebuilt aarch64 binary is published. This PR closes
that gap.

See survey: `/tmp/fusabi-aarch64-survey.md` (local to the DevOps agent
that filed this PR; the relevant section is the `fusabi` entry).

## What changed

**`.github/workflows/release.yml`**
- `aarch64-unknown-linux-gnu` matrix entry now runs on `ubuntu-24.04-arm`
  (native ARM runner, GA on GitHub-hosted runners since 2025).
- Removed the `gcc-aarch64-linux-gnu` cross-compile step and the
  `CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` env override, both of
  which are unnecessary on a native host.
- x86_64 Linux, macOS (both arches), and Windows jobs are untouched.

**`.github/workflows/ci.yml`**
- New `test-aarch64` job that runs `cargo build --workspace` and
  `cargo test --workspace` on `ubuntu-24.04-arm`. This is deliberately
  the plain `cargo` path (not `just test-*`) because nushell + just on
  an ARM runner adds setup cost we can defer. It's enough to catch any
  aarch64 compile or test regression before a tag is cut.
- `ci-success` now requires `test-aarch64` so aarch64 regressions block
  merges.

## Test plan

- [ ] Workflow run on this PR: `Test Suite (aarch64-unknown-linux-gnu)`
      job succeeds.
- [ ] Manually dispatch `Release` workflow with a pre-release version
      (e.g. `v0.36.0-rc.1`) and confirm `fusabi-linux-aarch64` artifact
      is produced and uploaded.
- [ ] Verify artifact is a valid aarch64 ELF: `file fusabi-linux-aarch64`
      should report `ELF 64-bit LSB ... ARM aarch64`.

## Known gaps

- `fusabi-mcp` is not in the `rust/Cargo.toml` workspace members list,
  so the new `test-aarch64` job (which runs `cargo test --workspace`)
  does not cover it. Out of scope here; separate issue material.
- Release workflow still uses the deprecated `actions/create-release@v1`
  and `actions/upload-release-asset@v1` actions. Not touched in this PR
  to keep the diff focused on aarch64.

## Status

**Draft** — will be marked ready for review after a workflow run
exercises the aarch64 job.