### PR TITLE
Fix missing `not` global and NativeFn stack corruption (#288)

### DIFF
--- a/rust/crates/fusabi-vm/src/stdlib/mod.rs
+++ b/rust/crates/fusabi-vm/src/stdlib/mod.rs
@@ -147,6 +147,11 @@ pub fn register_stdlib(vm: &mut Vm) {
             wrap_binary(args, string::string_format)
         });
 
+        // Boolean negation (global function, not in a module)
+        registry.register("not", |_vm, args| {
+            wrap_unary(args, |v| Ok(Value::Bool(!v.is_truthy())))
+        });
+
         // Print functions (global functions, not in a module)
         registry.register("print", |_vm, args| wrap_unary(args, print::print_value));
         registry.register("printfn", |_vm, args| {
@@ -598,6 +603,9 @@ pub fn register_stdlib(vm: &mut Vm) {
     // Register sprintf as a global alias for String.format
     vm.globals
         .insert("sprintf".to_string(), native("sprintf", 2));
+
+    // Register boolean negation as a global
+    vm.globals.insert("not".to_string(), native("not", 1));
 
     // Register print functions as globals
     vm.globals.insert("print".to_string(), native("print", 1));

--- a/rust/crates/fusabi-vm/src/vm.rs
+++ b/rust/crates/fusabi-vm/src/vm.rs
@@ -753,6 +753,13 @@ impl Vm {
                             let mut all_args = applied_args.clone();
                             all_args.extend(new_args);
 
+                            // Remove the callee (the NativeFn value) from the stack.
+                            // After popping `argc` arguments above, it now sits on top of
+                            // the stack at `func_idx`. If left in place it would corrupt
+                            // any surrounding expression (e.g. the right operand of `&&`),
+                            // because the produced result is pushed *above* it.
+                            let _ = self.pop()?;
+
                             let total_args = all_args.len();
                             let arity_usize = arity as usize;
 


### PR DESCRIPTION
## Summary

Issue #288 reports 12 failing tests under the aarch64 CI job. As the issue triage notes, these are pre-existing cross-platform compiler/VM gaps surfaced by aarch64 being the first matrix entry to run the full `cargo test --workspace` (and thus `crates/fusabi/tests/bytecode_api_tests.rs`) — not arch-specific bugs. They reproduce on arm64 macOS locally.

This PR fixes the concrete missing-global failure named in the issue title (`not`) and a genuine VM stack-corruption bug it exposed.

## What changed

**1. Register the `not` global (`crates/fusabi-vm/src/stdlib/mod.rs`)**
`register_stdlib` never registered `not`, so boolean negation failed at runtime with `Undefined global: not`. Added it as a host function and a global `NativeFn` (arity 1), following the existing `print`/`sprintf` pattern. It coerces with the same truthiness rules as the rest of the VM (`Value::is_truthy`).

**2. Fix `Call` NativeFn stack corruption (`crates/fusabi-vm/src/vm.rs`)**
The `Call` instruction's `NativeFn` branch popped the call arguments but left the callee value on the stack, pushing the result *above* it. Standalone this was harmless (the stale callee sat below the return value), but inside a larger expression it corrupted the stack. For example `x && not y` compiles to `LOAD not; LOAD y; CALL 1; AND` — after the call the leftover `not` function value was what `AND` consumed, yielding `Type mismatch: expected bool, got function`. The callee is now popped before the native result is pushed.

## Why

Boolean negation is a basic intrinsic and the stack bug affects *any* native-function call used as a sub-expression, not just `not`.

## Verification

Run on arm64 macOS (this machine):

- `cargo build` / `cargo test` compiles cleanly.
- `cargo test -p fusabi --test bytecode_api_tests` — `test_compile_boolean_logic` now PASSES (file went 26 → 27 passing).
- `cargo run -p fusabi -- run -e "let x = true in let y = false in if x && not y then 100 else 0"` → `100`.
- `cargo test -p fusabi-vm --lib stdlib::commands -- --test-threads=1` → all pass (the apparent stdlib `commands`/`config` failures under the full parallel suite are a pre-existing shared-global-registry flakiness, unrelated to this change — they pass in isolation).

## Scope / coverage

This intentionally fixes only the `not`/native-call gap, which is fully resolved and verified. The other 11 failures in `bytecode_api_tests.rs` are distinct, larger pre-existing gaps (closure/upvalue handling on the bytecode round-trip path, tuple-pattern destructuring parsing, `%` lexing, `String.concat` semantics, `Map.insert`/`Map.get` naming, empty-file handling). Per the issue's own triage recommendation, those are left as separate follow-ups.

Closes #288

🤖 Generated with [Claude Code](https://claude.com/claude-code)