### PR TITLE
ci: fix Windows CI test path + mitigate bash-env flake (#290)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,15 +82,26 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Pin Windows to windows-2022 rather than windows-latest. The
+        # windows-latest image rollout intermittently trips the runner's bash
+        # function-injection guard while setup actions write to $GITHUB_ENV
+        # (actions/runner-images#14052), flaking the whole leg. Pinning to a
+        # stable image sidesteps the rollout window.
+        os: [ubuntu-latest, macos-latest, windows-2022]
         rust: [stable, beta]
         exclude:
           # Only run beta on Ubuntu to save CI minutes
           - os: macos-latest
             rust: beta
-          - os: windows-latest
+          - os: windows-2022
             rust: beta
     runs-on: ${{ matrix.os }}
+    # Use bash everywhere so `run:` steps behave identically across OSes and
+    # don't depend on the Windows default shell (PowerShell) where the
+    # $GITHUB_ENV guard behaves differently.
+    defaults:
+      run:
+        shell: bash
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/rust/crates/fusabi/src/lib.rs
+++ b/rust/crates/fusabi/src/lib.rs
@@ -797,16 +797,17 @@ mod tests {
     fn test_compile_file_to_bytecode() {
         use std::io::Write;
 
-        // Create temporary file
-        let temp_path = "/tmp/test_compile.fsx";
+        // Create temporary file in the OS temp dir (cross-platform; avoids
+        // hardcoding a Unix-only path like "/tmp").
+        let temp_path = std::env::temp_dir().join("test_compile.fsx");
         let source = "let x = 42 in x";
 
-        let mut file = std::fs::File::create(temp_path).unwrap();
+        let mut file = std::fs::File::create(&temp_path).unwrap();
         file.write_all(source.as_bytes()).unwrap();
         drop(file);
 
         // Compile file to bytecode
-        let bytecode = compile_file_to_bytecode(temp_path).unwrap();
+        let bytecode = compile_file_to_bytecode(temp_path.to_str().unwrap()).unwrap();
 
         // Verify bytecode is valid
         assert!(bytecode.starts_with(FZB_MAGIC));
@@ -816,6 +817,6 @@ mod tests {
         assert_eq!(result.as_int(), Some(42));
 
         // Cleanup
-        std::fs::remove_file(temp_path).unwrap();
+        std::fs::remove_file(&temp_path).unwrap();
     }
 }

--- a/rust/crates/fusabi/tests/bytecode_api_tests.rs
+++ b/rust/crates/fusabi/tests/bytecode_api_tests.rs
@@ -379,7 +379,8 @@ fn test_empty_file_compilation() {
 
 #[test]
 fn test_file_not_found() {
-    let result = compile_file_to_bytecode("/tmp/definitely_does_not_exist_12345.fsx");
+    let missing = std::env::temp_dir().join("definitely_does_not_exist_12345.fsx");
+    let result = compile_file_to_bytecode(missing.to_str().unwrap());
     assert!(result.is_err(), "Should error on non-existent file");
 }
 


### PR DESCRIPTION
## Summary

Fixes the two issues in the `Test Suite (windows-latest, stable)` leg described in #290.

### 1. `test_compile_file_to_bytecode` real failure (path separator)

The unit test in `rust/crates/fusabi/src/lib.rs` hardcoded the Unix-only path `/tmp/test_compile.fsx`. On Windows that directory does not exist, so `File::create` / `compile_file_to_bytecode` failed — the single failing test in the run (26 passed / 1 failed).

Fix: construct the temp path via `std::env::temp_dir().join("test_compile.fsx")` so it is built with `std::path` and is correct on every OS. Applied the same defensive fix to `test_file_not_found` in `rust/crates/fusabi/tests/bytecode_api_tests.rs`, which also relied on a hardcoded `/tmp` path.

`compile_file_to_bytecode` itself was already OS-agnostic (plain `fs::read_to_string(path)`), so no production code needed changes — only the tests' path construction.

### 2. GH Actions bash-env flake (actions/runner-images#14052)

The `windows-latest` image rollout intermittently trips the runner's bash function-injection guard while setup actions write to `$GITHUB_ENV`. Mitigations in `.github/workflows/ci.yml`:

- Pin the Windows matrix leg to the stable `windows-2022` image to sidestep the affected `windows-latest` rollout window.
- Set the `test` job's default `run` shell to `bash` so `run:` steps behave identically across all OSes and don't depend on the Windows default shell.

## Verification

All commands run from `rust/` on macOS (Windows not available locally; the fix is genuinely OS-agnostic via `std::path`):

- `cargo test -p fusabi --lib tests::test_compile_file_to_bytecode` → `1 passed; 0 failed`
- `cargo test -p fusabi --test bytecode_api_tests -- test_compile_file_to_bytecode test_file_not_found` → `2 passed; 0 failed`
- `cargo build --workspace` → `Finished` (clean)
- `cargo fmt -p fusabi -- --check` → clean (exit 0)
- Workflow YAML validated with a YAML parser.

Note: `bytecode_api_tests` has 12 unrelated pre-existing failures (`Undefined global` runtime errors) present identically on clean `main` (26 passed / 12 failed before and after this change); they are out of scope for #290.

Closes #290

🤖 Generated with [Claude Code](https://claude.com/claude-code)